### PR TITLE
Исправление ошибок в стресс-тесте: O(n²) в deallocate и use-after-free в expand()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/PersistMemoryManager/issues/23
-Your prepared branch: issue-23-f35a1d63ca51
-Your prepared working directory: /tmp/gh-issue-solver-1772325750415
-Your forked repository: konard/netkeep80-PersistMemoryManager
-Original repository (upstream): netkeep80/PersistMemoryManager
-
-Proceed.


### PR DESCRIPTION
## Исправление ошибок в стресс-тесте (Issue #23)

Fixes #23

### Корневые причины сбоя `test_stress_realistic`

Тест зависал на 58+ секундах из-за четырёх взаимосвязанных ошибок в
`include/persist_memory_manager.h`.

---

### Ошибка 1: `header_from_ptr` не находил заголовки блоков

**Оригинальный код** содержал безусловный `break` в конце цикла — функция всегда пробовала ровно один кандидат (`ptr - sizeof(BlockHeader)`) и возвращала `nullptr` для всех блоков с ненулевым padding-ом.

**Следствие:** `deallocate()` вызывал `find_block_by_ptr()` как fallback — O(n) обход всего списка блоков.

**Исправление:** `header_from_ptr` переписан: сканирует от `ptr - sizeof(BlockHeader)` назад с шагом `kMinAlignment`, не более `kMaxAlignment/kMinAlignment = 512` итераций — **O(1)** вместо O(n).

---

### Ошибка 2: `required_block_size` не выравнивал размер блока до `kMinAlignment`

**Оригинальный код:** `return std::max(min_total, kMinBlockSize)` — результат мог не делиться на `kMinAlignment = 8`.

**Следствие:** Блоки размещались на адресах, которые не выровнены по `kMinAlignment`. Например, для `user_size=200` блок мог оказаться на смещении 251 (не кратно 8). Функция `header_from_ptr`, шагающая по 8 байт, никогда не попадала на такой заголовок → возвращала `nullptr` → `deallocate` ничего не освобождал → коалесция не работала.

**Исправление:**
```cpp
return align_up( std::max( min_total, kMinBlockSize ), kMinAlignment );
```

---

### Ошибка 3: `deallocate` использовал O(n) `find_block_by_ptr`

**Исправление:** `deallocate()` и `reallocate()` теперь используют O(1) `header_from_ptr` вместо O(n) `find_block_by_ptr`. При 20 000+ живых блоков это снижает сложность с O(n²) до O(n).

---

### Ошибка 4: heap-use-after-free после `expand()`

**Проблема:** Исправления 1–3 вернули коалесцию к жизни, но из-за оставшейся фрагментации (Фаза 1 быстро росла до 26 000+ блоков) `expand()` всё равно срабатывал. `expand()` вызывал `std::free(old_memory)` немедленно, тогда как вектор `live[]` в тесте ещё хранил указатели в освобождённый буфер → **heap-use-after-free** (подтверждено AddressSanitizer).

**Исправление:** Отложенное освобождение старого буфера:
- В `ManagerHeader` добавлены поля `owns_memory`, `prev_base`, `prev_total_size`, `prev_owns`.
- `expand()` сохраняет старый буфер в `prev_base` вместо немедленного `free()`. «Дедушка»-буфер (предыдущий `prev_base`) освобождается в этот момент. Старый буфер освобождается при следующем `expand()` или `destroy()`.
- `deallocate()` и `reallocate()` транслируют указатели из `prev_base` в текущий буфер по смещению, что делает их корректными после `expand()`.

---

### Результаты тестирования

| Тест | До | После |
|------|----|-------|
| test_allocate | ✅ | ✅ |
| test_deallocate | ✅ | ✅ |
| test_coalesce | ❌ (8/10 FAIL) | ✅ (10/10) |
| test_persistence | ❌ | ✅ |
| test_pptr | ✅ | ✅ |
| test_performance | ❌ | ✅ |
| **test_stress_realistic** | ❌ **58+ сек / зависание** | ✅ **0.18 сек** |
| test_thread_safety | ❌ | ✅ |

**Полный прогон (все 8 тестов): 0.35 сек**

AddressSanitizer: ошибок нет.

---

*This PR was created automatically by the AI issue solver*