### PR TITLE
fix: resolve stress test CI failures — clang-format and file size

### DIFF
--- a/include/persist_memory_manager.h
+++ b/include/persist_memory_manager.h
@@ -659,22 +659,22 @@ class PersistMemoryManager
         std::unique_lock<std::shared_mutex> lock( s_mutex );
         if ( s_instance != nullptr )
         {
-            detail::ManagerHeader* hdr  = s_instance->header();
-            hdr->magic                  = 0;
-            bool  owns                  = hdr->owns_memory;
-            void* buf                   = s_instance->base_ptr();
-            void* prev                  = hdr->prev_base;
-            bool  prev_owns             = hdr->prev_owns;
-            s_instance                  = nullptr;
+            detail::ManagerHeader* hdr = s_instance->header();
+            hdr->magic                 = 0;
+            bool  owns                 = hdr->owns_memory;
+            void* buf                  = s_instance->base_ptr();
+            void* prev                 = hdr->prev_base;
+            bool  prev_owns            = hdr->prev_owns;
+            s_instance                 = nullptr;
             // Освобождаем всю цепочку предыдущих буферов (grandparent и далее)
             while ( prev != nullptr && prev_owns )
             {
-                detail::ManagerHeader* ph         = reinterpret_cast<detail::ManagerHeader*>( prev );
-                void*                  next_prev  = ph->prev_base;
-                bool                   next_owns  = ph->prev_owns;
+                detail::ManagerHeader* ph        = reinterpret_cast<detail::ManagerHeader*>( prev );
+                void*                  next_prev = ph->prev_base;
+                bool                   next_owns = ph->prev_owns;
                 std::free( prev );
-                prev       = next_prev;
-                prev_owns  = next_owns;
+                prev      = next_prev;
+                prev_owns = next_owns;
             }
             if ( owns )
                 std::free( buf );
@@ -754,34 +754,11 @@ class PersistMemoryManager
     {
         std::unique_lock<std::shared_mutex> lock( s_mutex );
         if ( ptr == nullptr )
-        {
             return;
-        }
-
+        ptr                         = translate_ptr( ptr );
         std::uint8_t*          base = base_ptr();
         detail::ManagerHeader* hdr  = header();
-
-        // Транслируем указатель из любого предыдущего буфера цепочки (после expand()) в текущий.
-        // Обходим цепочку prev_base -> prev_base->prev_base -> ... пока не найдём совпадение.
-        {
-            std::uint8_t* raw       = static_cast<std::uint8_t*>( ptr );
-            void*         prev_buf  = hdr->prev_base;
-            std::size_t   prev_size = hdr->prev_total_size;
-            while ( prev_buf != nullptr && prev_size > 0 )
-            {
-                std::uint8_t* prev = static_cast<std::uint8_t*>( prev_buf );
-                if ( raw >= prev && raw < prev + prev_size )
-                {
-                    ptr = base + ( raw - prev );
-                    break;
-                }
-                detail::ManagerHeader* prev_hdr = reinterpret_cast<detail::ManagerHeader*>( prev_buf );
-                prev_buf  = prev_hdr->prev_base;
-                prev_size = prev_hdr->prev_total_size;
-            }
-        }
-
-        detail::BlockHeader* blk = detail::header_from_ptr( base, ptr );
+        detail::BlockHeader*   blk  = detail::header_from_ptr( base, ptr );
         if ( blk == nullptr || !blk->used )
             return;
 
@@ -815,27 +792,9 @@ class PersistMemoryManager
         }
 
         std::unique_lock<std::shared_mutex> lock( s_mutex );
-        std::uint8_t*                       base = base_ptr();
-        detail::ManagerHeader*              hdr  = header();
-        // Транслируем указатель из любого предыдущего буфера цепочки (после expand()) в текущий
-        {
-            std::uint8_t* raw       = static_cast<std::uint8_t*>( ptr );
-            void*         prev_buf  = hdr->prev_base;
-            std::size_t   prev_size = hdr->prev_total_size;
-            while ( prev_buf != nullptr && prev_size > 0 )
-            {
-                std::uint8_t* prev = static_cast<std::uint8_t*>( prev_buf );
-                if ( raw >= prev && raw < prev + prev_size )
-                {
-                    ptr = base + ( raw - prev );
-                    break;
-                }
-                detail::ManagerHeader* prev_hdr = reinterpret_cast<detail::ManagerHeader*>( prev_buf );
-                prev_buf  = prev_hdr->prev_base;
-                prev_size = prev_hdr->prev_total_size;
-            }
-        }
-        detail::BlockHeader* blk = detail::header_from_ptr( base, ptr );
+        ptr                       = translate_ptr( ptr );
+        std::uint8_t*        base = base_ptr();
+        detail::BlockHeader* blk  = detail::header_from_ptr( base, ptr );
         if ( blk == nullptr || !blk->used )
             return nullptr;
         if ( new_size <= blk->user_size )
@@ -1193,19 +1152,32 @@ class PersistMemoryManager
         while ( offset != detail::kNoBlock )
         {
             detail::BlockHeader* blk = detail::block_at( base, offset );
+            blk->free_prev_offset    = detail::kNoBlock;
+            blk->free_next_offset    = detail::kNoBlock;
             if ( !blk->used )
-            {
-                blk->free_prev_offset = detail::kNoBlock;
-                blk->free_next_offset = detail::kNoBlock;
                 detail::free_list_insert( base, hdr, blk );
-            }
-            else
-            {
-                blk->free_prev_offset = detail::kNoBlock;
-                blk->free_next_offset = detail::kNoBlock;
-            }
             offset = blk->next_offset;
         }
+    }
+
+    /// @brief Транслировать указатель из любого буфера в цепочке prev_base в текущий буфер.
+    void* translate_ptr( void* ptr ) const noexcept
+    {
+        std::uint8_t*                base     = const_cast<PersistMemoryManager*>( this )->base_ptr();
+        const detail::ManagerHeader* hdr      = header();
+        std::uint8_t*                raw      = static_cast<std::uint8_t*>( ptr );
+        void*                        prev_buf = hdr->prev_base;
+        std::size_t                  prev_sz  = hdr->prev_total_size;
+        while ( prev_buf != nullptr && prev_sz > 0 )
+        {
+            std::uint8_t* prev = static_cast<std::uint8_t*>( prev_buf );
+            if ( raw >= prev && raw < prev + prev_sz )
+                return base + ( raw - prev );
+            detail::ManagerHeader* ph = reinterpret_cast<detail::ManagerHeader*>( prev_buf );
+            prev_buf                  = ph->prev_base;
+            prev_sz                   = ph->prev_total_size;
+        }
+        return ptr;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes CI failures introduced by the previous commit for netkeep80/PersistMemoryManager#26.

### Root causes identified from CI logs:

1. **clang-format violations** — `persist_memory_manager.h` had misaligned assignments in `destroy()`, `deallocate()`, and `reallocate()` methods (lines 662–677, 779–780, 834–835). Applied `clang-format -i` to auto-fix all violations.

2. **File size limit exceeded** — The header grew to 1527 lines, exceeding the 1500-line CI check. Reduced to 1499 lines by:
   - Extracting the duplicated `prev_base` pointer translation loop (in `deallocate()` and `reallocate()`) into a private `translate_ptr()` helper method
   - Simplified `rebuild_free_list()` to remove a redundant `else` branch (both branches did the same reset before free-list insertion)

### Testing

All 9 tests pass locally:
- `test_allocate`, `test_deallocate`, `test_coalesce`, `test_persistence`, `test_pptr`
- `test_performance`, `test_stress_realistic` (100k iterations), `test_thread_safety`, `test_shared_mutex`

### Fixes
Fixes netkeep80/PersistMemoryManager#26

---
*This PR was created automatically by the AI issue solver*