### PR TITLE
perf: implement 4 priority performance optimizations (Issue #57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,3 @@ Your forked repository: konard/netkeep80-PersistMemoryManager
 Original repository (upstream): netkeep80/PersistMemoryManager
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/netkeep80/PersistMemoryManager/issues/57
-Your prepared branch: issue-57-347bcb8d1907
-Your prepared working directory: /tmp/gh-issue-solver-1772384938902
-Your forked repository: konard/netkeep80-PersistMemoryManager
-Original repository (upstream): netkeep80/PersistMemoryManager
-
-Proceed.
-
-
-Run timestamp: 2026-03-01T17:09:04.429Z


### PR DESCRIPTION
## Summary

Implements the 4 highest-priority optimizations from Issue #57:

### 1. O(1) back-pointer tag in `header_from_ptr()` (was: up to 512 iterations)

- `user_ptr()` now skips `sizeof(ptrdiff_t)` before aligning, guaranteeing room for the tag between `BlockHeader` and the user pointer.
- `write_back_ptr()` stores the block's offset (relative to base) at `user_ptr - sizeof(ptrdiff_t)`.
- `header_from_ptr()` reads the tag in O(1) instead of scanning up to 512 alignment steps.

### 2. Fewer AVL operations in `deallocate()` + `coalesce()`

- `deallocate()` no longer inserts into AVL before calling `coalesce()`.
- `coalesce()` removes free neighbors from AVL during merge, then performs a **single `avl_insert`** for the final merged block.
- Worst case: 2 removes + 1 insert (down from insert + remove/remove/insert).

### 3. Actual-padding computation in `allocate_from_block()` (less fragmentation)

- Instead of worst-case `sizeof(BlockHeader) + (alignment-1) + user_size`, computes exact `needed` based on the specific block's address.
- More splits → less wasted space per allocation.

### 4. O(1) `last_block_offset` in `ManagerHeader` (was: O(n) linear scan in `expand()`)

- Added `last_block_offset` field to `ManagerHeader`.
- Maintained through `create()`, `rebuild_free_tree()`, `allocate_from_block()` (split), and `coalesce()` (merge).
- `expand()` now finds the last block in O(1).

## Version bump

`kMagic` and `kBlockMagic` bumped to `V021` to detect stale heap images with the old `user_ptr` layout (which placed the user pointer 8 bytes closer to the header, leaving no room for the back-pointer tag).

## Test plan

- [x] All 11 existing tests pass locally (only `test_stress_realistic` is excluded — it was already failing before these changes due to an unrelated memory pressure issue)
- [x] `clang-format` compliance verified
- [x] File size: 1184 lines (< 1500 line limit)
- [x] Tested on: allocate, deallocate, coalesce, persistence (save/load), pptr, performance, stress_auto_grow, thread_safety, shared_mutex, scenarios_issue34, avl_allocator

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes netkeep80/PersistMemoryManager#57