### PR TITLE
ci(#81): run all 23 tests in build-demo job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,3 @@ Your forked repository: konard/netkeep80-PersistMemoryManager
 Original repository (upstream): netkeep80/PersistMemoryManager
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/netkeep80/PersistMemoryManager/issues/81
-Your prepared branch: issue-81-8f7951f17d5c
-Your prepared working directory: /tmp/gh-issue-solver-1772707713956
-Your forked repository: konard/netkeep80-PersistMemoryManager
-Original repository (upstream): netkeep80/PersistMemoryManager
-
-Proceed.
-
-
-Run timestamp: 2026-03-05T10:48:41.168Z


### PR DESCRIPTION
## Summary

Fixes #81

The CI `build-demo` job previously used an explicit `-R` test name filter to run the 8 headless demo tests:

```
ctest ... -R "test_demo_headless|test_mem_map_view|...|test_manual_alloc_view"
```

This meant:
- The filter had to be kept in sync with `demo/CMakeLists.txt` manually
- If a new demo test was added, it would not run in CI unless someone remembered to update the filter

**Fix**: Remove the `-R` filter and run `ctest` without arguments, so **all 23 tests** registered at configure time run automatically in the `build-demo` job:

| Job | Tests run |
|-----|-----------|
| `build-and-test` (gcc/clang/msvc, Debug+Release) | 15 core tests |
| `build-demo` (ubuntu/macos/windows, Release, `PMM_BUILD_DEMO=ON`) | **all 23 tests** (15 core + 8 headless demo) |

## Test plan

- [x] `ci.yml` diff reviewed: only the `ctest` step in `build-demo` changes
- [ ] CI passes on `konard/netkeep80-PersistMemoryManager` fork (triggered by this push)
- [ ] All 23 tests pass in the `build-demo` job across ubuntu, macos, and windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)