### PR TITLE
docs: update README.md to reflect v0.13.0 features (Issue #124)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/netkeep80/PersistMemoryManager/issues/124
-# Branch: issue-124-077e8e6d7c03
-# Timestamp: 2026-03-10T09:29:07.709Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

- Update version badge from `0.6.0` to `0.13.0`
- Add `pmm.h` (full-library single-header, v0.10.0) to quick start table
- Add all 7 single-header preset files with index type and use-case info
- Add 3 new embedded presets: `SmallEmbeddedStaticHeap<N>` (16-bit, v0.9.0), `EmbeddedStaticHeap<N>` (static buffer, v0.8.0), and `LargeDBHeap` (64-bit, v0.9.0)
- Add `pstringview` section with full API and usage examples (v0.11.0)
- Add `pmap<K,V>` section with full API and usage examples (v0.12.0)
- Update preset table with all 7 presets including index size, pptr size, and max heap
- Update address traits table with pptr size column
- Update repository structure listing all new files (`avl_tree_mixin.h`, `pstringview.h`, `pmap.h`, updated `single_include/` layout)
- Clarify that `lock_block_permanent()` is used internally by `pstringview`, not `pmap`

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all single-header preset files listed match `single_include/pmm/` directory
- [ ] Confirm all new API sections (`pstringview`, `pmap`) match source headers in `include/pmm/`
- [ ] Confirm version badge matches `CMakeLists.txt` version (`0.13.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes netkeep80/PersistMemoryManager#124