### PR TITLE
docs: stabilize verify/repair and diagnostics boundary (#256)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T16:38:43.717Z for PR creation at branch issue-256-4249a0b12082 for issue https://github.com/netkeep80/PersistMemoryManager/issues/256

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T16:38:43.717Z for PR creation at branch issue-256-4249a0b12082 for issue https://github.com/netkeep80/PersistMemoryManager/issues/256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(PersistMemoryManager VERSION 0.50.1 LANGUAGES CXX)
+project(PersistMemoryManager VERSION 0.50.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/changelog.d/20260411_stabilize_verify_repair_contract.md
+++ b/changelog.d/20260411_stabilize_verify_repair_contract.md
@@ -1,0 +1,11 @@
+bump: patch
+
+### Added
+- `docs/verify_repair_contract.md` — operational contract defining the boundary between verify, repair, and load
+- `docs/diagnostics_taxonomy.md` — violation types, severity levels, repair policies, and diagnostic entry format
+- `test_issue256_verify_repair_contract.cpp` — 9 tests for verify/repair/load operational contract
+
+### Changed
+- Clarified ambiguous "recovery" terminology in code comments to explicitly indicate "repair (within load)"
+- Regenerated single-include headers to reflect comment updates
+- Updated `docs/index.md` to reference new documents and reading order

--- a/docs/diagnostics_taxonomy.md
+++ b/docs/diagnostics_taxonomy.md
@@ -1,0 +1,243 @@
+# Diagnostics Taxonomy
+
+> **Canonical invariant reference:** [core_invariants.md](core_invariants.md) §F (Verify/Repair Contract).
+> **Operational contract:** [verify_repair_contract.md](verify_repair_contract.md).
+
+This document classifies every violation type PMM can detect, defines its
+severity, and specifies the allowed response in verify and repair modes.
+
+---
+
+## Violation classes
+
+PMM violations fall into six structural classes. Each class has a well-defined
+detection method, severity level, and repair policy.
+
+### Class 1: Header corruption
+
+Corruption of the image header (`ManagerHeader`) fields that anchor all
+addressing. Non-recoverable — the image cannot be trusted.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `HeaderCorruption` | `magic != kMagic` | **Fatal** | `Aborted` | `Aborted` (load returns false) |
+| `HeaderCorruption` | `total_size != backend.total_size()` | **Fatal** | `Aborted` | `Aborted` (load returns false) |
+| `HeaderCorruption` | `granule_size != address_traits::granule_size` | **Fatal** | `Aborted` | `Aborted` (load returns false) |
+
+**Detection:** `verify_image_unlocked()` (`verify_repair_mixin.inc:25–41`),
+`load()` header validation (`persist_memory_manager.h:316–339`).
+
+**Why non-recoverable:** these fields define the image format and addressing
+scheme. If any is wrong, all block offsets and sizes become meaningless.
+
+---
+
+### Class 2: Block state corruption (transitional states)
+
+A block's `weight` and `root_offset` are inconsistent, indicating a crash
+during allocation or deallocation.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `BlockStateInconsistent` | `weight > 0 && root_offset != own_idx` | **Recoverable** | `NoAction` | `Repaired` |
+| `BlockStateInconsistent` | `weight == 0 && root_offset != 0` | **Recoverable** | `NoAction` | `Repaired` |
+
+**Detection:** `verify_block_states()` (`allocator_policy.h:491–503`),
+`BlockStateBase::verify_state()` (`block_state.h:184–198`).
+
+**Repair:** `BlockStateBase::recover_state()` (`block_state.h:163–172`) —
+deterministic: `weight` determines the correct `root_offset`.
+
+**DiagnosticEntry fields:**
+- `block_index` — granule index of the affected block.
+- `expected` — correct `root_offset` value (`own_idx` for allocated, `0` for free).
+- `actual` — observed `root_offset` value.
+
+---
+
+### Class 3: Linked list corruption
+
+The doubly-linked block list has a `prev_offset` that does not match the
+preceding block's index. This can happen when a split or coalesce is
+interrupted mid-operation.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `PrevOffsetMismatch` | `stored_prev != expected_prev` | **Recoverable** | `NoAction` | `Repaired` |
+
+**Detection:** `verify_linked_list()` (`allocator_policy.h:413–434`).
+
+**Repair:** `repair_linked_list()` (`allocator_policy.h:340–355`) —
+deterministic: walks `next_offset` chain and sets each block's `prev_offset`
+to the index of the preceding block.
+
+**DiagnosticEntry fields:**
+- `block_index` — granule index of the block with wrong `prev_offset`.
+- `expected` — correct `prev_offset` (index of preceding block).
+- `actual` — observed `prev_offset` value.
+
+**Trust anchor:** `next_offset` is trusted. If `next_offset` is corrupted,
+the linked list is unrecoverably broken — this is detected as an out-of-bounds
+access and the walk terminates.
+
+---
+
+### Class 4: Counter corruption
+
+Stored counters (`block_count`, `free_count`, `alloc_count`, `used_size`) in
+the header do not match values recomputed by walking the linked list.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `CounterMismatch` | any counter differs from recomputed value | **Recoverable** | `NoAction` | `Rebuilt` |
+
+**Detection:** `verify_counters()` (`allocator_policy.h:446–479`).
+
+**Repair:** `recompute_counters()` (`allocator_policy.h:367–399`) —
+deterministic: recomputes all four counters by walking the linked list.
+
+**DiagnosticEntry fields:**
+- `block_index` — 0 (header-level violation).
+- `expected` — recomputed `block_count`.
+- `actual` — stored `block_count` in header.
+
+---
+
+### Class 5: Free tree corruption
+
+The AVL free tree root is inconsistent with the presence of free blocks.
+After a file round-trip, AVL fields (left/right/parent/height) are not
+persisted, so the free tree is always stale after loading from file.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `FreeTreeStale` | free blocks exist but `free_tree_root == no_block` | **Recoverable** | `NoAction` | `Rebuilt` |
+| `FreeTreeStale` | no free blocks but `free_tree_root != no_block` | **Recoverable** | `NoAction` | `Rebuilt` |
+
+**Detection:** `verify_free_tree()` (`allocator_policy.h:516–539`).
+
+**Repair:** `rebuild_free_tree()` (`allocator_policy.h:303–329`) —
+deterministic: resets all AVL fields and re-inserts every free block.
+
+**DiagnosticEntry fields:**
+- `block_index` — 0 (structure-level violation).
+- `expected` — recomputed free block count.
+- `actual` — stored `free_tree_root` value.
+
+---
+
+### Class 6: Forest registry corruption
+
+The persistent forest domain registry is missing, has invalid magic/version,
+or lacks required system domains or their flags.
+
+| ViolationType | Trigger | Severity | Verify action | Repair action |
+|---------------|---------|----------|---------------|---------------|
+| `ForestRegistryMissing` | registry pointer null or magic/version invalid | **Conditional** | `NoAction` | `Repaired` or `Aborted` |
+| `ForestDomainMissing` | required system domain not found | **Conditional** | `NoAction` | `Repaired` or `Aborted` |
+| `ForestDomainFlagsMissing` | system domain lacks `kForestDomainFlagSystem` | **Recoverable** | `NoAction` | `Repaired` |
+
+**Detection:** `verify_forest_registry_unlocked()` (`verify_repair_mixin.inc:64–95`).
+
+**Repair:** `validate_or_bootstrap_forest_registry_unlocked()`
+(`forest_domain_mixin.inc:397–451`) — attempts to bootstrap missing registry
+or domains. If bootstrap fails, entries are marked `Aborted` and load fails.
+
+**Required system domains:**
+- `system/free_tree` — free block AVL tree domain.
+- `system/symbols` — symbol dictionary (`pstringview`) domain.
+- `system/domain_registry` — domain registry meta-domain.
+
+**DiagnosticEntry fields:**
+- `block_index` — 0 (registry-level violation).
+- `expected` — expected magic (`kForestRegistryMagic`) for `ForestRegistryMissing`.
+- `actual` — observed magic value.
+
+---
+
+## Severity levels
+
+| Severity | Meaning | Verify behavior | Repair behavior |
+|----------|---------|-----------------|-----------------|
+| **Fatal** | Image format unrecognizable | Report `Aborted`, stop | Return `false`, report `Aborted` |
+| **Recoverable** | Deterministic reconstruction possible | Report `NoAction` | Apply fix, report `Repaired` or `Rebuilt` |
+| **Conditional** | May be recoverable via bootstrap | Report `NoAction` | Attempt bootstrap; `Repaired` on success, `Aborted` on failure |
+
+---
+
+## Diagnostic actions
+
+| DiagnosticAction | Meaning | Used in verify | Used in repair |
+|------------------|---------|----------------|----------------|
+| `NoAction` | Violation detected, no modification | Yes | No |
+| `Repaired` | Individual field corrected to deterministic value | No | Yes |
+| `Rebuilt` | Entire structure reconstructed from scratch | No | Yes |
+| `Aborted` | Corruption too severe, operation stopped | Yes (for fatal) | Yes (for fatal) |
+
+---
+
+## Diagnostic entry format
+
+Every violation is reported as a `DiagnosticEntry` (`diagnostics.h:59–66`):
+
+```cpp
+struct DiagnosticEntry {
+    ViolationType    type;        // Kind of violation (enum)
+    DiagnosticAction action;      // Action taken or proposed (enum)
+    std::uint64_t    block_index; // Affected block granule index (0 if N/A)
+    std::uint64_t    expected;    // Expected value (interpretation depends on type)
+    std::uint64_t    actual;      // Actual value found
+};
+```
+
+**Aggregated result** (`VerifyResult`, `diagnostics.h:75–105`):
+
+```cpp
+struct VerifyResult {
+    RecoveryMode mode;             // Verify or Repair
+    bool         ok;               // true if no violations
+    std::size_t  violation_count;  // Total violations (may exceed entry_count)
+    DiagnosticEntry entries[64];   // Detailed entries (up to kMaxDiagnosticEntries)
+    std::size_t  entry_count;      // Entries stored (≤ violation_count)
+};
+```
+
+If more than 64 violations occur, `violation_count` continues to increment
+but additional entries are not stored (overflow is silent but counted).
+
+---
+
+## Violation-to-action mapping (complete)
+
+| ViolationType | Verify action | Load action (recoverable) | Load action (unrecoverable) |
+|---------------|---------------|---------------------------|----------------------------|
+| `HeaderCorruption` | `Aborted` | — | `Aborted`, return false |
+| `BlockStateInconsistent` | `NoAction` | `Repaired` | — |
+| `PrevOffsetMismatch` | `NoAction` | `Repaired` | — |
+| `CounterMismatch` | `NoAction` | `Rebuilt` | — |
+| `FreeTreeStale` | `NoAction` | `Rebuilt` | — |
+| `ForestRegistryMissing` | `NoAction` | `Repaired` | `Aborted`, return false |
+| `ForestDomainMissing` | `NoAction` | `Repaired` | `Aborted`, return false |
+| `ForestDomainFlagsMissing` | `NoAction` | `Repaired` | — |
+
+---
+
+## Extension policy
+
+New violation types for tasks 08–10 must:
+
+1. Add a value to `ViolationType` enum in `diagnostics.h`.
+2. Implement a `verify_*()` read-only detection function.
+3. Implement a repair function (if recoverable) or document as fatal.
+4. Add detection to `verify_image_unlocked()`.
+5. Add repair to `load()` with proper `DiagnosticAction` marking.
+6. Add entries to this taxonomy.
+7. Add test cases covering both verify and repair paths.
+
+---
+
+## Related documents
+
+- [Verify/Repair Contract](verify_repair_contract.md) — operational boundary definition
+- [Core Invariants](core_invariants.md) — §F: Verify/Repair Contract invariants
+- [Recovery](recovery.md) — fault scenarios and 5-phase recovery mechanism

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ Single entry point for all PMM documentation. Each topic is covered by exactly o
 | [Bootstrap](bootstrap.md) | Deterministic 6-step initialization sequence for new PAP images |
 | [Free-Tree Forest Policy](free_tree_forest_policy.md) | Free-tree ordering, weight semantics, best-fit search |
 | [Recovery](recovery.md) | Fault recovery: 5-phase load sequence, block state machine, CRC32, atomic writes |
+| [Verify/Repair Contract](verify_repair_contract.md) | Operational boundary between verify, repair, and load — frozen contract for tasks 08–10 |
+| [Diagnostics Taxonomy](diagnostics_taxonomy.md) | Violation types, severity levels, repair policies, diagnostic entry format |
 | [Atomic Writes](atomic_writes.md) | Write criticality analysis, block state transitions, interruption guarantees |
 | [Thread Safety](thread_safety.md) | Lock policies, operation contracts, resolve() fast path, concurrent patterns |
 
@@ -40,4 +42,5 @@ For newcomers, the recommended path is:
 4. **[Architecture](architecture.md)** — understand the implementation layers
 5. **[API Reference](api_reference.md)** — use the library
 6. **[Bootstrap](bootstrap.md)** / **[Recovery](recovery.md)** — understand lifecycle guarantees
-7. **[Thread Safety](thread_safety.md)** — for concurrent usage
+7. **[Verify/Repair Contract](verify_repair_contract.md)** / **[Diagnostics Taxonomy](diagnostics_taxonomy.md)** — understand verify/repair boundary
+8. **[Thread Safety](thread_safety.md)** — for concurrent usage

--- a/docs/verify_repair_contract.md
+++ b/docs/verify_repair_contract.md
@@ -65,6 +65,8 @@ Code: `persist_memory_manager.h:1084–1095`, `verify_repair_mixin.inc:17–57`.
 - `test_issue245_verify_repair.cpp` — "verify detects missing system domain flags"
 - `test_issue256_verify_repair_contract.cpp` — "verify and load roles do not overlap"
 - `test_issue256_verify_repair_contract.cpp` — "load does not run on verify path"
+- `test_issue256_verify_repair_contract.cpp` — "verify with bad total_size stops after HeaderCorruption"
+- `test_issue256_verify_repair_contract.cpp` — "verify with bad granule_size stops after HeaderCorruption"
 
 ---
 

--- a/docs/verify_repair_contract.md
+++ b/docs/verify_repair_contract.md
@@ -1,0 +1,195 @@
+# Verify / Repair Operational Contract
+
+> **Canonical invariant reference:** [core_invariants.md](core_invariants.md) §F (Verify/Repair Contract).
+
+This document defines the operational boundary between **verify**, **repair**,
+and **load** in PersistMemoryManager. It serves as the binding contract for
+tasks 08–10 and any future validation, corruption testing, or storage seam work.
+
+---
+
+## Roles and boundaries
+
+PMM has three distinct operational modes that touch structural integrity.
+Their responsibilities do not overlap.
+
+| Operation | Entry point | Lock | Modifies image | Reports diagnostics |
+|-----------|-------------|------|----------------|---------------------|
+| **Verify** | `Mgr::verify()` | shared (read) | **No** | `VerifyResult` with `NoAction` entries |
+| **Repair** | `Mgr::load(VerifyResult&)` | unique (write) | **Yes** | `VerifyResult` with `Repaired` / `Rebuilt` / `Aborted` entries |
+| **Load** | `Mgr::load(VerifyResult&)` | unique (write) | **Yes** (repair phase) | Same `VerifyResult` as repair |
+
+**Key principle:** repair is never hidden. Every structural modification during
+`load()` is recorded in `VerifyResult` with an explicit `DiagnosticAction`.
+
+---
+
+## Verify contract
+
+### What verify does
+
+1. Acquires a **shared read lock** — no concurrent writes allowed during verify.
+2. Performs **read-only** checks on the loaded image:
+   - Header validation (magic, total_size, granule_size).
+   - Block state consistency (weight/root_offset invariants).
+   - Linked list prev_offset correctness.
+   - Counter consistency (block_count, free_count, alloc_count, used_size).
+   - Free tree root consistency (root presence vs. free block count).
+   - Forest registry and system domain presence/flags.
+3. Populates `VerifyResult` with `DiagnosticAction::NoAction` for all findings.
+4. Returns `VerifyResult` with `ok == true` if no violations found.
+
+### What verify does NOT do
+
+- **Never modifies** any byte of the image.
+- **Never repairs** any structural inconsistency.
+- **Never substitutes** for load recovery — verify on an unloaded image reports
+  `HeaderCorruption` / `Aborted`, it does not attempt to load.
+
+### Implementation
+
+```
+verify() → shared_lock → verify_image_unlocked(result) → return result
+```
+
+Code: `persist_memory_manager.h:1084–1095`, `verify_repair_mixin.inc:17–57`.
+
+### Test coverage
+
+- `test_issue245_verify_repair.cpp` — "clean image has no violations"
+- `test_issue245_verify_repair.cpp` — "verify detects block state inconsistency"
+- `test_issue245_verify_repair.cpp` — "verify does not modify the image"
+- `test_issue245_verify_repair.cpp` — "verify detects prev_offset mismatch"
+- `test_issue245_verify_repair.cpp` — "verify detects forest registry corruption"
+- `test_issue245_verify_repair.cpp` — "verify detects missing system domain"
+- `test_issue245_verify_repair.cpp` — "verify detects missing system domain flags"
+- `test_issue256_verify_repair_contract.cpp` — "verify and load roles do not overlap"
+- `test_issue256_verify_repair_contract.cpp` — "load does not run on verify path"
+
+---
+
+## Repair contract
+
+### What repair does
+
+Repair is the structural modification phase of `load()`. It is **never** a
+standalone operation — it always runs as part of `load(VerifyResult&)`.
+
+1. Acquires a **unique write lock**.
+2. **Detects** all violations by running verify functions on the raw image.
+3. **Marks** each detected violation with the action that will be applied:
+   - `Repaired` — field-level fix (block state, prev_offset).
+   - `Rebuilt` — structure rebuilt from scratch (counters, free tree).
+4. **Applies** all fixes in a deterministic order.
+5. Records every fix in `VerifyResult` — no silent modifications.
+
+### Repair phases (deterministic order)
+
+| Phase | Verify function | Repair function | Action |
+|-------|----------------|-----------------|--------|
+| 1 | `verify_block_states()` | `recover_state()` (via `rebuild_free_tree()`) | `Repaired` |
+| 2 | `verify_linked_list()` | `repair_linked_list()` | `Repaired` |
+| 3 | `verify_counters()` | `recompute_counters()` | `Rebuilt` |
+| 4 | `verify_free_tree()` | `rebuild_free_tree()` | `Rebuilt` |
+| 5 | `verify_forest_registry_unlocked()` | `validate_or_bootstrap_forest_registry_unlocked()` | `Repaired` |
+
+### Scope of allowed reconstruction
+
+| What can be repaired | Method | Rationale |
+|---------------------|--------|-----------|
+| Block weight/root_offset mismatch | `recover_state()` | Deterministic: weight determines correct root_offset |
+| Linked list prev_offset | `repair_linked_list()` | Deterministic: prev_offset derived from next_offset chain |
+| Counters (block_count, free_count, alloc_count, used_size) | `recompute_counters()` | Deterministic: recomputed by walking linked list |
+| Free tree (AVL structure) | `rebuild_free_tree()` | Deterministic: rebuilt from scratch using linked list |
+| Forest registry (missing or invalid) | `validate_or_bootstrap_forest_registry_unlocked()` | Bootstrap if missing; abort if unrecoverable |
+
+### What repair does NOT do
+
+- **Never repairs** corrupted `next_offset` chain — this is the trust anchor.
+- **Never repairs** corrupted magic, granule_size, or total_size — these are
+  non-recoverable and cause `Aborted`.
+- **Never repairs** user data inside allocated blocks.
+- **Never repairs** user-level AVL trees (`pmap`, `pstringview`).
+- **Never runs** outside of `load()` — no "quiet repair" on normal paths.
+
+### Test coverage
+
+- `test_issue245_verify_repair.cpp` — "load(VerifyResult&) reports repairs directly"
+- `test_issue245_verify_repair.cpp` — "Repaired vs Rebuilt distinction"
+- `test_issue245_verify_repair.cpp` — "Aborted action on header corruption"
+- `test_issue256_verify_repair_contract.cpp` — "every repair action is recorded"
+- `test_issue256_verify_repair_contract.cpp` — "repair scope is bounded"
+
+---
+
+## Load contract
+
+### What load does
+
+`load(VerifyResult&)` is the sole entry point for restoring a persisted image.
+It combines verification and repair in a single atomic operation under a write
+lock. The `VerifyResult` parameter receives a complete audit trail.
+
+### What load does NOT do
+
+- **No hidden repair** — every structural modification is recorded in
+  `VerifyResult` with an explicit `DiagnosticAction`.
+- **No silent normalization** — runtime fields (`owns_memory`,
+  `prev_total_size`) are reset to safe defaults, but these are runtime-only
+  fields that are never persisted.
+- **No masking of corruption** — on non-recoverable corruption (header),
+  load returns `false` with `DiagnosticAction::Aborted`.
+
+### Load via file I/O
+
+`load_manager_from_file<Mgr>(filename, result)` adds CRC32 verification
+before calling `Mgr::load(result)`. CRC mismatch is rejected before any
+structural check runs.
+
+Code: `io.h:164`.
+
+---
+
+## Non-recoverable conditions (hard stop)
+
+These violations cause `load()` to return `false` with `Aborted` action:
+
+| Condition | Detection | Why non-recoverable |
+|-----------|-----------|---------------------|
+| Invalid magic | `hdr->magic != kMagic` | Cannot identify the image as PMM |
+| Size mismatch | `hdr->total_size != backend.total_size()` | Cannot trust block boundaries |
+| Granule mismatch | `hdr->granule_size != address_traits::granule_size` | All offsets become meaningless |
+| CRC32 mismatch | `stored_crc != computed_crc` (file I/O path) | Raw data corruption detected |
+| Forest registry unrecoverable | `validate_or_bootstrap_forest_registry_unlocked()` fails | Bootstrap structure cannot be restored |
+
+---
+
+## Summary of guarantees
+
+1. **Verify, repair, and load have non-overlapping roles.**
+   Verify reads. Repair (within load) writes. Load orchestrates both.
+
+2. **No hidden repair on normal paths.**
+   `allocate()`, `deallocate()`, `reallocate_typed()`, `save_manager()` — none
+   of these perform structural repair. Repair happens only in `load()`.
+
+3. **Every violation class has a clear policy** (see
+   [diagnostics_taxonomy.md](diagnostics_taxonomy.md)).
+
+4. **Diagnostics are structured and uniform.**
+   Every violation is reported as a `DiagnosticEntry` with type, affected block,
+   expected/actual values, and action.
+
+5. **Tasks 08–10 can rely on this contract.**
+   The verify/repair boundary is frozen. New violation types or repair policies
+   must be added to `ViolationType` enum and documented in
+   [diagnostics_taxonomy.md](diagnostics_taxonomy.md).
+
+---
+
+## Related documents
+
+- [Diagnostics Taxonomy](diagnostics_taxonomy.md) — violation types, severity, repair policy
+- [Core Invariants](core_invariants.md) — §F: Verify/Repair Contract invariants
+- [Recovery](recovery.md) — fault scenarios and 5-phase recovery mechanism
+- [Architecture](architecture.md) — layer stack and storage backends

--- a/include/pmm/allocator_policy.h
+++ b/include/pmm/allocator_policy.h
@@ -22,7 +22,7 @@
  * обращается напрямую к полям Block<A>. В split-пути allocate_from_block()
  * используются методы SplittingBlock (initialize_new_block, link_new_block,
  * finalize_split). В coalesce() соседние блоки проверяются через BlockStateBase.
- * В recovery-методах (rebuild_free_tree, repair_linked_list, recompute_counters)
+ * В repair-методах load() (rebuild_free_tree, repair_linked_list, recompute_counters)
  * напрямую используются статические методы BlockStateBase<AT>:
  *   - reset_avl_fields_of()  — вместо удалённой reset_block_avl_fields()
  *   - repair_prev_offset()   — вместо удалённой repair_block_prev_offset()
@@ -288,7 +288,7 @@ class AllocatorPolicy
         FreeBlockTreeT::insert( base, hdr, b_idx );
     }
 
-    // ─── Восстановление состояния (после load()) ───────────────────────────────
+    // ─── Repair phase of load() — structural reconstruction ────────────────────
 
     /**
      * @brief Перестроить дерево свободных блоков.
@@ -309,7 +309,7 @@ class AllocatorPolicy
         {
             void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
 
-            // Recover state — fix incorrect transitional states
+            // Repair: fix incorrect transitional states (weight/root_offset mismatch)
             BlockState::recover_state( blk_ptr, idx );
 
             if ( BlockState::get_weight( blk_ptr ) == 0 ) // free block

--- a/include/pmm/block_state.h
+++ b/include/pmm/block_state.h
@@ -25,8 +25,8 @@
  *
  *   - reset_avl_fields_of()     — сброс AVL-полей перед rebuild_free_tree
  *   - repair_prev_offset()      — восстановление prev_offset при repair_linked_list
- *   - get_next_offset()         — чтение next_offset в recovery-методах
- *   - get_weight()              — чтение weight в recovery-методах
+ *   - get_next_offset()         — чтение next_offset в repair-методах (load)
+ *   - get_weight()              — чтение weight в repair-методах (load)
  *
  *   repair_block_prev_offset(), read_block_next_offset(), read_block_weight()
  *   AllocatorPolicy вызывает BlockStateBase<AT>::* напрямую.
@@ -149,13 +149,14 @@ template <typename AddressTraitsT> class BlockStateBase : private Block<AddressT
      */
     bool is_permanently_locked() const noexcept { return node_type() == pmm::kNodeReadOnly; }
 
-    // ─── Статические утилиты для recovery-операций ──────────────────────────
+    // ─── Статические утилиты для repair-операций (вызываются из load()) ─────
 
     /**
-     * @brief Восстановить блок в корректное состояние (при load()).
+     * @brief Repair block state to a consistent value (called during load()).
      *
-     * Используется для восстановления после crash — приводит блок к корректному
-     * состоянию (FreeBlock или AllocatedBlock) в зависимости от weight и root_offset.
+     * Part of the repair phase in load(): fixes transitional (inconsistent)
+     * weight/root_offset states left by interrupted allocate/deallocate.
+     * Deterministic: weight alone determines the correct root_offset.
      *
      * @param raw_blk   Указатель на блок.
      * @param own_idx   Гранульный индекс данного блока.

--- a/include/pmm/diagnostics.h
+++ b/include/pmm/diagnostics.h
@@ -25,7 +25,7 @@
 namespace pmm
 {
 
-/// @brief Mode for recovery operations: verify-only or repair.
+/// @brief Mode for diagnostic operations: verify-only (read) or repair (write, within load).
 enum class RecoveryMode : std::uint8_t
 {
     Verify = 0, ///< Read-only diagnostics; no modifications to the image.
@@ -52,7 +52,7 @@ enum class DiagnosticAction : std::uint8_t
     NoAction = 0, ///< No action (verify mode or no fix available).
     Repaired,     ///< Field was repaired to correct value.
     Rebuilt,      ///< Structure was rebuilt from scratch (AVL tree, counters).
-    Aborted,      ///< Recovery aborted — corruption too severe.
+    Aborted,      ///< Repair aborted — corruption too severe, load returns false.
 };
 
 /// @brief A single diagnostic entry describing one violation.

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -337,8 +337,7 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
                         static_cast<std::uint64_t>( hdr->granule_size ) );
             return false;
         }
-        // Verify before repair — detect violations in the raw image.
-        // Verify before repair — detect violations, then mark with repair actions.
+        // Detect violations in the raw image, then mark with repair actions.
         auto mark_entries = []( VerifyResult& r, std::size_t from, DiagnosticAction act )
         {
             for ( std::size_t i = from; i < r.entry_count; ++i )

--- a/include/pmm/verify_repair_mixin.inc
+++ b/include/pmm/verify_repair_mixin.inc
@@ -33,11 +33,13 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, _backend.total_size(),
                     static_cast<std::uint64_t>( hdr->total_size ) );
+        return; // Cannot proceed — addressing is unreliable
     }
     if ( hdr->granule_size != static_cast<std::uint16_t>( address_traits::granule_size ) )
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, address_traits::granule_size,
                     static_cast<std::uint64_t>( hdr->granule_size ) );
+        return; // Cannot proceed — block sizes are meaningless
     }
 
     // 2. Block state consistency (transitional states)

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -8332,11 +8332,13 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, _backend.total_size(),
                     static_cast<std::uint64_t>( hdr->total_size ) );
+        return; // Cannot proceed — addressing is unreliable
     }
     if ( hdr->granule_size != static_cast<std::uint16_t>( address_traits::granule_size ) )
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, address_traits::granule_size,
                     static_cast<std::uint64_t>( hdr->granule_size ) );
+        return; // Cannot proceed — block sizes are meaningless
     }
 
     // 2. Block state consistency (transitional states)

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -686,8 +686,8 @@ static_assert( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) == 32, "Block<Def
  *
  *   - reset_avl_fields_of()     — сброс AVL-полей перед rebuild_free_tree
  *   - repair_prev_offset()      — восстановление prev_offset при repair_linked_list
- *   - get_next_offset()         — чтение next_offset в recovery-методах
- *   - get_weight()              — чтение weight в recovery-методах
+ *   - get_next_offset()         — чтение next_offset в repair-методах (load)
+ *   - get_weight()              — чтение weight в repair-методах (load)
  *
  *   repair_block_prev_offset(), read_block_next_offset(), read_block_weight()
  *   AllocatorPolicy вызывает BlockStateBase<AT>::* напрямую.
@@ -721,7 +721,7 @@ static_assert( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) == 32, "Block<Def
 namespace pmm
 {
 
-/// @brief Mode for recovery operations: verify-only or repair.
+/// @brief Mode for diagnostic operations: verify-only (read) or repair (write, within load).
 enum class RecoveryMode : std::uint8_t
 {
     Verify = 0, ///< Read-only diagnostics; no modifications to the image.
@@ -748,7 +748,7 @@ enum class DiagnosticAction : std::uint8_t
     NoAction = 0, ///< No action (verify mode or no fix available).
     Repaired,     ///< Field was repaired to correct value.
     Rebuilt,      ///< Structure was rebuilt from scratch (AVL tree, counters).
-    Aborted,      ///< Recovery aborted — corruption too severe.
+    Aborted,      ///< Repair aborted — corruption too severe, load returns false.
 };
 
 /// @brief A single diagnostic entry describing one violation.
@@ -909,13 +909,14 @@ template <typename AddressTraitsT> class BlockStateBase : private Block<AddressT
      */
     bool is_permanently_locked() const noexcept { return node_type() == pmm::kNodeReadOnly; }
 
-    // ─── Статические утилиты для recovery-операций ──────────────────────────
+    // ─── Статические утилиты для repair-операций (вызываются из load()) ─────
 
     /**
-     * @brief Восстановить блок в корректное состояние (при load()).
+     * @brief Repair block state to a consistent value (called during load()).
      *
-     * Используется для восстановления после crash — приводит блок к корректному
-     * состоянию (FreeBlock или AllocatedBlock) в зависимости от weight и root_offset.
+     * Part of the repair phase in load(): fixes transitional (inconsistent)
+     * weight/root_offset states left by interrupted allocate/deallocate.
+     * Deterministic: weight alone determines the correct root_offset.
      *
      * @param raw_blk   Указатель на блок.
      * @param own_idx   Гранульный индекс данного блока.
@@ -3582,7 +3583,7 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
  * обращается напрямую к полям Block<A>. В split-пути allocate_from_block()
  * используются методы SplittingBlock (initialize_new_block, link_new_block,
  * finalize_split). В coalesce() соседние блоки проверяются через BlockStateBase.
- * В recovery-методах (rebuild_free_tree, repair_linked_list, recompute_counters)
+ * В repair-методах load() (rebuild_free_tree, repair_linked_list, recompute_counters)
  * напрямую используются статические методы BlockStateBase<AT>:
  *   - reset_avl_fields_of()  — вместо удалённой reset_block_avl_fields()
  *   - repair_prev_offset()   — вместо удалённой repair_block_prev_offset()
@@ -3841,7 +3842,7 @@ class AllocatorPolicy
         FreeBlockTreeT::insert( base, hdr, b_idx );
     }
 
-    // ─── Восстановление состояния (после load()) ───────────────────────────────
+    // ─── Repair phase of load() — structural reconstruction ────────────────────
 
     /**
      * @brief Перестроить дерево свободных блоков.
@@ -3862,7 +3863,7 @@ class AllocatorPolicy
         {
             void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
 
-            // Recover state — fix incorrect transitional states
+            // Repair: fix incorrect transitional states (weight/root_offset mismatch)
             BlockState::recover_state( blk_ptr, idx );
 
             if ( BlockState::get_weight( blk_ptr ) == 0 ) // free block
@@ -6820,8 +6821,7 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
                         static_cast<std::uint64_t>( hdr->granule_size ) );
             return false;
         }
-        // Verify before repair — detect violations in the raw image.
-        // Verify before repair — detect violations, then mark with repair actions.
+        // Detect violations in the raw image, then mark with repair actions.
         auto mark_entries = []( VerifyResult& r, std::size_t from, DiagnosticAction act )
         {
             for ( std::size_t i = from; i < r.entry_count; ++i )

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -5037,11 +5037,13 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, _backend.total_size(),
                     static_cast<std::uint64_t>( hdr->total_size ) );
+        return;
     }
     if ( hdr->granule_size != static_cast<std::uint16_t>( address_traits::granule_size ) )
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, address_traits::granule_size,
                     static_cast<std::uint64_t>( hdr->granule_size ) );
+        return;
     }
 
     allocator::verify_block_states( base, hdr, result );

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -5037,13 +5037,13 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, _backend.total_size(),
                     static_cast<std::uint64_t>( hdr->total_size ) );
-        return;
+        return; 
     }
     if ( hdr->granule_size != static_cast<std::uint16_t>( address_traits::granule_size ) )
     {
         result.add( ViolationType::HeaderCorruption, DiagnosticAction::Aborted, 0, address_traits::granule_size,
                     static_cast<std::uint64_t>( hdr->granule_size ) );
-        return;
+        return; 
     }
 
     allocator::verify_block_states( base, hdr, result );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -269,3 +269,6 @@ pmm_add_test(test_issue243_free_tree_policy test_issue243_free_tree_policy.cpp)
 
 # ─── Verify/repair mode separation tests ────────────────────────
 pmm_add_test(test_issue245_verify_repair test_issue245_verify_repair.cpp)
+
+# ─── Verify/repair/load operational contract tests ──────────────
+pmm_add_test(test_issue256_verify_repair_contract test_issue256_verify_repair_contract.cpp)

--- a/tests/test_issue256_verify_repair_contract.cpp
+++ b/tests/test_issue256_verify_repair_contract.cpp
@@ -1,0 +1,420 @@
+/**
+ * @file test_issue256_verify_repair_contract.cpp
+ * @brief Tests for the verify/repair/load operational contract.
+ *
+ * Verifies the stabilized boundary between verify, repair, and load:
+ *   - Verify and load roles do not overlap (verify never modifies, load always reports).
+ *   - Load does not perform hidden repair on normal operational paths.
+ *   - Every repair action during load is recorded in VerifyResult.
+ *   - Repair scope is bounded: only documented violations are repaired.
+ *   - Diagnostic entries are uniform and complete for all violation types.
+ *   - Non-recoverable corruption causes deterministic hard stop.
+ *
+ * @see docs/verify_repair_contract.md — operational contract
+ * @see docs/diagnostics_taxonomy.md — violation types and diagnostic formats
+ * @see include/pmm/diagnostics.h — RecoveryMode, VerifyResult, DiagnosticEntry
+ */
+
+#include "pmm/forest_registry.h"
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using Mgr = pmm::presets::SingleThreadedHeap;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static constexpr std::size_t kBlockHdrByteSize =
+    ( ( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) + pmm::DefaultAddressTraits::granule_size - 1 ) /
+      pmm::DefaultAddressTraits::granule_size ) *
+    pmm::DefaultAddressTraits::granule_size;
+
+static pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>* test_get_header( std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kBlockHdrByteSize );
+}
+
+static void setup_clean_image( std::size_t arena_size = 64 * 1024 )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( arena_size ) );
+}
+
+// ─── Test 1: verify and load roles do not overlap ──────────────────────────
+
+TEST_CASE( "contract: verify and load roles do not overlap", "[test_issue256]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset to create a detectable violation.
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * pmm::DefaultAddressTraits::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<pmm::DefaultAddressTraits> );
+    auto          orig    = pmm::BlockStateBase<pmm::DefaultAddressTraits>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<pmm::DefaultAddressTraits>::set_root_offset_of( blk_raw, orig + 42 );
+
+    // Verify detects but does NOT fix.
+    pmm::VerifyResult v1 = Mgr::verify();
+    REQUIRE_FALSE( v1.ok );
+    REQUIRE( v1.mode == pmm::RecoveryMode::Verify );
+    for ( std::size_t i = 0; i < v1.entry_count; ++i )
+    {
+        REQUIRE( v1.entries[i].action == pmm::DiagnosticAction::NoAction );
+    }
+
+    // Corruption persists after verify.
+    auto after = pmm::BlockStateBase<pmm::DefaultAddressTraits>::get_root_offset( blk_raw );
+    REQUIRE( after == orig + 42 );
+
+    // Second verify produces same result — idempotent.
+    pmm::VerifyResult v2 = Mgr::verify();
+    REQUIRE_FALSE( v2.ok );
+    REQUIRE( v2.violation_count == v1.violation_count );
+
+    // Restore and cleanup.
+    pmm::BlockStateBase<pmm::DefaultAddressTraits>::set_root_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+// ─── Test 2: load does not run on verify path ──────────────────────────────
+
+TEST_CASE( "contract: load does not run on verify path", "[test_issue256]" )
+{
+    setup_clean_image();
+
+    // Verify on a healthy, already-initialized manager should not trigger any
+    // load/repair machinery — it uses a shared (read) lock, not a unique lock.
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE( result.ok );
+    REQUIRE( result.mode == pmm::RecoveryMode::Verify );
+    REQUIRE( result.violation_count == 0 );
+    REQUIRE( result.entry_count == 0 );
+
+    Mgr::destroy();
+}
+
+// ─── Test 3: every repair action is recorded ───────────────────────────────
+
+TEST_CASE( "contract: every repair action is recorded in VerifyResult", "[test_issue256]" )
+{
+    using MgrA = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2560>;
+    using MgrB = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2561>;
+
+    static const char* kFile = "test_issue256_record.dat";
+    const std::size_t  arena = 64 * 1024;
+
+    REQUIRE( MgrA::create( arena ) );
+    auto p = MgrA::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt block state to trigger a Repaired entry.
+    std::uint8_t* src     = MgrA::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * pmm::DefaultAddressTraits::granule_size;
+    void*         blk_raw = src + usr_off - sizeof( pmm::Block<pmm::DefaultAddressTraits> );
+    auto          blk_idx = static_cast<pmm::DefaultAddressTraits::index_type>(
+        p.offset() - sizeof( pmm::Block<pmm::DefaultAddressTraits> ) / pmm::DefaultAddressTraits::granule_size );
+    pmm::BlockStateBase<pmm::DefaultAddressTraits>::set_root_offset_of( blk_raw, blk_idx + 999 );
+
+    REQUIRE( pmm::save_manager<MgrA>( kFile ) );
+    MgrA::destroy();
+
+    // Load with VerifyResult — repairs must be recorded.
+    REQUIRE( MgrB::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrB>( kFile, result ) );
+    REQUIRE( result.mode == pmm::RecoveryMode::Repair );
+    REQUIRE_FALSE( result.ok );
+
+    // At least BlockStateInconsistent should be recorded as Repaired.
+    bool found_block_repair = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::BlockStateInconsistent )
+        {
+            REQUIRE( result.entries[i].action == pmm::DiagnosticAction::Repaired );
+            found_block_repair = true;
+        }
+    }
+    REQUIRE( found_block_repair );
+
+    // After repair, verify must show clean state.
+    pmm::VerifyResult post = MgrB::verify();
+    REQUIRE( post.ok );
+
+    MgrB::destroy();
+    std::remove( kFile );
+}
+
+// ─── Test 4: repair scope is bounded ───────────────────────────────────────
+
+TEST_CASE( "contract: repair scope is bounded — no user data modified", "[test_issue256]" )
+{
+    using MgrC = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2562>;
+    using MgrD = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2563>;
+
+    static const char* kFile = "test_issue256_scope.dat";
+    const std::size_t  arena = 64 * 1024;
+
+    REQUIRE( MgrC::create( arena ) );
+
+    // Write known pattern into user data.
+    auto p = MgrC::allocate_typed<std::uint64_t>( 8 );
+    REQUIRE( !p.is_null() );
+    auto p_offset = p.offset(); // save raw offset for use with MgrD
+    std::uint64_t* data = MgrC::template resolve<std::uint64_t>( p );
+    REQUIRE( data != nullptr );
+    for ( int i = 0; i < 8; ++i )
+        data[i] = static_cast<std::uint64_t>( 0xCAFEBABE00000000ULL | i );
+
+    REQUIRE( pmm::save_manager<MgrC>( kFile ) );
+    MgrC::destroy();
+
+    // Load into fresh manager — load() runs repair phases.
+    REQUIRE( MgrD::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrD>( kFile, result ) );
+
+    // User data must survive repair unchanged.
+    typename MgrD::template pptr<std::uint64_t> pd( p_offset );
+    std::uint64_t* loaded_data = MgrD::template resolve<std::uint64_t>( pd );
+    REQUIRE( loaded_data != nullptr );
+    for ( int i = 0; i < 8; ++i )
+    {
+        REQUIRE( loaded_data[i] == static_cast<std::uint64_t>( 0xCAFEBABE00000000ULL | i ) );
+    }
+
+    MgrD::destroy();
+    std::remove( kFile );
+}
+
+// ─── Test 5: diagnostic entries are uniform for all violation types ─────────
+
+TEST_CASE( "contract: diagnostic entries are uniform for all violation types", "[test_issue256]" )
+{
+    // Construct entries for each ViolationType and verify all fields are populated.
+    pmm::VerifyResult result;
+
+    result.add( pmm::ViolationType::HeaderCorruption, pmm::DiagnosticAction::Aborted, 0, 100, 200 );
+    result.add( pmm::ViolationType::BlockStateInconsistent, pmm::DiagnosticAction::Repaired, 5, 5, 999 );
+    result.add( pmm::ViolationType::PrevOffsetMismatch, pmm::DiagnosticAction::Repaired, 10, 3, 777 );
+    result.add( pmm::ViolationType::CounterMismatch, pmm::DiagnosticAction::Rebuilt, 0, 50, 49 );
+    result.add( pmm::ViolationType::FreeTreeStale, pmm::DiagnosticAction::Rebuilt, 0, 3, 0 );
+    result.add( pmm::ViolationType::ForestRegistryMissing, pmm::DiagnosticAction::NoAction, 0, 0x50465247, 0 );
+    result.add( pmm::ViolationType::ForestDomainMissing, pmm::DiagnosticAction::NoAction );
+    result.add( pmm::ViolationType::ForestDomainFlagsMissing, pmm::DiagnosticAction::NoAction );
+
+    REQUIRE( result.entry_count == 8 );
+    REQUIRE( result.violation_count == 8 );
+    REQUIRE_FALSE( result.ok );
+
+    // All 8 violation types are represented.
+    REQUIRE( result.entries[0].type == pmm::ViolationType::HeaderCorruption );
+    REQUIRE( result.entries[1].type == pmm::ViolationType::BlockStateInconsistent );
+    REQUIRE( result.entries[2].type == pmm::ViolationType::PrevOffsetMismatch );
+    REQUIRE( result.entries[3].type == pmm::ViolationType::CounterMismatch );
+    REQUIRE( result.entries[4].type == pmm::ViolationType::FreeTreeStale );
+    REQUIRE( result.entries[5].type == pmm::ViolationType::ForestRegistryMissing );
+    REQUIRE( result.entries[6].type == pmm::ViolationType::ForestDomainMissing );
+    REQUIRE( result.entries[7].type == pmm::ViolationType::ForestDomainFlagsMissing );
+
+    // Verify specific field values for a representative entry.
+    REQUIRE( result.entries[2].block_index == 10 );
+    REQUIRE( result.entries[2].expected == 3 );
+    REQUIRE( result.entries[2].actual == 777 );
+}
+
+// ─── Test 6: non-recoverable corruption causes deterministic hard stop ─────
+
+TEST_CASE( "contract: non-recoverable corruption causes deterministic hard stop", "[test_issue256]" )
+{
+    using MgrE = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2564>;
+    using MgrF = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2565>;
+    using MgrG = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2566>;
+
+    const std::size_t arena = 64 * 1024;
+
+    // Test 6a: magic corruption → Aborted.
+    {
+        REQUIRE( MgrE::create( arena ) );
+        std::uint8_t* base = MgrE::backend().base_ptr();
+        auto*         hdr  = test_get_header( base );
+        auto          orig = hdr->magic;
+        hdr->magic         = 0xDEAD;
+
+        // Copy to MgrF and try load.
+        REQUIRE( MgrF::create( arena ) );
+        std::memcpy( MgrF::backend().base_ptr(), base, arena );
+        hdr->magic = orig; // restore MgrE
+        MgrE::destroy();
+
+        pmm::VerifyResult result;
+        bool              ok = MgrF::load( result );
+        REQUIRE_FALSE( ok );
+        REQUIRE_FALSE( result.ok );
+        REQUIRE( result.entry_count >= 1 );
+        REQUIRE( result.entries[0].type == pmm::ViolationType::HeaderCorruption );
+        REQUIRE( result.entries[0].action == pmm::DiagnosticAction::Aborted );
+        MgrF::destroy();
+    }
+
+    // Test 6b: granule mismatch → Aborted.
+    {
+        REQUIRE( MgrG::create( arena ) );
+        std::uint8_t* base = MgrG::backend().base_ptr();
+        auto*         hdr  = test_get_header( base );
+        auto          orig = hdr->granule_size;
+        hdr->granule_size  = 999;
+
+        pmm::VerifyResult result;
+        result.mode = pmm::RecoveryMode::Verify;
+        // Verify detects it too.
+        pmm::VerifyResult v = MgrG::verify();
+        REQUIRE_FALSE( v.ok );
+        bool found_hdr = false;
+        for ( std::size_t i = 0; i < v.entry_count; ++i )
+        {
+            if ( v.entries[i].type == pmm::ViolationType::HeaderCorruption )
+                found_hdr = true;
+        }
+        REQUIRE( found_hdr );
+
+        hdr->granule_size = orig;
+        MgrG::destroy();
+    }
+}
+
+// ─── Test 7: allocate/deallocate do not perform hidden repair ──────────────
+
+TEST_CASE( "contract: normal operations do not perform hidden repair", "[test_issue256]" )
+{
+    setup_clean_image();
+
+    // Corrupt a block's prev_offset.
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p2.offset() ) * pmm::DefaultAddressTraits::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<pmm::DefaultAddressTraits> );
+    auto          orig    = pmm::BlockStateBase<pmm::DefaultAddressTraits>::get_prev_offset( blk_raw );
+    pmm::BlockStateBase<pmm::DefaultAddressTraits>::set_prev_offset_of( blk_raw, orig + 500 );
+
+    // Perform normal operations — allocate and deallocate.
+    auto p3 = Mgr::allocate_typed<std::uint32_t>( 4 );
+    REQUIRE( !p3.is_null() );
+    Mgr::deallocate_typed( p3 );
+
+    // The corruption should still be present — normal operations do not repair.
+    auto after = pmm::BlockStateBase<pmm::DefaultAddressTraits>::get_prev_offset( blk_raw );
+    REQUIRE( after == orig + 500 );
+
+    // verify() confirms the corruption is still there.
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    bool found = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::PrevOffsetMismatch )
+            found = true;
+    }
+    REQUIRE( found );
+
+    // Restore and cleanup.
+    pmm::BlockStateBase<pmm::DefaultAddressTraits>::set_prev_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+// ─── Test 8: clean round-trip through save/load produces no violations ─────
+
+TEST_CASE( "contract: clean round-trip produces no violations", "[test_issue256]" )
+{
+    using MgrH = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2567>;
+    using MgrI = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2568>;
+
+    static const char* kFile  = "test_issue256_clean_rt.dat";
+    const std::size_t  arena  = 64 * 1024;
+
+    REQUIRE( MgrH::create( arena ) );
+    auto p1 = MgrH::allocate_typed<std::uint64_t>( 10 );
+    auto p2 = MgrH::allocate_typed<std::uint32_t>( 20 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+    MgrH::deallocate_typed( p1 );
+
+    // Verify clean before save.
+    pmm::VerifyResult pre = MgrH::verify();
+    REQUIRE( pre.ok );
+
+    REQUIRE( pmm::save_manager<MgrH>( kFile ) );
+    MgrH::destroy();
+
+    // Load and check — the only expected violations are structural ones
+    // that load() repairs (prev_offset, counters, free tree).
+    REQUIRE( MgrI::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrI>( kFile, result ) );
+
+    // After load, verify must show clean state.
+    pmm::VerifyResult post = MgrI::verify();
+    REQUIRE( post.ok );
+    REQUIRE( post.violation_count == 0 );
+
+    MgrI::destroy();
+    std::remove( kFile );
+}
+
+// ─── Test 9: ViolationType enum covers all documented violation classes ─────
+
+TEST_CASE( "contract: ViolationType enum covers all documented classes", "[test_issue256]" )
+{
+    // The diagnostics taxonomy documents 8 violation types.
+    // Verify they all exist and have distinct values.
+    std::vector<pmm::ViolationType> types = {
+        pmm::ViolationType::None,
+        pmm::ViolationType::BlockStateInconsistent,
+        pmm::ViolationType::PrevOffsetMismatch,
+        pmm::ViolationType::CounterMismatch,
+        pmm::ViolationType::FreeTreeStale,
+        pmm::ViolationType::ForestRegistryMissing,
+        pmm::ViolationType::ForestDomainMissing,
+        pmm::ViolationType::ForestDomainFlagsMissing,
+        pmm::ViolationType::HeaderCorruption,
+    };
+
+    // All values must be distinct.
+    for ( std::size_t i = 0; i < types.size(); ++i )
+    {
+        for ( std::size_t j = i + 1; j < types.size(); ++j )
+        {
+            REQUIRE( types[i] != types[j] );
+        }
+    }
+
+    // DiagnosticAction enum covers all documented actions.
+    std::vector<pmm::DiagnosticAction> actions = {
+        pmm::DiagnosticAction::NoAction,
+        pmm::DiagnosticAction::Repaired,
+        pmm::DiagnosticAction::Rebuilt,
+        pmm::DiagnosticAction::Aborted,
+    };
+
+    for ( std::size_t i = 0; i < actions.size(); ++i )
+    {
+        for ( std::size_t j = i + 1; j < actions.size(); ++j )
+        {
+            REQUIRE( actions[i] != actions[j] );
+        }
+    }
+}

--- a/tests/test_issue256_verify_repair_contract.cpp
+++ b/tests/test_issue256_verify_repair_contract.cpp
@@ -170,8 +170,8 @@ TEST_CASE( "contract: repair scope is bounded — no user data modified", "[test
     // Write known pattern into user data.
     auto p = MgrC::allocate_typed<std::uint64_t>( 8 );
     REQUIRE( !p.is_null() );
-    auto p_offset = p.offset(); // save raw offset for use with MgrD
-    std::uint64_t* data = MgrC::template resolve<std::uint64_t>( p );
+    auto           p_offset = p.offset(); // save raw offset for use with MgrD
+    std::uint64_t* data     = MgrC::template resolve<std::uint64_t>( p );
     REQUIRE( data != nullptr );
     for ( int i = 0; i < 8; ++i )
         data[i] = static_cast<std::uint64_t>( 0xCAFEBABE00000000ULL | i );
@@ -186,7 +186,7 @@ TEST_CASE( "contract: repair scope is bounded — no user data modified", "[test
 
     // User data must survive repair unchanged.
     typename MgrD::template pptr<std::uint64_t> pd( p_offset );
-    std::uint64_t* loaded_data = MgrD::template resolve<std::uint64_t>( pd );
+    std::uint64_t*                              loaded_data = MgrD::template resolve<std::uint64_t>( pd );
     REQUIRE( loaded_data != nullptr );
     for ( int i = 0; i < 8; ++i )
     {
@@ -343,8 +343,8 @@ TEST_CASE( "contract: clean round-trip produces no violations", "[test_issue256]
     using MgrH = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2567>;
     using MgrI = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2568>;
 
-    static const char* kFile  = "test_issue256_clean_rt.dat";
-    const std::size_t  arena  = 64 * 1024;
+    static const char* kFile = "test_issue256_clean_rt.dat";
+    const std::size_t  arena = 64 * 1024;
 
     REQUIRE( MgrH::create( arena ) );
     auto p1 = MgrH::allocate_typed<std::uint64_t>( 10 );

--- a/tests/test_issue256_verify_repair_contract.cpp
+++ b/tests/test_issue256_verify_repair_contract.cpp
@@ -293,6 +293,52 @@ TEST_CASE( "contract: non-recoverable corruption causes deterministic hard stop"
     }
 }
 
+// ─── Test 6c: verify with bad total_size → single HeaderCorruption, no deeper diagnostics
+
+TEST_CASE( "contract: verify with bad total_size stops after HeaderCorruption", "[test_issue256]" )
+{
+    setup_clean_image();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = test_get_header( base );
+    auto          orig = hdr->total_size;
+    hdr->total_size    = orig + 4096; // mismatch with backend
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    // Must produce exactly one entry: HeaderCorruption/Aborted.
+    REQUIRE( v.entry_count == 1 );
+    REQUIRE( v.entries[0].type == pmm::ViolationType::HeaderCorruption );
+    REQUIRE( v.entries[0].action == pmm::DiagnosticAction::Aborted );
+    // No deeper structural diagnostics should be present.
+
+    hdr->total_size = orig;
+    Mgr::destroy();
+}
+
+// ─── Test 6d: verify with bad granule_size → single HeaderCorruption, no deeper diagnostics
+
+TEST_CASE( "contract: verify with bad granule_size stops after HeaderCorruption", "[test_issue256]" )
+{
+    setup_clean_image();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = test_get_header( base );
+    auto          orig = hdr->granule_size;
+    hdr->granule_size  = 999; // mismatch with address_traits
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    // Must produce exactly one entry: HeaderCorruption/Aborted.
+    REQUIRE( v.entry_count == 1 );
+    REQUIRE( v.entries[0].type == pmm::ViolationType::HeaderCorruption );
+    REQUIRE( v.entries[0].action == pmm::DiagnosticAction::Aborted );
+    // No deeper structural diagnostics should be present.
+
+    hdr->granule_size = orig;
+    Mgr::destroy();
+}
+
 // ─── Test 7: allocate/deallocate do not perform hidden repair ──────────────
 
 TEST_CASE( "contract: normal operations do not perform hidden repair", "[test_issue256]" )


### PR DESCRIPTION
## Summary

Fixes netkeep80/PersistMemoryManager#256

Defines the frozen operational contract between **verify**, **repair**, and **load** — a clear boundary for tasks 08–10 to build on.

### Deliverables

1. **`docs/verify_repair_contract.md`** — operational contract defining:
   - Verify: read-only diagnostics under shared lock, no modifications
   - Repair: explicit structural fixes within `load()`, every action recorded in `VerifyResult`
   - Load: sole entry point for repair, no hidden fixes, deterministic hard stop on fatal corruption
   - Non-recoverable conditions (magic, size, granule mismatch → `Aborted`)
   - Repair scope: what can/cannot be reconstructed

2. **`docs/diagnostics_taxonomy.md`** — violation classification covering all 6 structural classes:
   - Header corruption (fatal)
   - Block state corruption (recoverable — `Repaired`)
   - Linked list corruption (recoverable — `Repaired`)
   - Counter corruption (recoverable — `Rebuilt`)
   - Free tree corruption (recoverable — `Rebuilt`)
   - Forest registry corruption (conditional — `Repaired` or `Aborted`)
   - Severity levels, diagnostic actions, entry format, extension policy

3. **`test_issue256_verify_repair_contract.cpp`** — 11 contract tests:
   - Verify and load roles do not overlap
   - Load does not run on verify path
   - Every repair action is recorded in VerifyResult
   - Repair scope is bounded (user data unchanged)
   - Diagnostic entries are uniform for all violation types
   - Non-recoverable corruption causes deterministic hard stop
   - **Verify with bad total_size stops after single HeaderCorruption/Aborted (no deeper diagnostics)**
   - **Verify with bad granule_size stops after single HeaderCorruption/Aborted (no deeper diagnostics)**
   - Normal operations (allocate/deallocate) do not perform hidden repair
   - Clean round-trip produces no violations
   - ViolationType enum covers all documented classes

4. **Ambiguous terminology cleanup** in code comments:
   - `recovery-методах` → `repair-методах load()`
   - `Восстановление состояния` → `Repair phase of load()`
   - `Recover state` → `Repair: fix incorrect transitional states`
   - `Recovery aborted` → `Repair aborted`
   - Duplicate comment line removed in `load()`

5. **Updated `docs/index.md`** with new documents in canonical set and reading order.

6. **Changelog fragment** and version bump `0.50.1` → `0.50.2`.

### Fix for reviewer feedback

**`verify_image_unlocked()` now early-returns on all fatal header mismatches** (total_size, granule_size), matching `load()` behavior and the documented contract. Previously, it reported `HeaderCorruption/Aborted` but continued traversing deeper structures — this contradicted the docs/taxonomy which specify that header corruption is fatal and should stop verification. Two regression tests confirm exactly one diagnostic entry and no deeper structural checks after a bad total_size or granule_size.

### Audit findings

Verified all recovery-related entry points (`load()`, `rebuild_free_tree()`, `repair_linked_list()`, `recompute_counters()`, `recover_state()`, `validate_or_bootstrap_forest_registry_unlocked()`). **No hidden repair found** — all structural modifications happen exclusively within `load(VerifyResult&)` and are recorded in `VerifyResult`.

## Test plan

- [x] `cmake -B build && cmake --build build` — compiles cleanly
- [x] `ctest --test-dir build --output-on-failure` — all 75 tests pass (74 existing + 1 new with 11 test cases)
- [x] Single-include headers regenerated
- [x] clang-format clean
- [x] No uncommitted changes
- [ ] CI passes on fork
- [ ] Review contract completeness against issue requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)