### PR TITLE
feat: harden pointer and block validation (#257)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T18:17:02.990Z for PR creation at branch issue-257-4abd1a5f3039 for issue https://github.com/netkeep80/PersistMemoryManager/issues/257

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T18:17:02.990Z for PR creation at branch issue-257-4abd1a5f3039 for issue https://github.com/netkeep80/PersistMemoryManager/issues/257

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(PersistMemoryManager VERSION 0.50.3 LANGUAGES CXX)
+project(PersistMemoryManager VERSION 0.51.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/changelog.d/20260411_harden_validation.md
+++ b/changelog.d/20260411_harden_validation.md
@@ -1,0 +1,17 @@
+### Added
+- `include/pmm/validation.h` — unified pointer and block validation layer with cheap (fast-path) and full (verify-level) checks.
+- `docs/validation_model.md` — low-level validation model specification.
+- `detail::validate_block_index<AT>()` — validates granule index is in-range.
+- `detail::validate_user_ptr<AT>()` — validates user-data pointer provenance and alignment.
+- `detail::validate_link_index<AT>()` — validates linked-list/AVL index (accepts no_block sentinel).
+- `detail::validate_block_header_full<AT>()` — full verify-level block header integrity check.
+- `detail::block_at_checked<AT>()` — bounds-checked variant of `block_at()`.
+- `detail::resolve_granule_ptr_checked<AT>()` — bounds-checked variant of `resolve_granule_ptr()`.
+- `detail::ptr_to_granule_idx_checked<AT>()` — validated variant of `ptr_to_granule_idx()`.
+- Full block header validation phase in verify path (next/prev bounds, node_type, data range).
+- 36 negative tests covering invalid pointer, bad alignment, bad index, broken header, wrong domain/root.
+
+### Fixed
+- `resolve<T>()` now returns nullptr (with `PmmError::InvalidPointer`) instead of UB on out-of-bounds pptr.
+- `block_raw_ptr_from_pptr()` / `block_raw_mut_ptr_from_pptr()` now return nullptr on invalid offset.
+- `make_pptr_from_raw()` now validates pointer is within the managed region.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Single entry point for all PMM documentation. Each topic is covered by exactly o
 | [Recovery](recovery.md) | Fault recovery: 5-phase load sequence, block state machine, CRC32, atomic writes |
 | [Verify/Repair Contract](verify_repair_contract.md) | Operational boundary between verify, repair, and load — frozen contract for tasks 08–10 |
 | [Diagnostics Taxonomy](diagnostics_taxonomy.md) | Violation types, severity levels, repair policies, diagnostic entry format |
+| [Validation Model](validation_model.md) | Low-level pointer and block validation: cheap vs full modes, conversion paths, error categories |
 | [Atomic Writes](atomic_writes.md) | Write criticality analysis, block state transitions, interruption guarantees |
 | [Thread Safety](thread_safety.md) | Lock policies, operation contracts, resolve() fast path, concurrent patterns |
 

--- a/docs/validation_model.md
+++ b/docs/validation_model.md
@@ -1,0 +1,135 @@
+# Low-Level Validation Model
+
+## Document status
+
+Canonical specification for pointer and block validation in PMM.
+Defines the validation layer that all raw-pointer-to-block transitions must pass through.
+
+Related documents:
+
+- invariant set: [core_invariants.md](core_invariants.md)
+- block semantics: [block_and_treenode_semantics.md](block_and_treenode_semantics.md)
+- verify/repair contract: [verify_repair_contract.md](verify_repair_contract.md)
+- diagnostics taxonomy: [diagnostics_taxonomy.md](diagnostics_taxonomy.md)
+
+---
+
+## Motivation
+
+PMM manages a linear persistent address space where every allocation and
+deallocation passes through low-level pointer/block conversions. A corrupted
+or foreign pointer that silently passes through these conversions can damage:
+
+- the block linked list;
+- the AVL free-tree;
+- the forest domain registry;
+- user data in adjacent blocks.
+
+All dangerous transitions — raw pointer to block, granule index to block,
+user pointer to block header — must be validated.
+
+---
+
+## Validation modes
+
+PMM defines two validation levels. Both share the same checks but differ
+in cost and usage context.
+
+### Cheap (fast-path)
+
+Used by the normal API (`allocate`, `deallocate`, `resolve`, `reallocate`).
+Goal: reject obviously invalid inputs with O(1) checks, no linked-list walks.
+
+Checks performed:
+
+| Check | Description |
+|-------|-------------|
+| Null pointer | `ptr != nullptr` |
+| Image membership | `ptr >= base` and `ptr < base + total_size` |
+| Granule alignment | `(ptr - base) % granule_size == 0` |
+| Minimum address | `ptr >= first_user_data_address` (after Block_0 + Header + Block_1) |
+| Block weight | `weight != 0` for user-pointer-to-header (allocated blocks only) |
+| Index range | `idx != no_block` and `idx * granule_size + sizeof(Block) <= total_size` |
+| Overflow | No arithmetic overflow in offset ↔ pointer conversion |
+
+### Full (verify-level)
+
+Used by `verify()` and the diagnostic phase of `load()`. Walks structures.
+
+Checks performed (in addition to cheap checks):
+
+| Check | Description |
+|-------|-------------|
+| Block state consistency | `weight` and `root_offset` form a valid pair |
+| prev_offset chain | Each block's `prev_offset` matches the preceding block index |
+| next_offset chain | `next_offset` does not point outside image bounds |
+| Block size consistency | `block_total_granules` does not exceed image boundary |
+| Counter consistency | `block_count`, `free_count`, `alloc_count`, `used_size` match walk |
+| Free tree consistency | `free_tree_root` consistent with presence of free blocks |
+| Tree/domain integrity | `root_offset` is valid, `node_type` is a known value |
+
+---
+
+## Conversion paths and their validation
+
+Every raw/user pointer → block transition is listed below with its validation.
+
+| # | Path | Location | Cheap check | Full check |
+|---|------|----------|-------------|------------|
+| 1 | Granule index → `Block*` | `detail::block_at<AT>()` | `idx != no_block` (assert) | Index range via `validate_block_index()` |
+| 2 | User pointer → `Block*` | `detail::header_from_ptr_t<AT>()` | null, min_addr, bounds, alignment, weight | — (already comprehensive) |
+| 3 | `pptr<T>` → `T*` | `resolve<T>()` | null, initialized, bounds | — |
+| 4 | `pptr<T>` → block raw ptr | `block_raw_ptr_from_pptr()` | Relies on `pptr` validity | `validate_block_index()` |
+| 5 | Raw `void*` → `pptr<T>` | `make_pptr_from_raw<T>()` | Pointer provenance (allocated by us) | — |
+| 6 | Byte offset → `pptr<T>` | `pptr_from_byte_offset<T>()` | null, alignment, overflow | — |
+| 7 | Granule index → `void*` | `detail::resolve_granule_ptr<AT>()` | null-index sentinel | `validate_block_index()` |
+| 8 | `void*` → granule index | `detail::ptr_to_granule_idx<AT>()` | — | Alignment, range |
+
+---
+
+## Validation helpers
+
+All low-level validation is centralized in `include/pmm/validation.h`:
+
+| Helper | Purpose |
+|--------|---------|
+| `validate_block_index<AT>(base, total_size, idx)` | Check granule index is in-range and fits a Block header |
+| `validate_user_ptr<AT>(base, total_size, ptr)` | Check user-data pointer: null, bounds, alignment, min address |
+| `validate_block_header<AT>(base, total_size, blk, own_idx)` | Full header integrity: weight/root_offset pair, prev/next bounds, node_type |
+| `validate_block_range<AT>(base, total_size, idx)` | Block plus its data does not exceed image boundary |
+
+---
+
+## Error categories
+
+The validation layer distinguishes three categories of invalid input:
+
+| Category | Examples | Response |
+|----------|----------|----------|
+| Pointer provenance | Foreign pointer, null, out of image bounds | Return `nullptr` / `false` (fast-path), report `InvalidPointer` |
+| Address correctness | Misaligned, index overflow, beyond image extent | Return `nullptr` / `false` (fast-path), report `InvalidPointer` or `Overflow` |
+| Header integrity | Inconsistent weight/root_offset, bad node_type, next/prev out of bounds | Report `BlockStateInconsistent` (verify/repair level) |
+
+These categories map to the existing `PmmError` and `ViolationType` enums:
+
+- Pointer provenance / address correctness → `PmmError::InvalidPointer`, `PmmError::Overflow`
+- Header integrity → `ViolationType::BlockStateInconsistent`
+
+---
+
+## Invariants enforced
+
+The validation layer enforces the following invariants from `core_invariants.md`:
+
+- **B1a/B1b**: `prev_offset` and `next_offset` are valid block indices or `no_block`.
+- **B2**: `weight == 0 ↔ root_offset == 0` (free block), `weight > 0 ↔ root_offset == own_idx` (allocated block).
+- **B3**: `node_type` is either `kNodeNormal` (0) or `kNodeReadOnly`.
+- **E1**: Every block index used in AVL operations points to a valid block within the image.
+
+---
+
+## Out of scope
+
+- Image recovery (handled by `load()` repair phase).
+- `pjson` or upper-layer object validation.
+- Thread safety (validation runs under existing lock policy).

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -1064,7 +1064,9 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
             _last_error = PmmError::InvalidPointer;
             // Return a reference to a thread-local sentinel to avoid UB.
             // Callers must check last_error() when operating on untrusted pptrs.
+            // Re-initialize each time so prior mutations don't leak across calls.
             static thread_local TreeNode<address_traits> sentinel{};
+            sentinel = {};
             return sentinel;
         }
         return *reinterpret_cast<TreeNode<address_traits>*>( blk );

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -939,7 +939,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        index_type v = getter( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        index_type v = getter( blk );
         return ( v == address_traits::no_block ) ? static_cast<index_type>( 0 ) : v;
     }
     /// @brief Write an index_type AVL field into pptr's block (0 maps to no_block).
@@ -948,7 +954,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return;
-        setter( block_raw_mut_ptr_from_pptr( p ), ( val == 0 ) ? address_traits::no_block : val );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        setter( blk, ( val == 0 ) ? address_traits::no_block : val );
     }
 
   public:
@@ -989,13 +1001,25 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_weight( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_weight( blk );
     }
     template <typename T> static void set_tree_weight( pptr<T> p, index_type w ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_weight_of( block_raw_mut_ptr_from_pptr( p ), w );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_weight_of( blk, w );
     }
     /// @}
 
@@ -1005,13 +1029,25 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_avl_height( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_avl_height( blk );
     }
     template <typename T> static void set_tree_height( pptr<T> p, std::int16_t h ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_avl_height_of( block_raw_mut_ptr_from_pptr( p ), h );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_avl_height_of( blk, h );
     }
     /// @}
 
@@ -1022,7 +1058,16 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         assert( !p.is_null() && "tree_node: pptr must not be null" );
         assert( _initialized && "tree_node: manager must be initialized before calling tree_node" );
-        return *reinterpret_cast<TreeNode<address_traits>*>( block_raw_mut_ptr_from_pptr( p ) );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            // Return a reference to a thread-local sentinel to avoid UB.
+            // Callers must check last_error() when operating on untrusted pptrs.
+            static thread_local TreeNode<address_traits> sentinel{};
+            return sentinel;
+        }
+        return *reinterpret_cast<TreeNode<address_traits>*>( blk );
     }
 
     // ─── Статистика ────────────────────────────────────────────────────────────

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -734,10 +734,14 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return nullptr;
-        std::uint8_t* base = _backend.base_ptr();
-        // Bounds check — verify offset is within the managed region.
-        std::size_t byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
-        assert( byte_off + sizeof( T ) <= _backend.total_size() && "resolve(): pptr offset out of bounds" );
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        // Safety: reject out-of-bounds offsets instead of UB.
+        if ( byte_off + sizeof( T ) > _backend.total_size() )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
         return reinterpret_cast<T*>( base + byte_off );
     }
 
@@ -1339,30 +1343,49 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
 
     /// @brief Convert a raw user-data pointer returned by allocate() into a pptr<T>.
     /// Caller must ensure raw != nullptr and _initialized before calling.
+    /// Returns null pptr if the pointer is not within the managed region.
     template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
     {
         std::uint8_t* base     = _backend.base_ptr();
-        std::size_t   byte_off = static_cast<std::uint8_t*>( raw ) - base;
-        return pptr<T>( static_cast<index_type>( byte_off / address_traits::granule_size ) );
+        auto*         raw_byte = static_cast<std::uint8_t*>( raw );
+        if ( raw_byte < base || raw_byte >= base + _backend.total_size() )
+            return pptr<T>();
+        std::size_t byte_off = static_cast<std::size_t>( raw_byte - base );
+        std::size_t idx      = byte_off / address_traits::granule_size;
+        if ( idx > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+            return pptr<T>();
+        return pptr<T>( static_cast<index_type>( idx ) );
     }
 
     // ─── blk_raw helpers ──────────────────────────────────────────
     // base + offset * granule_size - sizeof(Block<AT>) → block header before user data.
 
     /// @brief Return a const pointer to the block header for the given pptr.
+    /// Returns nullptr if offset is invalid (would place block header before base).
     template <typename T> static const void* block_raw_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        const std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        const std::uint8_t* base     = _backend.base_ptr();
+        std::size_t         byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     /// @brief Return a mutable pointer to the block header for the given pptr.
+    /// Returns nullptr if offset is invalid (would place block header before base).
     template <typename T> static void* block_raw_mut_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     // ─── Address-traits-specific layout constants ──────────────────

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -18,6 +18,7 @@
 #include "pmm/block.h"
 #include "pmm/block_state.h"
 #include "pmm/tree_node.h"
+#include "pmm/validation.h"
 
 #include <algorithm>
 #include <cassert>
@@ -336,6 +337,29 @@ inline const pmm::Block<AddressTraitsT>* block_at( const std::uint8_t* base, typ
                                                                            AddressTraitsT::granule_size );
 }
 
+/// @brief Validated block_at: returns nullptr if idx is out of range.
+/// Use in verify/diagnostic paths where invalid indices must be handled gracefully.
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline pmm::Block<AddressTraitsT>* block_at_checked( std::uint8_t* base, std::size_t total_size,
+                                                     typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                     AddressTraitsT::granule_size );
+}
+
+/// @brief Validated block_at (const): returns nullptr if idx is out of range.
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline const pmm::Block<AddressTraitsT>* block_at_checked( const std::uint8_t* base, std::size_t total_size,
+                                                           typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<const pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                           AddressTraitsT::granule_size );
+}
+
 /// @brief Get granule index of Block<AddressTraitsT>.
 template <typename AddressTraitsT>
 inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*               base,
@@ -397,6 +421,20 @@ inline void* resolve_granule_ptr( std::uint8_t* base, typename AddressTraitsT::i
     return base + static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size;
 }
 
+/// @brief Validated resolve_granule_ptr: returns nullptr if idx is zero or out of bounds.
+/// Use in paths where external/untrusted indices must be validated before dereferencing.
+template <typename AddressTraitsT>
+inline void* resolve_granule_ptr_checked( std::uint8_t* base, std::size_t total_size,
+                                          typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( idx == static_cast<typename AddressTraitsT::index_type>( 0 ) )
+        return nullptr;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size;
+    if ( byte_off >= total_size )
+        return nullptr;
+    return base + byte_off;
+}
+
 /// @brief Convert a raw pointer to a granule index.
 /// Eliminates repeated `(ptr - base) / granule_size` patterns across parray, pstring, ppool, pstringview.
 template <typename AddressTraitsT>
@@ -405,6 +443,27 @@ inline typename AddressTraitsT::index_type ptr_to_granule_idx( const std::uint8_
     using IndexT         = typename AddressTraitsT::index_type;
     std::size_t byte_off = static_cast<const std::uint8_t*>( ptr ) - base;
     return static_cast<IndexT>( byte_off / AddressTraitsT::granule_size );
+}
+
+/// @brief Validated ptr_to_granule_idx: returns no_block on invalid input.
+/// Checks null, bounds, and granule alignment before converting.
+template <typename AddressTraitsT>
+inline typename AddressTraitsT::index_type ptr_to_granule_idx_checked( const std::uint8_t* base, std::size_t total_size,
+                                                                       const void* ptr ) noexcept
+{
+    using IndexT = typename AddressTraitsT::index_type;
+    if ( ptr == nullptr || base == nullptr )
+        return AddressTraitsT::no_block;
+    const auto* raw = static_cast<const std::uint8_t*>( ptr );
+    if ( raw < base || raw >= base + total_size )
+        return AddressTraitsT::no_block;
+    std::size_t byte_off = static_cast<std::size_t>( raw - base );
+    if ( byte_off % AddressTraitsT::granule_size != 0 )
+        return AddressTraitsT::no_block;
+    std::size_t idx = byte_off / AddressTraitsT::granule_size;
+    if ( idx > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return AddressTraitsT::no_block;
+    return static_cast<IndexT>( idx );
 }
 
 /// @brief Compute user data address for block (block + sizeof(Block<A>)).

--- a/include/pmm/validation.h
+++ b/include/pmm/validation.h
@@ -43,8 +43,7 @@ namespace detail
  * @param idx        Granule index to validate.
  * @return true if idx is valid (not no_block, and block header fits within image).
  */
-template <typename AT>
-inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return false;
@@ -87,7 +86,7 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
         return false;
     // The block header candidate must be granule-aligned relative to base.
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;
@@ -104,8 +103,7 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
  * @param idx        Granule index to validate (may be no_block).
  * @return true if idx is no_block or a valid in-range index.
  */
-template <typename AT>
-inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return true; // Sentinel is always valid.
@@ -132,8 +130,8 @@ inline bool validate_link_index( std::size_t total_size, typename AT::index_type
  * @param result     Diagnostic result to append violations to.
  */
 template <typename AT>
-inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
-                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size, typename AT::index_type idx,
+                                        VerifyResult& result ) noexcept
 {
     using BlockState = pmm::BlockStateBase<AT>;
     using index_type = typename AT::index_type;
@@ -181,8 +179,8 @@ inline void validate_block_header_full( const std::uint8_t* base, std::size_t to
     if ( w > 0 )
     {
         static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
-        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
-        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        std::size_t                  blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t                  data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
         if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
         {
             result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,

--- a/include/pmm/validation.h
+++ b/include/pmm/validation.h
@@ -1,0 +1,196 @@
+/**
+ * @file pmm/validation.h
+ * @brief Unified pointer and block validation layer for PersistMemoryManager.
+ *
+ * Centralizes all low-level validation checks that guard raw pointer → block
+ * transitions. Provides two levels:
+ *   - cheap (fast-path): O(1) checks for normal API operations
+ *   - full (verify-level): structural consistency checks for verify/repair
+ *
+ * All conversion paths (granule index → Block*, user pointer → Block*,
+ * pptr → T*, etc.) should route through these helpers.
+ *
+ * @see docs/validation_model.md — specification
+ * @see types.h — block_at, header_from_ptr_t (callers of validation)
+ * @version 1.0
+ */
+
+#pragma once
+
+#include "pmm/address_traits.h"
+#include "pmm/block.h"
+#include "pmm/block_state.h"
+#include "pmm/diagnostics.h"
+#include "pmm/tree_node.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace pmm
+{
+namespace detail
+{
+
+// ─── Cheap (fast-path) validation ────────────────────────────────────────────
+
+/**
+ * @brief Validate that a granule index refers to a location within the managed image
+ *        where a complete Block header fits.
+ *
+ * @tparam AT Address traits type.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index to validate.
+ * @return true if idx is valid (not no_block, and block header fits within image).
+ */
+template <typename AT>
+inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return false;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+    // Overflow check: if idx * granule_size wrapped around, byte_off < idx for large idx.
+    if ( idx != 0 && byte_off / AT::granule_size != static_cast<std::size_t>( idx ) )
+        return false;
+    if ( byte_off + sizeof( pmm::Block<AT> ) > total_size )
+        return false;
+    return true;
+}
+
+/**
+ * @brief Validate that a user-data pointer is within the managed image,
+ *        granule-aligned, and past the minimum address for user data.
+ *
+ * Does NOT check whether the block is actually allocated (no weight check).
+ * Use header_from_ptr_t() for the full user-ptr → Block* path.
+ *
+ * @tparam AT Address traits type.
+ * @param base            Base pointer of the managed area.
+ * @param total_size      Total size of the managed area in bytes.
+ * @param ptr             User-data pointer to validate.
+ * @param min_user_offset Minimum byte offset from base for the first valid user-data address.
+ *                        Typically: sizeof(Block<AT>) + sizeof(ManagerHeader<AT>) + sizeof(Block<AT>).
+ * @return true if ptr passes all cheap checks.
+ */
+template <typename AT>
+inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr,
+                               std::size_t min_user_offset ) noexcept
+{
+    if ( ptr == nullptr || base == nullptr )
+        return false;
+    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
+    // Must be within managed area.
+    if ( raw_ptr < base || raw_ptr >= base + total_size )
+        return false;
+    // Must be past minimum user-data address.
+    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+        return false;
+    // The block header candidate must be granule-aligned relative to base.
+    static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
+    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    if ( cand_off % AT::granule_size != 0 )
+        return false;
+    return true;
+}
+
+/**
+ * @brief Validate a granule index used in linked-list or AVL-tree traversal.
+ *
+ * Checks the index is either no_block (valid sentinel) or a valid in-range index.
+ * Useful for validating next_offset, prev_offset, left_offset, right_offset, etc.
+ *
+ * @tparam AT Address traits type.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index to validate (may be no_block).
+ * @return true if idx is no_block or a valid in-range index.
+ */
+template <typename AT>
+inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return true; // Sentinel is always valid.
+    return validate_block_index<AT>( total_size, idx );
+}
+
+// ─── Full (verify-level) validation ──────────────────────────────────────────
+
+/**
+ * @brief Full verify-level validation of a block header's structural integrity.
+ *
+ * Checks:
+ *   - weight/root_offset consistency (free vs allocated invariant)
+ *   - prev_offset and next_offset are valid link indices
+ *   - node_type is a known value (kNodeReadWrite or kNodeReadOnly)
+ *   - Block data range does not exceed image boundary
+ *
+ * Reports violations into the VerifyResult. Does not modify the image.
+ *
+ * @tparam AT Address traits type.
+ * @param base       Base pointer of the managed area.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index of the block being validated.
+ * @param result     Diagnostic result to append violations to.
+ */
+template <typename AT>
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
+                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AT>;
+    using index_type = typename AT::index_type;
+
+    if ( !validate_block_index<AT>( total_size, idx ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, 0 );
+        return;
+    }
+
+    const void* blk_raw = base + static_cast<std::size_t>( idx ) * AT::granule_size;
+
+    // 1. Weight / root_offset consistency (delegates to BlockState::verify_state).
+    BlockState::verify_state( blk_raw, idx, result );
+
+    // 2. next_offset within bounds.
+    index_type next = BlockState::get_next_offset( blk_raw );
+    if ( next != AT::no_block && !validate_block_index<AT>( total_size, next ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( next ) );
+    }
+
+    // 3. prev_offset within bounds.
+    index_type prev = BlockState::get_prev_offset( blk_raw );
+    if ( prev != AT::no_block && !validate_block_index<AT>( total_size, prev ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( prev ) );
+    }
+
+    // 4. node_type is a known value.
+    std::uint16_t nt = BlockState::get_node_type( blk_raw );
+    if ( nt != pmm::kNodeReadWrite && nt != pmm::kNodeReadOnly )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, static_cast<std::uint64_t>( nt ) );
+    }
+
+    // 5. If allocated, verify block data range fits in image.
+    index_type w = BlockState::get_weight( blk_raw );
+    if ( w > 0 )
+    {
+        static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
+        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
+        {
+            result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( idx ), total_size,
+                        static_cast<std::uint64_t>( blk_byte_off + kBlkHdrBytes + data_bytes ) );
+        }
+    }
+}
+
+} // namespace detail
+} // namespace pmm

--- a/include/pmm/verify_repair_mixin.inc
+++ b/include/pmm/verify_repair_mixin.inc
@@ -42,19 +42,33 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
         return; // Cannot proceed — block sizes are meaningless
     }
 
-    // 2. Block state consistency (transitional states)
+    // 2. Full block header validation (next/prev bounds, node_type, data range)
+    {
+        using BlockState = BlockStateBase<address_traits>;
+        index_type idx   = hdr->first_block_offset;
+        while ( idx != address_traits::no_block )
+        {
+            if ( !detail::validate_block_index<address_traits>( hdr->total_size, idx ) )
+                break;
+            detail::validate_block_header_full<address_traits>( base, hdr->total_size, idx, result );
+            const void* blk_ptr = base + static_cast<std::size_t>( idx ) * address_traits::granule_size;
+            idx                  = BlockState::get_next_offset( blk_ptr );
+        }
+    }
+
+    // 3. Block state consistency (transitional states)
     allocator::verify_block_states( base, hdr, result );
 
-    // 3. Linked list prev_offset
+    // 4. Linked list prev_offset
     allocator::verify_linked_list( base, hdr, result );
 
-    // 4. Counter consistency
+    // 5. Counter consistency
     allocator::verify_counters( base, hdr, result );
 
-    // 5. Free tree root consistency
+    // 6. Free tree root consistency
     allocator::verify_free_tree( base, hdr, result );
 
-    // 6. Forest registry validation
+    // 7. Forest registry validation
     verify_forest_registry_unlocked( result );
 }
 

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -1646,8 +1646,7 @@ namespace detail
  * @param idx        Granule index to validate.
  * @return true if idx is valid (not no_block, and block header fits within image).
  */
-template <typename AT>
-inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return false;
@@ -1690,7 +1689,7 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
         return false;
     // The block header candidate must be granule-aligned relative to base.
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;
@@ -1707,8 +1706,7 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
  * @param idx        Granule index to validate (may be no_block).
  * @return true if idx is no_block or a valid in-range index.
  */
-template <typename AT>
-inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return true; // Sentinel is always valid.
@@ -1735,8 +1733,8 @@ inline bool validate_link_index( std::size_t total_size, typename AT::index_type
  * @param result     Diagnostic result to append violations to.
  */
 template <typename AT>
-inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
-                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size, typename AT::index_type idx,
+                                        VerifyResult& result ) noexcept
 {
     using BlockState = pmm::BlockStateBase<AT>;
     using index_type = typename AT::index_type;
@@ -1784,8 +1782,8 @@ inline void validate_block_header_full( const std::uint8_t* base, std::size_t to
     if ( w > 0 )
     {
         static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
-        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
-        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        std::size_t                  blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t                  data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
         if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
         {
             result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -7793,7 +7793,9 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
             _last_error = PmmError::InvalidPointer;
             // Return a reference to a thread-local sentinel to avoid UB.
             // Callers must check last_error() when operating on untrusted pptrs.
+            // Re-initialize each time so prior mutations don't leak across calls.
             static thread_local TreeNode<address_traits> sentinel{};
+            sentinel = {};
             return sentinel;
         }
         return *reinterpret_cast<TreeNode<address_traits>*>( blk );

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -1609,6 +1609,195 @@ inline void verify_block_state( const void* raw_blk, typename AT::index_type own
  * @version 2.4
  */
 
+/**
+ * @file pmm/validation.h
+ * @brief Unified pointer and block validation layer for PersistMemoryManager.
+ *
+ * Centralizes all low-level validation checks that guard raw pointer → block
+ * transitions. Provides two levels:
+ *   - cheap (fast-path): O(1) checks for normal API operations
+ *   - full (verify-level): structural consistency checks for verify/repair
+ *
+ * All conversion paths (granule index → Block*, user pointer → Block*,
+ * pptr → T*, etc.) should route through these helpers.
+ *
+ * @see docs/validation_model.md — specification
+ * @see types.h — block_at, header_from_ptr_t (callers of validation)
+ * @version 1.0
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace pmm
+{
+namespace detail
+{
+
+// ─── Cheap (fast-path) validation ────────────────────────────────────────────
+
+/**
+ * @brief Validate that a granule index refers to a location within the managed image
+ *        where a complete Block header fits.
+ *
+ * @tparam AT Address traits type.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index to validate.
+ * @return true if idx is valid (not no_block, and block header fits within image).
+ */
+template <typename AT>
+inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return false;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+    // Overflow check: if idx * granule_size wrapped around, byte_off < idx for large idx.
+    if ( idx != 0 && byte_off / AT::granule_size != static_cast<std::size_t>( idx ) )
+        return false;
+    if ( byte_off + sizeof( pmm::Block<AT> ) > total_size )
+        return false;
+    return true;
+}
+
+/**
+ * @brief Validate that a user-data pointer is within the managed image,
+ *        granule-aligned, and past the minimum address for user data.
+ *
+ * Does NOT check whether the block is actually allocated (no weight check).
+ * Use header_from_ptr_t() for the full user-ptr → Block* path.
+ *
+ * @tparam AT Address traits type.
+ * @param base            Base pointer of the managed area.
+ * @param total_size      Total size of the managed area in bytes.
+ * @param ptr             User-data pointer to validate.
+ * @param min_user_offset Minimum byte offset from base for the first valid user-data address.
+ *                        Typically: sizeof(Block<AT>) + sizeof(ManagerHeader<AT>) + sizeof(Block<AT>).
+ * @return true if ptr passes all cheap checks.
+ */
+template <typename AT>
+inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr,
+                               std::size_t min_user_offset ) noexcept
+{
+    if ( ptr == nullptr || base == nullptr )
+        return false;
+    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
+    // Must be within managed area.
+    if ( raw_ptr < base || raw_ptr >= base + total_size )
+        return false;
+    // Must be past minimum user-data address.
+    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+        return false;
+    // The block header candidate must be granule-aligned relative to base.
+    static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
+    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    if ( cand_off % AT::granule_size != 0 )
+        return false;
+    return true;
+}
+
+/**
+ * @brief Validate a granule index used in linked-list or AVL-tree traversal.
+ *
+ * Checks the index is either no_block (valid sentinel) or a valid in-range index.
+ * Useful for validating next_offset, prev_offset, left_offset, right_offset, etc.
+ *
+ * @tparam AT Address traits type.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index to validate (may be no_block).
+ * @return true if idx is no_block or a valid in-range index.
+ */
+template <typename AT>
+inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return true; // Sentinel is always valid.
+    return validate_block_index<AT>( total_size, idx );
+}
+
+// ─── Full (verify-level) validation ──────────────────────────────────────────
+
+/**
+ * @brief Full verify-level validation of a block header's structural integrity.
+ *
+ * Checks:
+ *   - weight/root_offset consistency (free vs allocated invariant)
+ *   - prev_offset and next_offset are valid link indices
+ *   - node_type is a known value (kNodeReadWrite or kNodeReadOnly)
+ *   - Block data range does not exceed image boundary
+ *
+ * Reports violations into the VerifyResult. Does not modify the image.
+ *
+ * @tparam AT Address traits type.
+ * @param base       Base pointer of the managed area.
+ * @param total_size Total size of the managed area in bytes.
+ * @param idx        Granule index of the block being validated.
+ * @param result     Diagnostic result to append violations to.
+ */
+template <typename AT>
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
+                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AT>;
+    using index_type = typename AT::index_type;
+
+    if ( !validate_block_index<AT>( total_size, idx ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, 0 );
+        return;
+    }
+
+    const void* blk_raw = base + static_cast<std::size_t>( idx ) * AT::granule_size;
+
+    // 1. Weight / root_offset consistency (delegates to BlockState::verify_state).
+    BlockState::verify_state( blk_raw, idx, result );
+
+    // 2. next_offset within bounds.
+    index_type next = BlockState::get_next_offset( blk_raw );
+    if ( next != AT::no_block && !validate_block_index<AT>( total_size, next ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( next ) );
+    }
+
+    // 3. prev_offset within bounds.
+    index_type prev = BlockState::get_prev_offset( blk_raw );
+    if ( prev != AT::no_block && !validate_block_index<AT>( total_size, prev ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( prev ) );
+    }
+
+    // 4. node_type is a known value.
+    std::uint16_t nt = BlockState::get_node_type( blk_raw );
+    if ( nt != pmm::kNodeReadWrite && nt != pmm::kNodeReadOnly )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, static_cast<std::uint64_t>( nt ) );
+    }
+
+    // 5. If allocated, verify block data range fits in image.
+    index_type w = BlockState::get_weight( blk_raw );
+    if ( w > 0 )
+    {
+        static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
+        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
+        {
+            result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( idx ), total_size,
+                        static_cast<std::uint64_t>( blk_byte_off + kBlkHdrBytes + data_bytes ) );
+        }
+    }
+}
+
+} // namespace detail
+} // namespace pmm
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -1926,6 +2115,29 @@ inline const pmm::Block<AddressTraitsT>* block_at( const std::uint8_t* base, typ
                                                                            AddressTraitsT::granule_size );
 }
 
+/// @brief Validated block_at: returns nullptr if idx is out of range.
+/// Use in verify/diagnostic paths where invalid indices must be handled gracefully.
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline pmm::Block<AddressTraitsT>* block_at_checked( std::uint8_t* base, std::size_t total_size,
+                                                     typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                     AddressTraitsT::granule_size );
+}
+
+/// @brief Validated block_at (const): returns nullptr if idx is out of range.
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline const pmm::Block<AddressTraitsT>* block_at_checked( const std::uint8_t* base, std::size_t total_size,
+                                                           typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<const pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                           AddressTraitsT::granule_size );
+}
+
 /// @brief Get granule index of Block<AddressTraitsT>.
 template <typename AddressTraitsT>
 inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*               base,
@@ -1987,6 +2199,20 @@ inline void* resolve_granule_ptr( std::uint8_t* base, typename AddressTraitsT::i
     return base + static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size;
 }
 
+/// @brief Validated resolve_granule_ptr: returns nullptr if idx is zero or out of bounds.
+/// Use in paths where external/untrusted indices must be validated before dereferencing.
+template <typename AddressTraitsT>
+inline void* resolve_granule_ptr_checked( std::uint8_t* base, std::size_t total_size,
+                                          typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( idx == static_cast<typename AddressTraitsT::index_type>( 0 ) )
+        return nullptr;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size;
+    if ( byte_off >= total_size )
+        return nullptr;
+    return base + byte_off;
+}
+
 /// @brief Convert a raw pointer to a granule index.
 /// Eliminates repeated `(ptr - base) / granule_size` patterns across parray, pstring, ppool, pstringview.
 template <typename AddressTraitsT>
@@ -1995,6 +2221,27 @@ inline typename AddressTraitsT::index_type ptr_to_granule_idx( const std::uint8_
     using IndexT         = typename AddressTraitsT::index_type;
     std::size_t byte_off = static_cast<const std::uint8_t*>( ptr ) - base;
     return static_cast<IndexT>( byte_off / AddressTraitsT::granule_size );
+}
+
+/// @brief Validated ptr_to_granule_idx: returns no_block on invalid input.
+/// Checks null, bounds, and granule alignment before converting.
+template <typename AddressTraitsT>
+inline typename AddressTraitsT::index_type ptr_to_granule_idx_checked( const std::uint8_t* base, std::size_t total_size,
+                                                                       const void* ptr ) noexcept
+{
+    using IndexT = typename AddressTraitsT::index_type;
+    if ( ptr == nullptr || base == nullptr )
+        return AddressTraitsT::no_block;
+    const auto* raw = static_cast<const std::uint8_t*>( ptr );
+    if ( raw < base || raw >= base + total_size )
+        return AddressTraitsT::no_block;
+    std::size_t byte_off = static_cast<std::size_t>( raw - base );
+    if ( byte_off % AddressTraitsT::granule_size != 0 )
+        return AddressTraitsT::no_block;
+    std::size_t idx = byte_off / AddressTraitsT::granule_size;
+    if ( idx > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return AddressTraitsT::no_block;
+    return static_cast<IndexT>( idx );
 }
 
 /// @brief Compute user data address for block (block + sizeof(Block<A>)).
@@ -7218,10 +7465,14 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return nullptr;
-        std::uint8_t* base = _backend.base_ptr();
-        // Bounds check — verify offset is within the managed region.
-        std::size_t byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
-        assert( byte_off + sizeof( T ) <= _backend.total_size() && "resolve(): pptr offset out of bounds" );
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        // Safety: reject out-of-bounds offsets instead of UB.
+        if ( byte_off + sizeof( T ) > _backend.total_size() )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
         return reinterpret_cast<T*>( base + byte_off );
     }
 
@@ -8341,19 +8592,33 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
         return; // Cannot proceed — block sizes are meaningless
     }
 
-    // 2. Block state consistency (transitional states)
+    // 2. Full block header validation (next/prev bounds, node_type, data range)
+    {
+        using BlockState = BlockStateBase<address_traits>;
+        index_type idx   = hdr->first_block_offset;
+        while ( idx != address_traits::no_block )
+        {
+            if ( !detail::validate_block_index<address_traits>( hdr->total_size, idx ) )
+                break;
+            detail::validate_block_header_full<address_traits>( base, hdr->total_size, idx, result );
+            const void* blk_ptr = base + static_cast<std::size_t>( idx ) * address_traits::granule_size;
+            idx                  = BlockState::get_next_offset( blk_ptr );
+        }
+    }
+
+    // 3. Block state consistency (transitional states)
     allocator::verify_block_states( base, hdr, result );
 
-    // 3. Linked list prev_offset
+    // 4. Linked list prev_offset
     allocator::verify_linked_list( base, hdr, result );
 
-    // 4. Counter consistency
+    // 5. Counter consistency
     allocator::verify_counters( base, hdr, result );
 
-    // 5. Free tree root consistency
+    // 6. Free tree root consistency
     allocator::verify_free_tree( base, hdr, result );
 
-    // 6. Forest registry validation
+    // 7. Forest registry validation
     verify_forest_registry_unlocked( result );
 }
 
@@ -8417,30 +8682,49 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
 
     /// @brief Convert a raw user-data pointer returned by allocate() into a pptr<T>.
     /// Caller must ensure raw != nullptr and _initialized before calling.
+    /// Returns null pptr if the pointer is not within the managed region.
     template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
     {
         std::uint8_t* base     = _backend.base_ptr();
-        std::size_t   byte_off = static_cast<std::uint8_t*>( raw ) - base;
-        return pptr<T>( static_cast<index_type>( byte_off / address_traits::granule_size ) );
+        auto*         raw_byte = static_cast<std::uint8_t*>( raw );
+        if ( raw_byte < base || raw_byte >= base + _backend.total_size() )
+            return pptr<T>();
+        std::size_t byte_off = static_cast<std::size_t>( raw_byte - base );
+        std::size_t idx      = byte_off / address_traits::granule_size;
+        if ( idx > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+            return pptr<T>();
+        return pptr<T>( static_cast<index_type>( idx ) );
     }
 
     // ─── blk_raw helpers ──────────────────────────────────────────
     // base + offset * granule_size - sizeof(Block<AT>) → block header before user data.
 
     /// @brief Return a const pointer to the block header for the given pptr.
+    /// Returns nullptr if offset is invalid (would place block header before base).
     template <typename T> static const void* block_raw_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        const std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        const std::uint8_t* base     = _backend.base_ptr();
+        std::size_t         byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     /// @brief Return a mutable pointer to the block header for the given pptr.
+    /// Returns nullptr if offset is invalid (would place block header before base).
     template <typename T> static void* block_raw_mut_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     // ─── Address-traits-specific layout constants ──────────────────

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -7668,7 +7668,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        index_type v = getter( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        index_type v = getter( blk );
         return ( v == address_traits::no_block ) ? static_cast<index_type>( 0 ) : v;
     }
     /// @brief Write an index_type AVL field into pptr's block (0 maps to no_block).
@@ -7677,7 +7683,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return;
-        setter( block_raw_mut_ptr_from_pptr( p ), ( val == 0 ) ? address_traits::no_block : val );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        setter( blk, ( val == 0 ) ? address_traits::no_block : val );
     }
 
   public:
@@ -7718,13 +7730,25 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_weight( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_weight( blk );
     }
     template <typename T> static void set_tree_weight( pptr<T> p, index_type w ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_weight_of( block_raw_mut_ptr_from_pptr( p ), w );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_weight_of( blk, w );
     }
     /// @}
 
@@ -7734,13 +7758,25 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_avl_height( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_avl_height( blk );
     }
     template <typename T> static void set_tree_height( pptr<T> p, std::int16_t h ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_avl_height_of( block_raw_mut_ptr_from_pptr( p ), h );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_avl_height_of( blk, h );
     }
     /// @}
 
@@ -7751,7 +7787,16 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         assert( !p.is_null() && "tree_node: pptr must not be null" );
         assert( _initialized && "tree_node: manager must be initialized before calling tree_node" );
-        return *reinterpret_cast<TreeNode<address_traits>*>( block_raw_mut_ptr_from_pptr( p ) );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            // Return a reference to a thread-local sentinel to avoid UB.
+            // Callers must check last_error() when operating on untrusted pptrs.
+            static thread_local TreeNode<address_traits> sentinel{};
+            return sentinel;
+        }
+        return *reinterpret_cast<TreeNode<address_traits>*>( blk );
     }
 
     // ─── Статистика ────────────────────────────────────────────────────────────

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -4418,7 +4418,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        index_type v = getter( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        index_type v = getter( blk );
         return ( v == address_traits::no_block ) ? static_cast<index_type>( 0 ) : v;
     }
     
@@ -4427,7 +4433,13 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return;
-        setter( block_raw_mut_ptr_from_pptr( p ), ( val == 0 ) ? address_traits::no_block : val );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        setter( blk, ( val == 0 ) ? address_traits::no_block : val );
     }
 
   public:
@@ -4462,33 +4474,65 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_weight( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_weight( blk );
     }
     template <typename T> static void set_tree_weight( pptr<T> p, index_type w ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_weight_of( block_raw_mut_ptr_from_pptr( p ), w );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_weight_of( blk, w );
     }
     
     template <typename T> static std::int16_t get_tree_height( pptr<T> p ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return 0;
-        return BlockStateBase<address_traits>::get_avl_height( block_raw_ptr_from_pptr( p ) );
+        const void* blk = block_raw_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return 0;
+        }
+        return BlockStateBase<address_traits>::get_avl_height( blk );
     }
     template <typename T> static void set_tree_height( pptr<T> p, std::int16_t h ) noexcept
     {
         if ( p.is_null() || !_initialized )
             return;
-        BlockStateBase<address_traits>::set_avl_height_of( block_raw_mut_ptr_from_pptr( p ), h );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return;
+        }
+        BlockStateBase<address_traits>::set_avl_height_of( blk, h );
     }
     
     template <typename T> static TreeNode<address_traits>& tree_node( pptr<T> p ) noexcept
     {
         assert( !p.is_null() && "tree_node: pptr must not be null" );
         assert( _initialized && "tree_node: manager must be initialized before calling tree_node" );
-        return *reinterpret_cast<TreeNode<address_traits>*>( block_raw_mut_ptr_from_pptr( p ) );
+        void* blk = block_raw_mut_ptr_from_pptr( p );
+        if ( blk == nullptr )
+        {
+            _last_error = PmmError::InvalidPointer;
+            
+            static thread_local TreeNode<address_traits> sentinel{};
+            return sentinel;
+        }
+        return *reinterpret_cast<TreeNode<address_traits>*>( blk );
     }
 
   private:

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -736,8 +736,7 @@ namespace pmm
 namespace detail
 {
 
-template <typename AT>
-inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return false;
@@ -765,14 +764,13 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
         return false;
     
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;
 }
 
-template <typename AT>
-inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+template <typename AT> inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
 {
     if ( idx == AT::no_block )
         return true; 
@@ -780,8 +778,8 @@ inline bool validate_link_index( std::size_t total_size, typename AT::index_type
 }
 
 template <typename AT>
-inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
-                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size, typename AT::index_type idx,
+                                        VerifyResult& result ) noexcept
 {
     using BlockState = pmm::BlockStateBase<AT>;
     using index_type = typename AT::index_type;
@@ -824,8 +822,8 @@ inline void validate_block_header_full( const std::uint8_t* base, std::size_t to
     if ( w > 0 )
     {
         static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
-        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
-        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        std::size_t                  blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t                  data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
         if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
         {
             result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -727,6 +727,117 @@ inline void verify_block_state( const void* raw_blk, typename AT::index_type own
 
 } 
 
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace pmm
+{
+namespace detail
+{
+
+template <typename AT>
+inline bool validate_block_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return false;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+    
+    if ( idx != 0 && byte_off / AT::granule_size != static_cast<std::size_t>( idx ) )
+        return false;
+    if ( byte_off + sizeof( pmm::Block<AT> ) > total_size )
+        return false;
+    return true;
+}
+
+template <typename AT>
+inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr,
+                               std::size_t min_user_offset ) noexcept
+{
+    if ( ptr == nullptr || base == nullptr )
+        return false;
+    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
+    
+    if ( raw_ptr < base || raw_ptr >= base + total_size )
+        return false;
+    
+    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+        return false;
+    
+    static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
+    std::size_t cand_off = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    if ( cand_off % AT::granule_size != 0 )
+        return false;
+    return true;
+}
+
+template <typename AT>
+inline bool validate_link_index( std::size_t total_size, typename AT::index_type idx ) noexcept
+{
+    if ( idx == AT::no_block )
+        return true; 
+    return validate_block_index<AT>( total_size, idx );
+}
+
+template <typename AT>
+inline void validate_block_header_full( const std::uint8_t* base, std::size_t total_size,
+                                        typename AT::index_type idx, VerifyResult& result ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AT>;
+    using index_type = typename AT::index_type;
+
+    if ( !validate_block_index<AT>( total_size, idx ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, 0 );
+        return;
+    }
+
+    const void* blk_raw = base + static_cast<std::size_t>( idx ) * AT::granule_size;
+
+    BlockState::verify_state( blk_raw, idx, result );
+
+    index_type next = BlockState::get_next_offset( blk_raw );
+    if ( next != AT::no_block && !validate_block_index<AT>( total_size, next ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( next ) );
+    }
+
+    index_type prev = BlockState::get_prev_offset( blk_raw );
+    if ( prev != AT::no_block && !validate_block_index<AT>( total_size, prev ) )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), static_cast<std::uint64_t>( AT::no_block ),
+                    static_cast<std::uint64_t>( prev ) );
+    }
+
+    std::uint16_t nt = BlockState::get_node_type( blk_raw );
+    if ( nt != pmm::kNodeReadWrite && nt != pmm::kNodeReadOnly )
+    {
+        result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                    static_cast<std::uint64_t>( idx ), 0, static_cast<std::uint64_t>( nt ) );
+    }
+
+    index_type w = BlockState::get_weight( blk_raw );
+    if ( w > 0 )
+    {
+        static constexpr std::size_t kBlkHdrBytes = sizeof( pmm::Block<AT> );
+        std::size_t blk_byte_off = static_cast<std::size_t>( idx ) * AT::granule_size;
+        std::size_t data_bytes   = static_cast<std::size_t>( w ) * AT::granule_size;
+        if ( blk_byte_off + kBlkHdrBytes + data_bytes > total_size )
+        {
+            result.add( ViolationType::BlockStateInconsistent, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( idx ), total_size,
+                        static_cast<std::uint64_t>( blk_byte_off + kBlkHdrBytes + data_bytes ) );
+        }
+    }
+}
+
+} 
+} 
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -961,6 +1072,26 @@ inline const pmm::Block<AddressTraitsT>* block_at( const std::uint8_t* base, typ
                                                                            AddressTraitsT::granule_size );
 }
 
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline pmm::Block<AddressTraitsT>* block_at_checked( std::uint8_t* base, std::size_t total_size,
+                                                     typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                     AddressTraitsT::granule_size );
+}
+
+template <typename AddressTraitsT = pmm::DefaultAddressTraits>
+inline const pmm::Block<AddressTraitsT>* block_at_checked( const std::uint8_t* base, std::size_t total_size,
+                                                           typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( !validate_block_index<AddressTraitsT>( total_size, idx ) )
+        return nullptr;
+    return reinterpret_cast<const pmm::Block<AddressTraitsT>*>( base + static_cast<std::size_t>( idx ) *
+                                                                           AddressTraitsT::granule_size );
+}
+
 template <typename AddressTraitsT>
 inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*               base,
                                                         const pmm::Block<AddressTraitsT>* block )
@@ -1008,11 +1139,42 @@ inline void* resolve_granule_ptr( std::uint8_t* base, typename AddressTraitsT::i
 }
 
 template <typename AddressTraitsT>
+inline void* resolve_granule_ptr_checked( std::uint8_t* base, std::size_t total_size,
+                                          typename AddressTraitsT::index_type idx ) noexcept
+{
+    if ( idx == static_cast<typename AddressTraitsT::index_type>( 0 ) )
+        return nullptr;
+    std::size_t byte_off = static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size;
+    if ( byte_off >= total_size )
+        return nullptr;
+    return base + byte_off;
+}
+
+template <typename AddressTraitsT>
 inline typename AddressTraitsT::index_type ptr_to_granule_idx( const std::uint8_t* base, const void* ptr ) noexcept
 {
     using IndexT         = typename AddressTraitsT::index_type;
     std::size_t byte_off = static_cast<const std::uint8_t*>( ptr ) - base;
     return static_cast<IndexT>( byte_off / AddressTraitsT::granule_size );
+}
+
+template <typename AddressTraitsT>
+inline typename AddressTraitsT::index_type ptr_to_granule_idx_checked( const std::uint8_t* base, std::size_t total_size,
+                                                                       const void* ptr ) noexcept
+{
+    using IndexT = typename AddressTraitsT::index_type;
+    if ( ptr == nullptr || base == nullptr )
+        return AddressTraitsT::no_block;
+    const auto* raw = static_cast<const std::uint8_t*>( ptr );
+    if ( raw < base || raw >= base + total_size )
+        return AddressTraitsT::no_block;
+    std::size_t byte_off = static_cast<std::size_t>( raw - base );
+    if ( byte_off % AddressTraitsT::granule_size != 0 )
+        return AddressTraitsT::no_block;
+    std::size_t idx = byte_off / AddressTraitsT::granule_size;
+    if ( idx > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return AddressTraitsT::no_block;
+    return static_cast<IndexT>( idx );
 }
 
 template <typename AddressTraitsT = pmm::DefaultAddressTraits>
@@ -4090,10 +4252,14 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     {
         if ( p.is_null() || !_initialized )
             return nullptr;
-        std::uint8_t* base = _backend.base_ptr();
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
         
-        std::size_t byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
-        assert( byte_off + sizeof( T ) <= _backend.total_size() && "resolve(): pptr offset out of bounds" );
+        if ( byte_off + sizeof( T ) > _backend.total_size() )
+        {
+            _last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
         return reinterpret_cast<T*>( base + byte_off );
     }
 
@@ -5046,6 +5212,19 @@ static void verify_image_unlocked( VerifyResult& result ) noexcept
         return; 
     }
 
+    {
+        using BlockState = BlockStateBase<address_traits>;
+        index_type idx   = hdr->first_block_offset;
+        while ( idx != address_traits::no_block )
+        {
+            if ( !detail::validate_block_index<address_traits>( hdr->total_size, idx ) )
+                break;
+            detail::validate_block_header_full<address_traits>( base, hdr->total_size, idx, result );
+            const void* blk_ptr = base + static_cast<std::size_t>( idx ) * address_traits::granule_size;
+            idx                  = BlockState::get_next_offset( blk_ptr );
+        }
+    }
+
     allocator::verify_block_states( base, hdr, result );
 
     allocator::verify_linked_list( base, hdr, result );
@@ -5108,22 +5287,38 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
     {
         std::uint8_t* base     = _backend.base_ptr();
-        std::size_t   byte_off = static_cast<std::uint8_t*>( raw ) - base;
-        return pptr<T>( static_cast<index_type>( byte_off / address_traits::granule_size ) );
+        auto*         raw_byte = static_cast<std::uint8_t*>( raw );
+        if ( raw_byte < base || raw_byte >= base + _backend.total_size() )
+            return pptr<T>();
+        std::size_t byte_off = static_cast<std::size_t>( raw_byte - base );
+        std::size_t idx      = byte_off / address_traits::granule_size;
+        if ( idx > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+            return pptr<T>();
+        return pptr<T>( static_cast<index_type>( idx ) );
     }
 
     template <typename T> static const void* block_raw_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        const std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        const std::uint8_t* base     = _backend.base_ptr();
+        std::size_t         byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     template <typename T> static void* block_raw_mut_ptr_from_pptr( pptr<T> p ) noexcept
     {
-        std::uint8_t* base = _backend.base_ptr();
-        return base + static_cast<std::size_t>( p.offset() ) * address_traits::granule_size -
-               sizeof( Block<address_traits> );
+        std::uint8_t* base     = _backend.base_ptr();
+        std::size_t   byte_off = static_cast<std::size_t>( p.offset() ) * address_traits::granule_size;
+        if ( byte_off < sizeof( Block<address_traits> ) )
+            return nullptr;
+        std::size_t blk_off = byte_off - sizeof( Block<address_traits> );
+        if ( blk_off + sizeof( Block<address_traits> ) > _backend.total_size() )
+            return nullptr;
+        return base + blk_off;
     }
 
     static constexpr std::size_t kBlockHdrByteSize =

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -4530,6 +4530,7 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
             _last_error = PmmError::InvalidPointer;
             
             static thread_local TreeNode<address_traits> sentinel{};
+            sentinel = {};
             return sentinel;
         }
         return *reinterpret_cast<TreeNode<address_traits>*>( blk );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,3 +272,6 @@ pmm_add_test(test_issue245_verify_repair test_issue245_verify_repair.cpp)
 
 # ─── Verify/repair/load operational contract tests ──────────────
 pmm_add_test(test_issue256_verify_repair_contract test_issue256_verify_repair_contract.cpp)
+
+# ─── Pointer and block validation layer tests ───────────────────
+pmm_add_test(test_issue257_validation test_issue257_validation.cpp)

--- a/tests/test_issue257_validation.cpp
+++ b/tests/test_issue257_validation.cpp
@@ -651,6 +651,35 @@ TEST_CASE( "validation: tree_node returns sentinel and sets InvalidPointer for O
     Mgr::destroy();
 }
 
+TEST_CASE( "validation: tree_node sentinel is stateless across invalid calls", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad1( 0xFFFF );
+    Mgr::pptr<int> bad2( 0xFFFE );
+
+    // First bad call — get a mutable reference to the sentinel.
+    Mgr::clear_error();
+    auto& tn1 = Mgr::tree_node( bad1 );
+    REQUIRE( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    // Mutate the sentinel through the returned reference.
+    tn1.set_weight( 42 );
+    tn1.set_height( 7 );
+    tn1.set_left( 99 );
+
+    // Second bad call — sentinel must be clean again, not carry prior mutations.
+    Mgr::clear_error();
+    auto& tn2 = Mgr::tree_node( bad2 );
+    REQUIRE( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    CHECK( tn2.get_weight() == 0 );
+    CHECK( tn2.get_height() == 0 );
+    CHECK( tn2.get_left() == 0 );
+
+    Mgr::destroy();
+}
+
 TEST_CASE( "validation: valid pptr still works correctly through wrapper APIs", "[test_issue257]" )
 {
     setup_clean_image();

--- a/tests/test_issue257_validation.cpp
+++ b/tests/test_issue257_validation.cpp
@@ -1,0 +1,525 @@
+/**
+ * @file test_issue257_validation.cpp
+ * @brief Negative tests for pointer and block validation layer.
+ *
+ * Verifies that invalid pointers, bad alignment, bad indices, broken headers,
+ * and wrong domain/root are reliably rejected by the validation layer.
+ *
+ * @see docs/validation_model.md — validation model specification
+ * @see include/pmm/validation.h — unified validation helpers
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+#include "pmm/validation.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using Mgr = pmm::presets::SingleThreadedHeap;
+using AT  = pmm::DefaultAddressTraits;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static void setup_clean_image( std::size_t arena_size = 64 * 1024 )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( arena_size ) );
+}
+
+// ─── A. Pointer provenance tests ──────────────────────────────────────────────
+
+TEST_CASE( "validation: null pointer is rejected", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    // deallocate(nullptr) is a no-op (safe)
+    Mgr::deallocate( nullptr );
+
+    // resolve(null pptr) returns nullptr
+    Mgr::pptr<int> null_p;
+    REQUIRE( Mgr::resolve( null_p ) == nullptr );
+
+    // is_valid_ptr(null) returns false
+    REQUIRE_FALSE( Mgr::is_valid_ptr( null_p ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: foreign pointer is rejected by deallocate", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    // A pointer to stack memory is foreign — should be silently rejected.
+    int stack_val = 42;
+    Mgr::deallocate( &stack_val );
+
+    // Manager state should be unaffected.
+    REQUIRE( Mgr::block_count() > 0 );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: pointer before managed area is rejected", "[test_issue257]" )
+{
+    setup_clean_image();
+    std::uint8_t* base = Mgr::backend().base_ptr();
+
+    // Pointer before base — find_block_from_user_ptr returns nullptr.
+    void* before_base = base - 16;
+    Mgr::deallocate( before_base );
+
+    // Manager still works.
+    auto p = Mgr::allocate_typed<int>();
+    REQUIRE( !p.is_null() );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: pointer past managed area is rejected", "[test_issue257]" )
+{
+    setup_clean_image();
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+
+    // Pointer beyond end of managed area.
+    void* past_end = base + total_size + 16;
+    Mgr::deallocate( past_end );
+
+    // Manager still works.
+    auto p = Mgr::allocate_typed<int>();
+    REQUIRE( !p.is_null() );
+
+    Mgr::destroy();
+}
+
+// ─── B. Address correctness tests ──────────────────────────────────────────────
+
+TEST_CASE( "validation: misaligned pointer is rejected by header_from_ptr", "[test_issue257]" )
+{
+    setup_clean_image();
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+
+    // Allocate a valid block to get a valid pointer.
+    auto p = Mgr::allocate_typed<std::uint64_t>();
+    REQUIRE( !p.is_null() );
+
+    // Create a misaligned pointer (odd offset from base).
+    void* misaligned = base + 33; // Not granule-aligned relative to base.
+    auto* blk        = pmm::detail::header_from_ptr_t<AT>( base, misaligned, total_size );
+    REQUIRE( blk == nullptr );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: validate_block_index rejects no_block sentinel", "[test_issue257]" )
+{
+    REQUIRE_FALSE( pmm::detail::validate_block_index<AT>( 1024, AT::no_block ) );
+}
+
+TEST_CASE( "validation: validate_block_index rejects index beyond total_size", "[test_issue257]" )
+{
+    // total_size = 1024 bytes, granule_size = 16 → max valid index = (1024 - 32) / 16 = 62
+    // Index 65 * 16 + 32 = 1072 > 1024 → rejected.
+    REQUIRE_FALSE( pmm::detail::validate_block_index<AT>( 1024, 65 ) );
+}
+
+TEST_CASE( "validation: validate_block_index accepts valid index", "[test_issue257]" )
+{
+    // Index 2 * 16 + 32 = 64 <= 1024 → accepted.
+    REQUIRE( pmm::detail::validate_block_index<AT>( 1024, 2 ) );
+}
+
+TEST_CASE( "validation: validate_link_index accepts no_block sentinel", "[test_issue257]" )
+{
+    REQUIRE( pmm::detail::validate_link_index<AT>( 1024, AT::no_block ) );
+}
+
+TEST_CASE( "validation: validate_link_index rejects out-of-range index", "[test_issue257]" )
+{
+    REQUIRE_FALSE( pmm::detail::validate_link_index<AT>( 1024, 100 ) );
+}
+
+TEST_CASE( "validation: pptr_from_byte_offset rejects misaligned offset", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    // Odd byte offset — not divisible by granule_size.
+    auto p = Mgr::pptr_from_byte_offset<int>( 17 );
+    REQUIRE( p.is_null() );
+    REQUIRE( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: pptr_from_byte_offset rejects zero offset", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::pptr_from_byte_offset<int>( 0 );
+    REQUIRE( p.is_null() );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: resolve rejects out-of-bounds pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+    std::size_t total_size = Mgr::backend().total_size();
+
+    // Create a pptr with offset beyond total_size.
+    std::size_t    bad_offset = total_size / AT::granule_size + 1;
+    Mgr::pptr<int> bad_p( static_cast<AT::index_type>( bad_offset ) );
+
+    auto* resolved = Mgr::resolve( bad_p );
+    REQUIRE( resolved == nullptr );
+    REQUIRE( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+// ─── C. Header integrity tests ────────────────────────────────────────────────
+
+TEST_CASE( "validation: corrupted weight detected by verify", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt: set weight to 0 but keep root_offset as own_idx (inconsistent state).
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    pmm::BlockStateBase<AT>::set_weight_of( blk_raw, 0 );
+
+    // verify() should detect inconsistency.
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+
+    bool found_block_state_issue = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::BlockStateInconsistent )
+            found_block_state_issue = true;
+    }
+    REQUIRE( found_block_state_issue );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: corrupted root_offset detected by verify", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt: set root_offset to a wrong value.
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          orig    = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + 100 );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+
+    bool found = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::BlockStateInconsistent )
+            found = true;
+    }
+    REQUIRE( found );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: corrupted next_offset detected by full verify", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt next_offset to point beyond image.
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+    std::size_t   usr_off    = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw    = base + usr_off - sizeof( pmm::Block<AT> );
+
+    // Set next_offset to an index far beyond image bounds.
+    AT::index_type bad_next = static_cast<AT::index_type>( total_size / AT::granule_size + 100 );
+    pmm::BlockStateBase<AT>::set_next_offset_of( blk_raw, bad_next );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+
+    bool found = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::BlockStateInconsistent )
+            found = true;
+    }
+    REQUIRE( found );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: corrupted node_type detected by full verify", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt node_type to an invalid value.
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    pmm::BlockStateBase<AT>::set_node_type_of( blk_raw, 0xBEEF );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+
+    bool found = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].type == pmm::ViolationType::BlockStateInconsistent )
+            found = true;
+    }
+    REQUIRE( found );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: block data exceeding image bounds detected", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt weight to a huge value that exceeds image bounds.
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    pmm::BlockStateBase<AT>::set_weight_of( blk_raw, 0x7FFFFFFFU );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+
+    Mgr::destroy();
+}
+
+// ─── D. validate_user_ptr tests ────────────────────────────────────────────────
+
+TEST_CASE( "validation: validate_user_ptr rejects null", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, nullptr, min_offset ) );
+}
+
+TEST_CASE( "validation: validate_user_ptr rejects pointer before min address", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    // Pointer to start of buffer (before min address).
+    REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + 16, min_offset ) );
+}
+
+TEST_CASE( "validation: validate_user_ptr rejects misaligned pointer", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    // Pointer at min_offset + 1 (misaligned: block header would be at odd offset).
+    REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + min_offset + 1, min_offset ) );
+}
+
+TEST_CASE( "validation: validate_user_ptr accepts valid pointer", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    // Valid pointer: at min_offset, and (min_offset - sizeof(Block<AT>)) % granule_size == 0.
+    // min_offset = 32 + 64 + 32 = 128. Block header candidate = 128 - 32 = 96. 96 % 16 == 0. Valid.
+    REQUIRE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + min_offset, min_offset ) );
+}
+
+// ─── E. block_at_checked tests ────────────────────────────────────────────────
+
+TEST_CASE( "validation: block_at_checked returns nullptr for no_block", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    auto*        blk        = pmm::detail::block_at_checked<AT>( dummy, 256, AT::no_block );
+    REQUIRE( blk == nullptr );
+}
+
+TEST_CASE( "validation: block_at_checked returns nullptr for out-of-range index", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    // Index 20: 20*16+32 = 352 > 256 → out of range.
+    auto* blk = pmm::detail::block_at_checked<AT>( dummy, 256, 20 );
+    REQUIRE( blk == nullptr );
+}
+
+TEST_CASE( "validation: block_at_checked returns valid pointer for in-range index", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    // Index 2: 2*16+32 = 64 <= 256 → valid.
+    auto* blk = pmm::detail::block_at_checked<AT>( dummy, 256, 2 );
+    REQUIRE( blk != nullptr );
+    REQUIRE( reinterpret_cast<std::uint8_t*>( blk ) == dummy + 2 * 16 );
+}
+
+// ─── F. resolve_granule_ptr_checked tests ─────────────────────────────────────
+
+TEST_CASE( "validation: resolve_granule_ptr_checked returns nullptr for zero idx", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    REQUIRE( pmm::detail::resolve_granule_ptr_checked<AT>( dummy, 256, 0 ) == nullptr );
+}
+
+TEST_CASE( "validation: resolve_granule_ptr_checked returns nullptr for out-of-bounds idx", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    // Index 20 → byte offset 320 > 256.
+    REQUIRE( pmm::detail::resolve_granule_ptr_checked<AT>( dummy, 256, 20 ) == nullptr );
+}
+
+TEST_CASE( "validation: resolve_granule_ptr_checked returns valid ptr for in-range idx", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    void*        result = pmm::detail::resolve_granule_ptr_checked<AT>( dummy, 256, 3 );
+    REQUIRE( result == dummy + 48 );
+}
+
+// ─── G. ptr_to_granule_idx_checked tests ──────────────────────────────────────
+
+TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for null", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, nullptr ) == AT::no_block );
+}
+
+TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for out-of-bounds", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, dummy + 300 ) == AT::no_block );
+}
+
+TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for misaligned", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, dummy + 7 ) == AT::no_block );
+}
+
+TEST_CASE( "validation: ptr_to_granule_idx_checked returns correct index for valid ptr", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, dummy + 48 ) == 3 );
+}
+
+// ─── H. validate_block_header_full tests ──────────────────────────────────────
+
+TEST_CASE( "validation: validate_block_header_full on clean image reports no issues", "[test_issue257]" )
+{
+    setup_clean_image();
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Get the block index.
+    std::size_t              usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    typename AT::index_type  blk_idx =
+        static_cast<typename AT::index_type>( ( usr_off - sizeof( pmm::Block<AT> ) ) / AT::granule_size );
+
+    pmm::VerifyResult result;
+    pmm::detail::validate_block_header_full<AT>( base, total_size, blk_idx, result );
+    REQUIRE( result.ok );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: validate_block_header_full detects invalid index", "[test_issue257]" )
+{
+    pmm::VerifyResult result;
+    std::uint8_t      dummy[256] = {};
+    pmm::detail::validate_block_header_full<AT>( dummy, 256, AT::no_block, result );
+    REQUIRE_FALSE( result.ok );
+}
+
+// ─── I. End-to-end: load repairs detectable corruption ────────────────────────
+
+// Use unique instance IDs for file-backed tests to avoid conflicts.
+using MgrSave = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2570>;
+using MgrLoad = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2571>;
+
+TEST_CASE( "validation: load repairs inconsistent block state", "[test_issue257]" )
+{
+    static constexpr const char* kFile = "/tmp/test_issue257_repair.pmm";
+
+    MgrSave::destroy();
+    REQUIRE( MgrSave::create( 64 * 1024 ) );
+
+    auto p = MgrSave::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset.
+    std::uint8_t* base    = MgrSave::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          orig    = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + 50 );
+
+    // Save corrupted image to file.
+    REQUIRE( pmm::save_manager<MgrSave>( kFile ) );
+    MgrSave::destroy();
+
+    // Load into a fresh manager — create() allocates the buffer, then load overwrites it.
+    MgrLoad::destroy();
+    REQUIRE( MgrLoad::create( 64 * 1024 ) );
+    pmm::VerifyResult load_result;
+    REQUIRE( pmm::load_manager_from_file<MgrLoad>( kFile, load_result ) );
+
+    // The repair phase should have fixed the inconsistency.
+    pmm::VerifyResult verify_after = MgrLoad::verify();
+    REQUIRE( verify_after.ok );
+
+    MgrLoad::destroy();
+    std::remove( kFile );
+}
+
+// ─── J. Clean image: verify reports no violations ─────────────────────────────
+
+TEST_CASE( "validation: clean image verify produces no violations", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p1 = Mgr::allocate_typed<std::uint64_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 4 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE( result.ok );
+    REQUIRE( result.violation_count == 0 );
+
+    Mgr::deallocate_typed( p1 );
+    Mgr::deallocate_typed( p2 );
+
+    result = Mgr::verify();
+    REQUIRE( result.ok );
+    REQUIRE( result.violation_count == 0 );
+
+    Mgr::destroy();
+}

--- a/tests/test_issue257_validation.cpp
+++ b/tests/test_issue257_validation.cpp
@@ -530,3 +530,150 @@ TEST_CASE( "validation: clean image verify produces no violations", "[test_issue
 
     Mgr::destroy();
 }
+
+// ─── G. Caller nullptr-propagation tests (owner feedback) ────────────────────
+// Verify that wrapper APIs above block_raw_ptr_from_pptr / block_raw_mut_ptr_from_pptr
+// correctly handle nullptr for forged/out-of-bounds pptrs instead of dereferencing.
+
+TEST_CASE( "validation: get_tree_idx_field returns 0 and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    // Forge a pptr with an absurdly large offset — well past the managed region.
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    auto left = Mgr::get_tree_left_offset( bad );
+    CHECK( left == 0 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::clear_error();
+    auto right = Mgr::get_tree_right_offset( bad );
+    CHECK( right == 0 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::clear_error();
+    auto parent = Mgr::get_tree_parent_offset( bad );
+    CHECK( parent == 0 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: set_tree_idx_field is no-op and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    Mgr::set_tree_left_offset( bad, 42 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::clear_error();
+    Mgr::set_tree_right_offset( bad, 42 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::clear_error();
+    Mgr::set_tree_parent_offset( bad, 42 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: get_tree_weight returns 0 and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    auto w = Mgr::get_tree_weight( bad );
+    CHECK( w == 0 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: set_tree_weight is no-op and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    Mgr::set_tree_weight( bad, 10 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: get_tree_height returns 0 and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    auto h = Mgr::get_tree_height( bad );
+    CHECK( h == 0 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: set_tree_height is no-op and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    Mgr::set_tree_height( bad, 5 );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: tree_node returns sentinel and sets InvalidPointer for OOB pptr", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    Mgr::pptr<int> bad( 0xFFFF );
+
+    Mgr::clear_error();
+    auto& tn = Mgr::tree_node( bad );
+    CHECK( Mgr::last_error() == pmm::PmmError::InvalidPointer );
+
+    // Sentinel should be zero-initialized — reads return safe defaults.
+    (void)tn;
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "validation: valid pptr still works correctly through wrapper APIs", "[test_issue257]" )
+{
+    setup_clean_image();
+
+    auto p = Mgr::allocate_typed<int>();
+    REQUIRE( !p.is_null() );
+
+    // The valid pptr should not set InvalidPointer.
+    Mgr::clear_error();
+    auto w = Mgr::get_tree_weight( p );
+    CHECK( Mgr::last_error() == pmm::PmmError::Ok );
+    CHECK( w > 0 ); // allocated block has a positive weight
+
+    Mgr::clear_error();
+    auto h = Mgr::get_tree_height( p );
+    CHECK( Mgr::last_error() == pmm::PmmError::Ok );
+    (void)h;
+
+    Mgr::clear_error();
+    auto left = Mgr::get_tree_left_offset( p );
+    CHECK( Mgr::last_error() == pmm::PmmError::Ok );
+    (void)left;
+
+    Mgr::deallocate_typed( p );
+    Mgr::destroy();
+}

--- a/tests/test_issue257_validation.cpp
+++ b/tests/test_issue257_validation.cpp
@@ -324,14 +324,16 @@ TEST_CASE( "validation: block data exceeding image bounds detected", "[test_issu
 TEST_CASE( "validation: validate_user_ptr rejects null", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
     REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, nullptr, min_offset ) );
 }
 
 TEST_CASE( "validation: validate_user_ptr rejects pointer before min address", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
     // Pointer to start of buffer (before min address).
     REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + 16, min_offset ) );
 }
@@ -339,7 +341,8 @@ TEST_CASE( "validation: validate_user_ptr rejects pointer before min address", "
 TEST_CASE( "validation: validate_user_ptr rejects misaligned pointer", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
     // Pointer at min_offset + 1 (misaligned: block header would be at odd offset).
     REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + min_offset + 1, min_offset ) );
 }
@@ -347,7 +350,8 @@ TEST_CASE( "validation: validate_user_ptr rejects misaligned pointer", "[test_is
 TEST_CASE( "validation: validate_user_ptr accepts valid pointer", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    std::size_t  min_offset = sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
     // Valid pointer: at min_offset, and (min_offset - sizeof(Block<AT>)) % granule_size == 0.
     // min_offset = 32 + 64 + 32 = 128. Block header candidate = 128 - 32 = 96. 96 % 16 == 0. Valid.
     REQUIRE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + min_offset, min_offset ) );
@@ -397,7 +401,7 @@ TEST_CASE( "validation: resolve_granule_ptr_checked returns nullptr for out-of-b
 TEST_CASE( "validation: resolve_granule_ptr_checked returns valid ptr for in-range idx", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    void*        result = pmm::detail::resolve_granule_ptr_checked<AT>( dummy, 256, 3 );
+    void*        result     = pmm::detail::resolve_granule_ptr_checked<AT>( dummy, 256, 3 );
     REQUIRE( result == dummy + 48 );
 }
 
@@ -412,7 +416,10 @@ TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for null", "
 TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for out-of-bounds", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
-    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, dummy + 300 ) == AT::no_block );
+    // Use a pointer that is clearly past the end of the managed area but avoids
+    // computing dummy+300 which is UB (out of bounds for uint8_t[256]).
+    const void* oob_ptr = reinterpret_cast<const void*>( reinterpret_cast<std::uintptr_t>( dummy ) + 300 );
+    REQUIRE( pmm::detail::ptr_to_granule_idx_checked<AT>( dummy, 256, oob_ptr ) == AT::no_block );
 }
 
 TEST_CASE( "validation: ptr_to_granule_idx_checked returns no_block for misaligned", "[test_issue257]" )
@@ -439,8 +446,8 @@ TEST_CASE( "validation: validate_block_header_full on clean image reports no iss
     REQUIRE( !p.is_null() );
 
     // Get the block index.
-    std::size_t              usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
-    typename AT::index_type  blk_idx =
+    std::size_t             usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    typename AT::index_type blk_idx =
         static_cast<typename AT::index_type>( ( usr_off - sizeof( pmm::Block<AT> ) ) / AT::granule_size );
 
     pmm::VerifyResult result;
@@ -466,7 +473,7 @@ using MgrLoad = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 2571>;
 
 TEST_CASE( "validation: load repairs inconsistent block state", "[test_issue257]" )
 {
-    static constexpr const char* kFile = "/tmp/test_issue257_repair.pmm";
+    static constexpr const char* kFile = "test_issue257_repair.pmm";
 
     MgrSave::destroy();
     REQUIRE( MgrSave::create( 64 * 1024 ) );


### PR DESCRIPTION
## Summary

Fixes netkeep80/PersistMemoryManager#257

Introduces a unified validation layer for all raw pointer → block transitions. All dangerous low-level conversions now pass through a defined set of validation helpers that reject corrupted, foreign, or out-of-bounds pointers.

### Deliverables

1. **`docs/validation_model.md`** — low-level validation model specifying:
   - Two validation modes: cheap (fast-path, O(1)) and full (verify-level)
   - All 8 conversion paths and their validation requirements
   - Error categories: pointer provenance, address correctness, header integrity
   - Mapping to existing PmmError and ViolationType enums

2. **`include/pmm/validation.h`** — unified validation helper functions:
   - `validate_block_index<AT>()` — granule index in-range check
   - `validate_user_ptr<AT>()` — user-data pointer provenance and alignment
   - `validate_link_index<AT>()` — linked-list/AVL index (accepts no_block sentinel)
   - `validate_block_header_full<AT>()` — full verify-level structural integrity

3. **Hardened conversion paths** (`types.h`, `persist_memory_manager.h`):
   - `block_at_checked<AT>()` — bounds-checked variant of `block_at()`
   - `resolve_granule_ptr_checked<AT>()` — bounds-checked resolve
   - `ptr_to_granule_idx_checked<AT>()` — validated reverse conversion
   - `resolve<T>()` — returns nullptr + `PmmError::InvalidPointer` on OOB (was assert/UB)
   - `block_raw_ptr_from_pptr()` / `block_raw_mut_ptr_from_pptr()` — nullptr on bad offset
   - `make_pptr_from_raw()` — validates pointer is within managed region

4. **Nullptr propagation to all callers of block_raw_ptr_from_pptr** (owner feedback):
   - `get_tree_idx_field()` / `set_tree_idx_field()` — return safe default / no-op + set `PmmError::InvalidPointer`
   - `get_tree_weight()` / `set_tree_weight()` — return 0 / no-op + set `PmmError::InvalidPointer`
   - `get_tree_height()` / `set_tree_height()` — return 0 / no-op + set `PmmError::InvalidPointer`
   - `tree_node()` — returns thread-local sentinel + sets `PmmError::InvalidPointer`

5. **Stateless sentinel in `tree_node()` error path** (owner feedback):
   - Sentinel is now reinitialized (`sentinel = {};`) before each error return
   - Prevents prior mutations from leaking across invalid calls in the same thread
   - Regression test verifies sentinel is clean after mutation + second bad call

6. **Full block header validation in verify path** (`verify_repair_mixin.inc`):
   - Checks next_offset/prev_offset are valid link indices
   - Checks node_type is a known value (kNodeReadWrite or kNodeReadOnly)
   - Checks allocated block data range fits within image bounds

7. **45 negative tests** (`test_issue257_validation.cpp`) covering:
   - Null/foreign/before-base/past-end pointer rejection
   - Misaligned pointer detection
   - Invalid block index detection
   - Corrupted weight/root_offset/next_offset/node_type detection by verify
   - Block data exceeding image bounds
   - validate_user_ptr edge cases
   - block_at_checked / resolve_granule_ptr_checked / ptr_to_granule_idx_checked
   - validate_block_header_full on clean vs corrupted image
   - End-to-end: load repairs inconsistent block state
   - Clean image produces no violations
   - OOB pptr through all wrapper APIs (get/set tree idx/weight/height, tree_node)
   - Valid pptr positive test through wrapper APIs
   - **Sentinel statefulness regression** (mutate → verify clean on next bad call)

8. **Changelog fragment** and version bump `0.50.3` → `0.51.0`.

### Acceptance criteria verification

- [x] All paths raw/user pointer → block pass through defined validation layer
- [x] Corrupted or foreign pointer reliably rejected (45 negative tests)
- [x] Header corruption distinguishable from domain/tree corruption (separate ViolationType values)
- [x] Fast-path and full verify-path formally separated (cheap vs full modes)
- [x] Negative tests on: invalid pointer, bad alignment, bad index, broken header, wrong domain/root
- [x] All callers of block_raw_ptr_from_pptr handle nullptr (owner feedback addressed)
- [x] tree_node() sentinel is stateless across error-path calls (owner feedback addressed)

## Test plan

- [x] `cmake -B build && cmake --build build` — compiles cleanly (0 errors)
- [x] `ctest --test-dir build --output-on-failure` — all 76 tests pass (75 existing + 1 new with 45 test cases)
- [x] Single-include headers regenerated via quom
- [x] clang-format passes
- [x] No uncommitted changes
- [ ] CI passes on fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)