### PR TITLE
feat: build reload, corruption and property test matrix (#258)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T19:55:17.884Z for PR creation at branch issue-258-d7453e59d9ba for issue https://github.com/netkeep80/PersistMemoryManager/issues/258

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T19:55:17.884Z for PR creation at branch issue-258-d7453e59d9ba for issue https://github.com/netkeep80/PersistMemoryManager/issues/258

--- a/changelog.d/20260411_200000_issue258_test_matrix.md
+++ b/changelog.d/20260411_200000_issue258_test_matrix.md
@@ -1,0 +1,12 @@
+---
+bump: minor
+---
+
+### Added
+- Comprehensive test matrix document (`docs/test_matrix.md`) mapping all test groups to invariants and violation types
+- Bootstrap test suite across multiple preset configurations (`test_issue258_bootstrap.cpp`)
+- Reload/relocation test suite with different base address, multi-preset round-trip, domain survival, and pstringview persistence (`test_issue258_reload.cpp`)
+- Structural invariant test suite covering linked-list topology, block counts, weight/state consistency, no-overlap, and total-size sum (`test_issue258_structural.cpp`)
+- Deterministic corruption test suite for all violation types: root_offset, prev_offset, weight, registry magic, domain name/flags, header fields, and multiple simultaneous corruptions (`test_issue258_corruption.cpp`)
+- Verify/repair behavior test suite verifying diagnostics accuracy, idempotency, and post-repair cleanliness (`test_issue258_verify_behavior.cpp`)
+- Property/generative test suite with random alloc/dealloc, save/load round-trips, corruption injection, repeated verify, mixed pstringview ops, and multi-reload cycles (`test_issue258_property.cpp`)

--- a/docs/test_matrix.md
+++ b/docs/test_matrix.md
@@ -1,0 +1,141 @@
+# Test Matrix
+
+## Document status
+
+Comprehensive test coverage map for PersistMemoryManager.
+Organized by test group as defined in issue #258.
+
+Related documents:
+- [core_invariants.md](core_invariants.md) — frozen invariant set
+- [verify_repair_contract.md](verify_repair_contract.md) — operational boundary
+- [diagnostics_taxonomy.md](diagnostics_taxonomy.md) — violation types
+- [validation_model.md](validation_model.md) — pointer/block validation
+
+---
+
+## A. Bootstrap tests
+
+Verify that `create()` produces a correct minimal image.
+
+| ID  | What is verified                        | Invariant | Mode  | Test file                         |
+|-----|-----------------------------------------|-----------|-------|-----------------------------------|
+| A1  | Manager header valid (magic, granule)   | D1a       | —     | test_issue241_bootstrap.cpp       |
+| A2  | Free-tree root exists and is non-zero   | E4a       | —     | test_issue241_bootstrap.cpp       |
+| A3  | Domain registry exists                  | C2a       | —     | test_issue241_bootstrap.cpp       |
+| A4  | Symbol dictionary exists                | C3a       | —     | test_issue241_bootstrap.cpp       |
+| A5  | System symbol names interned            | C3a       | —     | test_issue241_bootstrap.cpp       |
+| A6  | Domains discoverable by name/symbol     | C1a       | —     | test_issue241_bootstrap.cpp       |
+| A7  | Bootstrap deterministic                 | D1d       | —     | test_issue241_bootstrap.cpp       |
+| A8  | Bootstrap across preset configurations  | D1a–D1d   | —     | test_issue258_bootstrap.cpp       |
+| A9  | Memory stats consistent after create    | D1b       | —     | test_issue258_bootstrap.cpp       |
+
+---
+
+## B. Reload / relocation tests
+
+Verify save/load round-trip, relocation, and root binding survival.
+
+| ID  | What is verified                         | Invariant  | Mode       | Test file                          |
+|-----|------------------------------------------|------------|------------|------------------------------------|
+| B1  | Basic round-trip (stats preserved)       | D2a        | load       | test_persistence.cpp               |
+| B2  | User data preserved after reload         | A2, D2a    | load       | test_persistence.cpp               |
+| B3  | Allocate/deallocate after reload         | D2a        | load       | test_persistence.cpp               |
+| B4  | Root bindings survive reload             | C2a        | load       | test_issue241_bootstrap.cpp        |
+| B5  | Dictionary survives reload               | C3a        | load       | test_issue241_bootstrap.cpp        |
+| B6  | Double save/load cycle                   | D2a        | load       | test_persistence.cpp               |
+| B7  | Reload at different buffer address       | D2a        | load       | test_issue258_reload.cpp           |
+| B8  | Multiple presets save/load round-trip    | D2a        | load       | test_issue258_reload.cpp           |
+| B9  | User domains survive reload              | C2a        | load       | test_issue258_reload.cpp           |
+| B10 | pstring/pstringview survive reload       | C3a        | load       | test_issue258_reload.cpp           |
+
+---
+
+## C. Structural invariant tests
+
+Verify internal consistency of persistent data structures.
+
+| ID  | What is verified                         | Invariant  | Mode    | Test file                            |
+|-----|------------------------------------------|------------|---------|--------------------------------------|
+| C1  | Linked-list topology (prev/next chain)   | B1a, B1b   | verify  | test_issue258_structural.cpp         |
+| C2  | Block count consistency                  | D2a        | verify  | test_issue258_structural.cpp         |
+| C3  | Free-tree AVL balance                    | E1a        | verify  | test_issue258_structural.cpp         |
+| C4  | Tree ownership (root_offset match)       | B4a, B4b   | verify  | test_issue258_structural.cpp         |
+| C5  | Domain membership consistency            | C1a        | verify  | test_issue258_structural.cpp         |
+| C6  | Weight/state consistency for all blocks  | B3b, B4b   | verify  | test_issue258_structural.cpp         |
+| C7  | No overlapping blocks                    | B1b        | verify  | test_issue258_structural.cpp         |
+| C8  | Total size equals sum of blocks          | B1b        | verify  | test_issue258_structural.cpp         |
+
+---
+
+## D. Corruption tests
+
+Deterministic corruption injection with known violation types.
+
+| ID  | What is corrupted                        | Violation type              | Mode         | Test file                         |
+|-----|------------------------------------------|-----------------------------|--------------|-----------------------------------|
+| D1  | Block root_offset (wrong value)          | BlockStateInconsistent      | verify       | test_issue258_corruption.cpp      |
+| D2  | Block prev_offset (wrong value)          | PrevOffsetMismatch          | verify       | test_issue258_corruption.cpp      |
+| D3  | Block weight (free→allocated mismatch)   | BlockStateInconsistent      | verify       | test_issue258_corruption.cpp      |
+| D4  | Forest registry magic                    | ForestRegistryMissing       | verify       | test_issue258_corruption.cpp      |
+| D5  | System domain name corrupted             | ForestDomainMissing         | verify       | test_issue258_corruption.cpp      |
+| D6  | System domain flags cleared              | ForestDomainFlagsMissing    | verify       | test_issue258_corruption.cpp      |
+| D7  | Manager header magic                     | HeaderCorruption            | verify/load  | test_issue258_corruption.cpp      |
+| D8  | Manager header granule_size              | HeaderCorruption            | verify       | test_issue258_corruption.cpp      |
+| D9  | Manager header total_size                | HeaderCorruption            | verify       | test_issue258_corruption.cpp      |
+| D10 | Multiple simultaneous corruptions        | Multiple                    | verify       | test_issue258_corruption.cpp      |
+| D11 | Corruption repaired after load           | BlockStateInconsistent      | load/verify  | test_issue258_corruption.cpp      |
+| D12 | Invalid pointer provenance (out-of-range)| —                           | verify       | test_issue258_corruption.cpp      |
+
+---
+
+## E. Verify / repair behavior tests
+
+Verify operational contract boundaries.
+
+| ID  | What is verified                          | Policy outcome         | Mode        | Test file                              |
+|-----|-------------------------------------------|------------------------|-------------|----------------------------------------|
+| E1  | Verify only reports (no modification)     | NoAction               | verify      | test_issue256_verify_repair_contract   |
+| E2  | Repair records all actions                | Repaired/Rebuilt        | load        | test_issue256_verify_repair_contract   |
+| E3  | Load does not mask corruption             | —                      | load        | test_issue256_verify_repair_contract   |
+| E4  | Diagnostics reflect real action           | —                      | verify/load | test_issue258_verify_behavior.cpp      |
+| E5  | Verify is idempotent                      | —                      | verify      | test_issue258_verify_behavior.cpp      |
+| E6  | Repair is idempotent (verify clean after) | —                      | load/verify | test_issue258_verify_behavior.cpp      |
+| E7  | Aborted on non-recoverable corruption     | Aborted                | load        | test_issue256_verify_repair_contract   |
+| E8  | Verify after repair shows clean state     | ok=true                | verify      | test_issue258_verify_behavior.cpp      |
+
+---
+
+## F. Property / generative tests
+
+Random sequences to find unexpected combinations.
+
+| ID  | Scenario                                        | Test file                          |
+|-----|-------------------------------------------------|------------------------------------|
+| F1  | Random allocate/deallocate, then verify          | test_issue258_property.cpp         |
+| F2  | Random alloc/dealloc + save/load round-trip      | test_issue258_property.cpp         |
+| F3  | Random corruption injection + verify             | test_issue258_property.cpp         |
+| F4  | Repeated verify after random operations          | test_issue258_property.cpp         |
+| F5  | Alloc/dealloc mixed with container ops (pstring) | test_issue258_property.cpp         |
+| F6  | Multiple reload cycles with operations between   | test_issue258_property.cpp         |
+
+---
+
+## Coverage summary
+
+| Group | New tests | Existing tests enhanced |
+|-------|-----------|------------------------|
+| A     | 2         | 0                      |
+| B     | 4         | 0                      |
+| C     | 8         | 0                      |
+| D     | 12        | 0                      |
+| E     | 4         | 0                      |
+| F     | 6         | 0                      |
+| Total | 36        | 0                      |
+
+New test files:
+- `test_issue258_bootstrap.cpp` — extended bootstrap coverage
+- `test_issue258_reload.cpp` — reload/relocation tests
+- `test_issue258_structural.cpp` — structural invariant tests
+- `test_issue258_corruption.cpp` — deterministic corruption tests
+- `test_issue258_verify_behavior.cpp` — verify/repair behavior tests
+- `test_issue258_property.cpp` — property/generative tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -275,3 +275,12 @@ pmm_add_test(test_issue256_verify_repair_contract test_issue256_verify_repair_co
 
 # ─── Pointer and block validation layer tests ───────────────────
 pmm_add_test(test_issue257_validation test_issue257_validation.cpp)
+
+# ─── Issue 258: Test matrix — bootstrap, reload, structural, corruption,
+#     verify/repair behavior, and property/generative tests ──────
+pmm_add_test(test_issue258_bootstrap      test_issue258_bootstrap.cpp)
+pmm_add_test(test_issue258_reload         test_issue258_reload.cpp)
+pmm_add_test(test_issue258_structural     test_issue258_structural.cpp)
+pmm_add_test(test_issue258_corruption     test_issue258_corruption.cpp)
+pmm_add_test(test_issue258_verify_behavior test_issue258_verify_behavior.cpp)
+pmm_add_test(test_issue258_property       test_issue258_property.cpp)

--- a/tests/test_issue258_bootstrap.cpp
+++ b/tests/test_issue258_bootstrap.cpp
@@ -1,0 +1,106 @@
+/**
+ * @file test_issue258_bootstrap.cpp
+ * @brief Extended bootstrap tests across preset configurations.
+ *
+ * Covers test matrix group A: bootstrap invariants across
+ * multiple manager configurations and memory stats consistency.
+ *
+ * @see docs/test_matrix.md — A8, A9
+ * @see docs/core_invariants.md — D1a–D1d
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+
+// ─── A8: Bootstrap across preset configurations ─────────────────────────────
+
+template <typename MgrT> static void verify_bootstrap_for_preset( std::size_t arena_size )
+{
+    MgrT::destroy();
+    REQUIRE( MgrT::create( arena_size ) );
+
+    REQUIRE( MgrT::is_initialized() );
+    REQUIRE( MgrT::validate_bootstrap_invariants() );
+
+    REQUIRE( MgrT::has_domain( pmm::detail::kSystemDomainFreeTree ) );
+    REQUIRE( MgrT::has_domain( pmm::detail::kSystemDomainSymbols ) );
+    REQUIRE( MgrT::has_domain( pmm::detail::kSystemDomainRegistry ) );
+
+    REQUIRE( MgrT::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) != 0 );
+    REQUIRE( MgrT::get_domain_root_offset( pmm::detail::kSystemDomainSymbols ) != 0 );
+    REQUIRE( MgrT::get_domain_root_offset( pmm::detail::kSystemDomainRegistry ) != 0 );
+
+    auto free_id     = MgrT::find_domain_by_name( pmm::detail::kSystemDomainFreeTree );
+    auto symbols_id  = MgrT::find_domain_by_name( pmm::detail::kSystemDomainSymbols );
+    auto registry_id = MgrT::find_domain_by_name( pmm::detail::kSystemDomainRegistry );
+    REQUIRE( free_id != 0 );
+    REQUIRE( symbols_id != 0 );
+    REQUIRE( registry_id != 0 );
+    REQUIRE( free_id != symbols_id );
+    REQUIRE( free_id != registry_id );
+    REQUIRE( symbols_id != registry_id );
+
+    MgrT::destroy();
+}
+
+TEST_CASE( "bootstrap: SingleThreadedHeap preset", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25801>;
+    verify_bootstrap_for_preset<Mgr>( 64 * 1024 );
+}
+
+TEST_CASE( "bootstrap: EmbeddedHeap preset", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::EmbeddedManagerConfig, 25802>;
+    verify_bootstrap_for_preset<Mgr>( 64 * 1024 );
+}
+
+TEST_CASE( "bootstrap: EmbeddedStaticHeap preset", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::EmbeddedStaticConfig<65536>, 25803>;
+    verify_bootstrap_for_preset<Mgr>( 64 * 1024 );
+}
+
+TEST_CASE( "bootstrap: SmallEmbeddedStaticHeap preset", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::SmallEmbeddedStaticConfig<32768>, 25804>;
+    verify_bootstrap_for_preset<Mgr>( 32 * 1024 );
+}
+
+// ─── A9: Memory stats consistent after create ───────────────────────────────
+
+TEST_CASE( "bootstrap: memory stats consistent after create", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25805>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    REQUIRE( Mgr::total_size() == 64 * 1024 );
+    REQUIRE( Mgr::block_count() > 0 );
+    REQUIRE( Mgr::free_block_count() >= 1 );
+    REQUIRE( Mgr::alloc_block_count() > 0 );
+    REQUIRE( Mgr::block_count() == Mgr::free_block_count() + Mgr::alloc_block_count() );
+    REQUIRE( Mgr::used_size() > 0 );
+    REQUIRE( Mgr::free_size() > 0 );
+    REQUIRE( Mgr::used_size() + Mgr::free_size() == Mgr::total_size() );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "bootstrap: minimal arena size still bootstraps", "[issue258][bootstrap]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25806>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 4 * 1024 ) );
+    REQUIRE( Mgr::is_initialized() );
+    REQUIRE( Mgr::validate_bootstrap_invariants() );
+
+    Mgr::destroy();
+}

--- a/tests/test_issue258_corruption.cpp
+++ b/tests/test_issue258_corruption.cpp
@@ -1,0 +1,396 @@
+/**
+ * @file test_issue258_corruption.cpp
+ * @brief Deterministic corruption tests.
+ *
+ * Covers test matrix group D: injection of specific corruption
+ * types and verification that each is detected with the correct
+ * ViolationType.
+ *
+ * @see docs/test_matrix.md — D1–D12
+ * @see docs/diagnostics_taxonomy.md — violation types
+ */
+
+#include "pmm/forest_registry.h"
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using AT  = pmm::DefaultAddressTraits;
+using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25830>;
+
+static constexpr std::size_t kBlockHdrByteSize =
+    ( ( sizeof( pmm::Block<AT> ) + AT::granule_size - 1 ) / AT::granule_size ) * AT::granule_size;
+
+static pmm::detail::ManagerHeader<AT>* get_header( std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + kBlockHdrByteSize );
+}
+
+static void setup_clean( std::size_t arena = 64 * 1024 )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( arena ) );
+}
+
+// Helper: find ViolationType in result
+static bool has_violation( const pmm::VerifyResult& r, pmm::ViolationType t )
+{
+    for ( std::size_t i = 0; i < r.entry_count; ++i )
+        if ( r.entries[i].type == t )
+            return true;
+    return false;
+}
+
+// ─── D1: Block root_offset corruption ───────────────────────────────────────
+
+TEST_CASE( "corruption: wrong root_offset detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+
+    auto orig = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + 111 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::BlockStateInconsistent ) );
+
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+// ─── D2: Block prev_offset corruption ───────────────────────────────────────
+
+TEST_CASE( "corruption: wrong prev_offset detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p2.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+
+    auto orig = pmm::BlockStateBase<AT>::get_prev_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw, orig + 300 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::PrevOffsetMismatch ) );
+
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+// ─── D3: Block weight mismatch (free block with weight > 0) ─────────────────
+
+TEST_CASE( "corruption: free block with non-zero weight detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+    Mgr::deallocate_typed( p );
+
+    // Find a free block and corrupt its weight
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+
+    auto orig_weight = pmm::BlockStateBase<AT>::get_weight( blk_raw );
+    auto orig_root   = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+
+    // Set weight > 0 on a free block (root_offset == 0) => inconsistent
+    pmm::BlockStateBase<AT>::set_weight_of( blk_raw, 42 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::BlockStateInconsistent ) );
+
+    pmm::BlockStateBase<AT>::set_weight_of( blk_raw, orig_weight );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig_root );
+    Mgr::destroy();
+}
+
+// ─── D4: Forest registry magic corruption ───────────────────────────────────
+
+TEST_CASE( "corruption: forest registry bad magic detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    REQUIRE( hdr->root_offset != AT::no_block );
+
+    auto* reg = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
+        base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
+
+    auto orig_magic = reg->magic;
+    reg->magic      = 0xBAD0CAFE;
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::ForestRegistryMissing ) );
+
+    reg->magic = orig_magic;
+    Mgr::destroy();
+}
+
+// ─── D5: System domain name corrupted ───────────────────────────────────────
+
+TEST_CASE( "corruption: corrupted system domain name detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    auto*         reg  = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
+        base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
+
+    // Find system/symbols domain and corrupt its name
+    char original_name[pmm::detail::kForestDomainNameCapacity];
+    bool found = false;
+    for ( std::uint16_t i = 0; i < reg->domain_count; ++i )
+    {
+        if ( std::strncmp( reg->domains[i].name, pmm::detail::kSystemDomainSymbols,
+                           pmm::detail::kForestDomainNameCapacity ) == 0 )
+        {
+            std::memcpy( original_name, reg->domains[i].name, sizeof( original_name ) );
+            std::memset( reg->domains[i].name, 0, sizeof( reg->domains[i].name ) );
+            std::strncpy( reg->domains[i].name, "corrupted/name", pmm::detail::kForestDomainNameCapacity - 1 );
+            found = true;
+            break;
+        }
+    }
+    REQUIRE( found );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::ForestDomainMissing ) );
+
+    // Restore
+    for ( std::uint16_t i = 0; i < reg->domain_count; ++i )
+    {
+        if ( std::strncmp( reg->domains[i].name, "corrupted/name", pmm::detail::kForestDomainNameCapacity ) == 0 )
+        {
+            std::memcpy( reg->domains[i].name, original_name, sizeof( original_name ) );
+            break;
+        }
+    }
+    Mgr::destroy();
+}
+
+// ─── D6: System domain flags cleared ────────────────────────────────────────
+
+TEST_CASE( "corruption: cleared system domain flag detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    auto*         reg  = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
+        base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
+
+    std::uint8_t orig_flags = 0;
+    bool         found      = false;
+    for ( std::uint16_t i = 0; i < reg->domain_count; ++i )
+    {
+        if ( ( reg->domains[i].flags & pmm::detail::kForestDomainFlagSystem ) != 0 )
+        {
+            orig_flags = reg->domains[i].flags;
+            reg->domains[i].flags &= ~pmm::detail::kForestDomainFlagSystem;
+            found = true;
+            break;
+        }
+    }
+    REQUIRE( found );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::ForestDomainFlagsMissing ) );
+
+    // Restore
+    for ( std::uint16_t i = 0; i < reg->domain_count; ++i )
+    {
+        if ( ( reg->domains[i].flags & pmm::detail::kForestDomainFlagSystem ) == 0 &&
+             std::strncmp( reg->domains[i].name, "system/", 7 ) == 0 )
+        {
+            reg->domains[i].flags = orig_flags;
+            break;
+        }
+    }
+    Mgr::destroy();
+}
+
+// ─── D7: Manager header magic corruption ────────────────────────────────────
+
+TEST_CASE( "corruption: header magic corruption detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    auto          orig = hdr->magic;
+    hdr->magic         = 0xDEADBEEFDEADBEEFULL;
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::HeaderCorruption ) );
+
+    hdr->magic = orig;
+    Mgr::destroy();
+}
+
+// ─── D8: Manager header granule_size corruption ─────────────────────────────
+
+TEST_CASE( "corruption: header granule_size corruption detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    auto          orig = hdr->granule_size;
+    hdr->granule_size  = 999;
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::HeaderCorruption ) );
+
+    hdr->granule_size = orig;
+    Mgr::destroy();
+}
+
+// ─── D9: Manager header total_size corruption ───────────────────────────────
+
+TEST_CASE( "corruption: header total_size corruption detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+    auto*         hdr  = get_header( base );
+    auto          orig = hdr->total_size;
+    hdr->total_size    = orig + 8192;
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( has_violation( v, pmm::ViolationType::HeaderCorruption ) );
+
+    hdr->total_size = orig;
+    Mgr::destroy();
+}
+
+// ─── D10: Multiple simultaneous corruptions ─────────────────────────────────
+
+TEST_CASE( "corruption: multiple simultaneous corruptions detected", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    std::uint8_t* base = Mgr::backend().base_ptr();
+
+    // Corrupt root_offset of p1
+    std::size_t usr_off1  = static_cast<std::size_t>( p1.offset() ) * AT::granule_size;
+    void*       blk_raw1  = base + usr_off1 - sizeof( pmm::Block<AT> );
+    auto        orig_root = pmm::BlockStateBase<AT>::get_root_offset( blk_raw1 );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw1, orig_root + 50 );
+
+    // Corrupt prev_offset of p2
+    std::size_t usr_off2  = static_cast<std::size_t>( p2.offset() ) * AT::granule_size;
+    void*       blk_raw2  = base + usr_off2 - sizeof( pmm::Block<AT> );
+    auto        orig_prev = pmm::BlockStateBase<AT>::get_prev_offset( blk_raw2 );
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw2, orig_prev + 200 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( v.violation_count >= 2 );
+    REQUIRE( has_violation( v, pmm::ViolationType::BlockStateInconsistent ) );
+    REQUIRE( has_violation( v, pmm::ViolationType::PrevOffsetMismatch ) );
+
+    // Restore
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw1, orig_root );
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw2, orig_prev );
+    Mgr::destroy();
+}
+
+// ─── D11: Corruption repaired after load ────────────────────────────────────
+
+TEST_CASE( "corruption: block state corruption repaired by load", "[issue258][corruption]" )
+{
+    using MgrA = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25831>;
+    using MgrB = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25832>;
+
+    const char*       kFile = "test_issue258_corr_repair.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( MgrA::create( arena ) );
+    auto p = MgrA::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset before save
+    std::uint8_t* base    = MgrA::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          blk_idx = static_cast<AT::index_type>(
+        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 500 );
+
+    REQUIRE( pmm::save_manager<MgrA>( kFile ) );
+    MgrA::destroy();
+
+    // Load should repair
+    REQUIRE( MgrB::create( arena ) );
+    pmm::VerifyResult load_result;
+    REQUIRE( pmm::load_manager_from_file<MgrB>( kFile, load_result ) );
+
+    // After repair, verify should be clean
+    pmm::VerifyResult post = MgrB::verify();
+    REQUIRE( post.ok );
+
+    MgrB::destroy();
+    std::remove( kFile );
+}
+
+// ─── D12: Invalid pointer provenance ────────────────────────────────────────
+
+TEST_CASE( "corruption: out-of-range block index in prev_offset", "[issue258][corruption]" )
+{
+    setup_clean();
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p2.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+
+    // Set prev to an impossibly large value
+    auto orig = pmm::BlockStateBase<AT>::get_prev_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw, AT::no_block - 1 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+
+    pmm::BlockStateBase<AT>::set_prev_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}

--- a/tests/test_issue258_corruption.cpp
+++ b/tests/test_issue258_corruption.cpp
@@ -349,8 +349,7 @@ TEST_CASE( "corruption: block state corruption repaired by load", "[issue258][co
     std::uint8_t* base    = MgrA::backend().base_ptr();
     std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
     void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
-    auto          blk_idx = static_cast<AT::index_type>(
-        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    auto          blk_idx = static_cast<AT::index_type>( p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
     pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 500 );
 
     REQUIRE( pmm::save_manager<MgrA>( kFile ) );

--- a/tests/test_issue258_property.cpp
+++ b/tests/test_issue258_property.cpp
@@ -1,0 +1,363 @@
+/**
+ * @file test_issue258_property.cpp
+ * @brief Property-based / generative tests.
+ *
+ * Covers test matrix group F: random alloc/dealloc sequences,
+ * save/load round-trips, corruption injection, and repeated
+ * verify checks.
+ *
+ * Uses deterministic pseudo-random sequences (fixed seeds) for
+ * reproducibility.
+ *
+ * @see docs/test_matrix.md — F1–F6
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+using AT = pmm::DefaultAddressTraits;
+
+// ─── F1: Random allocate/deallocate, then verify ────────────────────────────
+
+TEST_CASE( "property: random alloc/dealloc then verify", "[issue258][property]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25850>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 256 * 1024 ) );
+
+    std::mt19937 rng( 42 );
+
+    std::vector<typename Mgr::template pptr<std::uint8_t>> live;
+
+    for ( int round = 0; round < 200; ++round )
+    {
+        std::uniform_int_distribution<int> op_dist( 0, 2 );
+        int                                op = op_dist( rng );
+
+        if ( op <= 1 || live.empty() )
+        {
+            // Allocate
+            std::uniform_int_distribution<int> size_dist( 1, 512 );
+            int                                sz = size_dist( rng );
+            auto                               p  = Mgr::allocate_typed<std::uint8_t>( static_cast<std::size_t>( sz ) );
+            if ( !p.is_null() )
+            {
+                // Write pattern to detect data corruption
+                std::uint8_t* data = Mgr::template resolve<std::uint8_t>( p );
+                if ( data )
+                    std::memset( data, static_cast<std::uint8_t>( round & 0xFF ), static_cast<std::size_t>( sz ) );
+                live.push_back( p );
+            }
+        }
+        else
+        {
+            // Deallocate a random live pointer
+            std::uniform_int_distribution<std::size_t> idx_dist( 0, live.size() - 1 );
+            std::size_t                                idx = idx_dist( rng );
+            Mgr::deallocate_typed( live[idx] );
+            live.erase( live.begin() + static_cast<std::ptrdiff_t>( idx ) );
+        }
+    }
+
+    // After all operations, verify should be clean
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE( v.ok );
+
+    // Block count consistency
+    REQUIRE( Mgr::block_count() == Mgr::free_block_count() + Mgr::alloc_block_count() );
+
+    Mgr::destroy();
+}
+
+// ─── F2: Random alloc/dealloc + save/load round-trip ────────────────────────
+
+TEST_CASE( "property: random alloc/dealloc then save/load round-trip", "[issue258][property]" )
+{
+    using MgrA = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25851>;
+    using MgrB = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25852>;
+
+    const char*       kFile = "test_issue258_prop_rt.dat";
+    const std::size_t arena = 256 * 1024;
+
+    REQUIRE( MgrA::create( arena ) );
+
+    std::mt19937 rng( 123 );
+
+    std::vector<std::pair<std::uint32_t, std::size_t>> live_offsets;
+
+    for ( int round = 0; round < 100; ++round )
+    {
+        std::uniform_int_distribution<int> op_dist( 0, 2 );
+        int                                op = op_dist( rng );
+
+        if ( op <= 1 || live_offsets.empty() )
+        {
+            std::uniform_int_distribution<int> size_dist( 1, 256 );
+            std::size_t                        sz = static_cast<std::size_t>( size_dist( rng ) );
+            auto                               p  = MgrA::allocate_typed<std::uint8_t>( sz );
+            if ( !p.is_null() )
+            {
+                std::uint8_t* data = MgrA::template resolve<std::uint8_t>( p );
+                if ( data )
+                    std::memset( data, 0xAB, sz );
+                live_offsets.push_back( { p.offset(), sz } );
+            }
+        }
+        else
+        {
+            std::uniform_int_distribution<std::size_t> idx_dist( 0, live_offsets.size() - 1 );
+            std::size_t                                idx = idx_dist( rng );
+            typename MgrA::template pptr<std::uint8_t> p( live_offsets[idx].first );
+            MgrA::deallocate_typed( p );
+            live_offsets.erase( live_offsets.begin() + static_cast<std::ptrdiff_t>( idx ) );
+        }
+    }
+
+    auto saved_blocks = MgrA::block_count();
+    auto saved_alloc  = MgrA::alloc_block_count();
+
+    REQUIRE( pmm::save_manager<MgrA>( kFile ) );
+    MgrA::destroy();
+
+    REQUIRE( MgrB::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrB>( kFile, result ) );
+
+    REQUIRE( MgrB::block_count() == saved_blocks );
+    REQUIRE( MgrB::alloc_block_count() == saved_alloc );
+
+    // Verify data survived
+    for ( const auto& [off, sz] : live_offsets )
+    {
+        typename MgrB::template pptr<std::uint8_t> p( off );
+        const std::uint8_t*                        data = MgrB::template resolve<std::uint8_t>( p );
+        REQUIRE( data != nullptr );
+        for ( std::size_t i = 0; i < sz; ++i )
+        {
+            REQUIRE( data[i] == 0xAB );
+        }
+    }
+
+    pmm::VerifyResult post = MgrB::verify();
+    REQUIRE( post.ok );
+
+    MgrB::destroy();
+    std::remove( kFile );
+}
+
+// ─── F3: Random corruption injection + verify ───────────────────────────────
+
+TEST_CASE( "property: random corruption injection detected by verify", "[issue258][property]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25853>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    // Allocate several blocks
+    std::vector<typename Mgr::template pptr<std::uint32_t>> ptrs;
+    for ( int i = 0; i < 5; ++i )
+    {
+        auto p = Mgr::allocate_typed<std::uint32_t>( 8 + i * 4 );
+        REQUIRE( !p.is_null() );
+        ptrs.push_back( p );
+    }
+
+    // Verify clean before corruption
+    pmm::VerifyResult v_clean = Mgr::verify();
+    REQUIRE( v_clean.ok );
+
+    std::mt19937 rng( 777 );
+
+    // Inject random corruptions: corrupt root_offset of random blocks
+    std::uint8_t* base = Mgr::backend().base_ptr();
+
+    struct Saved
+    {
+        void*          blk_raw;
+        AT::index_type orig;
+    };
+    std::vector<Saved> saved;
+
+    std::uniform_int_distribution<std::size_t> idx_dist( 0, ptrs.size() - 1 );
+    for ( int i = 0; i < 3; ++i )
+    {
+        std::size_t idx     = idx_dist( rng );
+        std::size_t usr_off = static_cast<std::size_t>( ptrs[idx].offset() ) * AT::granule_size;
+        void*       blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+
+        auto orig = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+        std::uniform_int_distribution<AT::index_type> val_dist( 1, 1000 );
+        pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + val_dist( rng ) );
+        saved.push_back( { blk_raw, orig } );
+    }
+
+    // Verify should detect corruptions
+    pmm::VerifyResult v_corrupt = Mgr::verify();
+    REQUIRE_FALSE( v_corrupt.ok );
+    REQUIRE( v_corrupt.violation_count > 0 );
+
+    // Restore
+    for ( auto& s : saved )
+        pmm::BlockStateBase<AT>::set_root_offset_of( s.blk_raw, s.orig );
+
+    Mgr::destroy();
+}
+
+// ─── F4: Repeated verify after random operations ────────────────────────────
+
+TEST_CASE( "property: repeated verify after random operations", "[issue258][property]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25854>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 128 * 1024 ) );
+
+    std::mt19937 rng( 999 );
+
+    std::vector<typename Mgr::template pptr<std::uint8_t>> live;
+
+    for ( int cycle = 0; cycle < 5; ++cycle )
+    {
+        // Do some operations
+        for ( int op = 0; op < 20; ++op )
+        {
+            std::uniform_int_distribution<int> action( 0, 2 );
+            if ( action( rng ) <= 1 || live.empty() )
+            {
+                std::uniform_int_distribution<int> sz_dist( 16, 256 );
+                auto p = Mgr::allocate_typed<std::uint8_t>( static_cast<std::size_t>( sz_dist( rng ) ) );
+                if ( !p.is_null() )
+                    live.push_back( p );
+            }
+            else
+            {
+                std::uniform_int_distribution<std::size_t> idx_dist( 0, live.size() - 1 );
+                std::size_t                                idx = idx_dist( rng );
+                Mgr::deallocate_typed( live[idx] );
+                live.erase( live.begin() + static_cast<std::ptrdiff_t>( idx ) );
+            }
+        }
+
+        // Verify after each cycle
+        pmm::VerifyResult v = Mgr::verify();
+        REQUIRE( v.ok );
+    }
+
+    Mgr::destroy();
+}
+
+// ─── F5: Alloc/dealloc mixed with pstringview operations ────────────────────
+
+TEST_CASE( "property: mixed alloc/dealloc and pstringview ops", "[issue258][property]" )
+{
+    using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25855>;
+
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 128 * 1024 ) );
+
+    std::mt19937 rng( 555 );
+
+    std::vector<typename Mgr::template pptr<std::uint8_t>> live;
+
+    for ( int round = 0; round < 50; ++round )
+    {
+        std::uniform_int_distribution<int> op_dist( 0, 3 );
+        int                                op = op_dist( rng );
+
+        if ( op == 0 )
+        {
+            // Allocate raw block
+            std::uniform_int_distribution<int> sz_dist( 8, 128 );
+            auto p = Mgr::allocate_typed<std::uint8_t>( static_cast<std::size_t>( sz_dist( rng ) ) );
+            if ( !p.is_null() )
+                live.push_back( p );
+        }
+        else if ( op == 1 && !live.empty() )
+        {
+            // Deallocate
+            std::uniform_int_distribution<std::size_t> idx_dist( 0, live.size() - 1 );
+            std::size_t                                idx = idx_dist( rng );
+            Mgr::deallocate_typed( live[idx] );
+            live.erase( live.begin() + static_cast<std::ptrdiff_t>( idx ) );
+        }
+        else
+        {
+            // Intern a string
+            std::string                            s   = "prop_test_" + std::to_string( round );
+            Mgr::pptr<Mgr::pstringview> psv = Mgr::pstringview( s.c_str() );
+            // pstringview may fail if OOM, that's OK
+            (void)psv;
+        }
+    }
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE( v.ok );
+
+    Mgr::destroy();
+}
+
+// ─── F6: Multiple reload cycles with operations between ─────────────────────
+
+TEST_CASE( "property: multiple reload cycles with operations between", "[issue258][property]" )
+{
+    using MgrC = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25856>;
+    using MgrD = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25857>;
+
+    const char*       kFile = "test_issue258_prop_multi_reload.dat";
+    const std::size_t arena = 128 * 1024;
+
+    std::mt19937 rng( 314 );
+
+    REQUIRE( MgrC::create( arena ) );
+
+    for ( int cycle = 0; cycle < 3; ++cycle )
+    {
+        // Allocate a few blocks
+        for ( int i = 0; i < 5; ++i )
+        {
+            std::uniform_int_distribution<int> sz_dist( 16, 128 );
+            auto                               p = MgrC::allocate_typed<std::uint8_t>(
+                static_cast<std::size_t>( sz_dist( rng ) ) );
+            // Ignore OOM
+        }
+
+        // Verify clean before save
+        pmm::VerifyResult v = MgrC::verify();
+        REQUIRE( v.ok );
+
+        // Save
+        REQUIRE( pmm::save_manager<MgrC>( kFile ) );
+        MgrC::destroy();
+
+        // Load into MgrD
+        REQUIRE( MgrD::create( arena ) );
+        pmm::VerifyResult load_result;
+        REQUIRE( pmm::load_manager_from_file<MgrD>( kFile, load_result ) );
+
+        // Verify clean after load
+        pmm::VerifyResult post = MgrD::verify();
+        REQUIRE( post.ok );
+
+        // Copy state from MgrD to MgrC for next cycle
+        REQUIRE( MgrC::create( arena ) );
+        std::memcpy( MgrC::backend().base_ptr(), MgrD::backend().base_ptr(), arena );
+        pmm::VerifyResult copy_result;
+        MgrC::load( copy_result );
+        MgrD::destroy();
+    }
+
+    MgrC::destroy();
+    std::remove( kFile );
+}

--- a/tests/test_issue258_property.cpp
+++ b/tests/test_issue258_property.cpp
@@ -197,7 +197,7 @@ TEST_CASE( "property: random corruption injection detected by verify", "[issue25
         std::size_t usr_off = static_cast<std::size_t>( ptrs[idx].offset() ) * AT::granule_size;
         void*       blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
 
-        auto orig = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+        auto                                          orig = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
         std::uniform_int_distribution<AT::index_type> val_dist( 1, 1000 );
         pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + val_dist( rng ) );
         saved.push_back( { blk_raw, orig } );
@@ -295,7 +295,7 @@ TEST_CASE( "property: mixed alloc/dealloc and pstringview ops", "[issue258][prop
         else
         {
             // Intern a string
-            std::string                            s   = "prop_test_" + std::to_string( round );
+            std::string                 s   = "prop_test_" + std::to_string( round );
             Mgr::pptr<Mgr::pstringview> psv = Mgr::pstringview( s.c_str() );
             // pstringview may fail if OOM, that's OK
             (void)psv;
@@ -328,8 +328,7 @@ TEST_CASE( "property: multiple reload cycles with operations between", "[issue25
         for ( int i = 0; i < 5; ++i )
         {
             std::uniform_int_distribution<int> sz_dist( 16, 128 );
-            auto                               p = MgrC::allocate_typed<std::uint8_t>(
-                static_cast<std::size_t>( sz_dist( rng ) ) );
+            auto p = MgrC::allocate_typed<std::uint8_t>( static_cast<std::size_t>( sz_dist( rng ) ) );
             // Ignore OOM
         }
 

--- a/tests/test_issue258_reload.cpp
+++ b/tests/test_issue258_reload.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file test_issue258_reload.cpp
+ * @brief Reload and relocation tests.
+ *
+ * Covers test matrix group B: reload at different buffer address,
+ * multi-preset round-trip, user domain survival, pstring/pstringview
+ * persistence across reload.
+ *
+ * @see docs/test_matrix.md — B7–B10
+ * @see docs/core_invariants.md — D2a, C2a, C3a
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// ─── B7: Reload at different buffer address ─────────────────────────────────
+//
+// Two managers with different InstanceIds map to different static backends,
+// meaning the loaded image sits at a different base address.
+// All offset-based data should still be valid because PMM uses granule indices,
+// not raw pointers.
+
+TEST_CASE( "reload: different base address via different InstanceId", "[issue258][reload]" )
+{
+    using Mgr1 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25810>;
+    using Mgr2 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25811>;
+
+    const char*       kFile = "test_issue258_reload_base.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( Mgr1::create( arena ) );
+
+    auto p1 = Mgr1::allocate_typed<std::uint64_t>( 8 );
+    REQUIRE( !p1.is_null() );
+
+    std::uint64_t* data1 = Mgr1::template resolve<std::uint64_t>( p1 );
+    REQUIRE( data1 != nullptr );
+    for ( int i = 0; i < 8; ++i )
+        data1[i] = static_cast<std::uint64_t>( 0xDEAD000000000000ULL | i );
+
+    auto saved_offset = p1.offset();
+
+    REQUIRE( pmm::save_manager<Mgr1>( kFile ) );
+    auto* base1_ptr = Mgr1::backend().base_ptr();
+    Mgr1::destroy();
+
+    REQUIRE( Mgr2::create( arena ) );
+    auto* base2_ptr = Mgr2::backend().base_ptr();
+
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<Mgr2>( kFile, result ) );
+
+    REQUIRE( Mgr2::is_initialized() );
+    REQUIRE( Mgr2::validate_bootstrap_invariants() );
+
+    typename Mgr2::template pptr<std::uint64_t> p2( saved_offset );
+    std::uint64_t* data2 = Mgr2::template resolve<std::uint64_t>( p2 );
+    REQUIRE( data2 != nullptr );
+    for ( int i = 0; i < 8; ++i )
+    {
+        REQUIRE( data2[i] == static_cast<std::uint64_t>( 0xDEAD000000000000ULL | i ) );
+    }
+
+    Mgr2::destroy();
+    std::remove( kFile );
+}
+
+// ─── B8: Multiple presets save/load round-trip ──────────────────────────────
+
+template <typename MgrSave, typename MgrLoad>
+static void test_preset_roundtrip( const char* filename, std::size_t arena )
+{
+    MgrSave::destroy();
+    MgrLoad::destroy();
+
+    REQUIRE( MgrSave::create( arena ) );
+
+    auto p = MgrSave::template allocate_typed<std::uint32_t>( 4 );
+    REQUIRE( !p.is_null() );
+    std::uint32_t* data = MgrSave::template resolve<std::uint32_t>( p );
+    for ( int i = 0; i < 4; ++i )
+        data[i] = static_cast<std::uint32_t>( 42 + i );
+
+    auto saved_offset = p.offset();
+    auto saved_blocks = MgrSave::block_count();
+
+    REQUIRE( pmm::save_manager<MgrSave>( filename ) );
+    MgrSave::destroy();
+
+    REQUIRE( MgrLoad::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrLoad>( filename, result ) );
+
+    REQUIRE( MgrLoad::is_initialized() );
+    REQUIRE( MgrLoad::block_count() == saved_blocks );
+
+    typename MgrLoad::template pptr<std::uint32_t> p2( saved_offset );
+    std::uint32_t* loaded = MgrLoad::template resolve<std::uint32_t>( p2 );
+    REQUIRE( loaded != nullptr );
+    for ( int i = 0; i < 4; ++i )
+    {
+        REQUIRE( loaded[i] == static_cast<std::uint32_t>( 42 + i ) );
+    }
+
+    MgrLoad::destroy();
+    std::remove( filename );
+}
+
+TEST_CASE( "reload: CacheManagerConfig round-trip", "[issue258][reload]" )
+{
+    using Save = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25812>;
+    using Load = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25813>;
+    test_preset_roundtrip<Save, Load>( "test_issue258_rt_cache.dat", 64 * 1024 );
+}
+
+TEST_CASE( "reload: EmbeddedManagerConfig round-trip", "[issue258][reload]" )
+{
+    using Save = pmm::PersistMemoryManager<pmm::EmbeddedManagerConfig, 25814>;
+    using Load = pmm::PersistMemoryManager<pmm::EmbeddedManagerConfig, 25815>;
+    test_preset_roundtrip<Save, Load>( "test_issue258_rt_embedded.dat", 64 * 1024 );
+}
+
+// ─── B9: User domains survive reload ────────────────────────────────────────
+
+TEST_CASE( "reload: user domain survives save/load", "[issue258][reload]" )
+{
+    using Mgr1 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25816>;
+    using Mgr2 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25817>;
+
+    const char*       kFile = "test_issue258_reload_domain.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( Mgr1::create( arena ) );
+
+    const char* domain_name = "user/test_domain";
+    REQUIRE( Mgr1::register_domain( domain_name ) );
+    REQUIRE( Mgr1::has_domain( domain_name ) );
+
+    auto domain_binding = Mgr1::find_domain_by_name( domain_name );
+    REQUIRE( domain_binding != 0 );
+
+    REQUIRE( pmm::save_manager<Mgr1>( kFile ) );
+    Mgr1::destroy();
+
+    REQUIRE( Mgr2::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<Mgr2>( kFile, result ) );
+
+    REQUIRE( Mgr2::has_domain( domain_name ) );
+    auto loaded_binding = Mgr2::find_domain_by_name( domain_name );
+    REQUIRE( loaded_binding == domain_binding );
+
+    Mgr2::destroy();
+    std::remove( kFile );
+}
+
+// ─── B10: pstringview survives reload ───────────────────────────────────────
+
+TEST_CASE( "reload: pstringview content survives save/load", "[issue258][reload]" )
+{
+    using Mgr1 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25818>;
+    using Mgr2 = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25819>;
+
+    const char*       kFile = "test_issue258_reload_psv.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( Mgr1::create( arena ) );
+
+    Mgr1::pptr<Mgr1::pstringview> psv = Mgr1::pstringview( "test_interned_string" );
+    REQUIRE( !psv.is_null() );
+    auto psv_offset = psv.offset();
+
+    REQUIRE( pmm::save_manager<Mgr1>( kFile ) );
+    Mgr1::destroy();
+
+    REQUIRE( Mgr2::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<Mgr2>( kFile, result ) );
+
+    Mgr2::pptr<Mgr2::pstringview> psv2 = Mgr2::pstringview( "test_interned_string" );
+    REQUIRE( !psv2.is_null() );
+    REQUIRE( psv2.offset() == psv_offset );
+
+    Mgr2::destroy();
+    std::remove( kFile );
+}

--- a/tests/test_issue258_reload.cpp
+++ b/tests/test_issue258_reload.cpp
@@ -23,8 +23,10 @@
 
 // ─── B7: Reload at different buffer address ─────────────────────────────────
 //
-// Two managers with different InstanceIds map to different static backends,
-// meaning the loaded image sits at a different base address.
+// Both managers are kept alive simultaneously so that each holds its own
+// heap-allocated backend buffer.  Because two independent malloc'd regions
+// cannot overlap, the loaded image is guaranteed to reside at a different
+// virtual address than the original.
 // All offset-based data should still be valid because PMM uses granule indices,
 // not raw pointers.
 
@@ -36,6 +38,7 @@ TEST_CASE( "reload: different base address via different InstanceId", "[issue258
     const char*       kFile = "test_issue258_reload_base.dat";
     const std::size_t arena = 64 * 1024;
 
+    // Create Mgr1 and populate data.
     REQUIRE( Mgr1::create( arena ) );
 
     auto p1 = Mgr1::allocate_typed<std::uint64_t>( 8 );
@@ -49,11 +52,13 @@ TEST_CASE( "reload: different base address via different InstanceId", "[issue258
     auto saved_offset = p1.offset();
 
     REQUIRE( pmm::save_manager<Mgr1>( kFile ) );
-    auto* base1_ptr = Mgr1::backend().base_ptr();
-    Mgr1::destroy();
 
+    // Create Mgr2 while Mgr1 is still alive — guarantees a separate buffer.
     REQUIRE( Mgr2::create( arena ) );
+
+    auto* base1_ptr = Mgr1::backend().base_ptr();
     auto* base2_ptr = Mgr2::backend().base_ptr();
+    REQUIRE( base1_ptr != base2_ptr );
 
     pmm::VerifyResult result;
     REQUIRE( pmm::load_manager_from_file<Mgr2>( kFile, result ) );
@@ -69,6 +74,8 @@ TEST_CASE( "reload: different base address via different InstanceId", "[issue258
         REQUIRE( data2[i] == static_cast<std::uint64_t>( 0xDEAD000000000000ULL | i ) );
     }
 
+    // Clean up both managers.
+    Mgr1::destroy();
     Mgr2::destroy();
     std::remove( kFile );
 }

--- a/tests/test_issue258_reload.cpp
+++ b/tests/test_issue258_reload.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "reload: different base address via different InstanceId", "[issue258
     REQUIRE( Mgr2::validate_bootstrap_invariants() );
 
     typename Mgr2::template pptr<std::uint64_t> p2( saved_offset );
-    std::uint64_t* data2 = Mgr2::template resolve<std::uint64_t>( p2 );
+    std::uint64_t*                              data2 = Mgr2::template resolve<std::uint64_t>( p2 );
     REQUIRE( data2 != nullptr );
     for ( int i = 0; i < 8; ++i )
     {
@@ -103,7 +103,7 @@ static void test_preset_roundtrip( const char* filename, std::size_t arena )
     REQUIRE( MgrLoad::block_count() == saved_blocks );
 
     typename MgrLoad::template pptr<std::uint32_t> p2( saved_offset );
-    std::uint32_t* loaded = MgrLoad::template resolve<std::uint32_t>( p2 );
+    std::uint32_t*                                 loaded = MgrLoad::template resolve<std::uint32_t>( p2 );
     REQUIRE( loaded != nullptr );
     for ( int i = 0; i < 4; ++i )
     {

--- a/tests/test_issue258_structural.cpp
+++ b/tests/test_issue258_structural.cpp
@@ -1,0 +1,292 @@
+/**
+ * @file test_issue258_structural.cpp
+ * @brief Structural invariant tests.
+ *
+ * Covers test matrix group C: linked-list topology, block count
+ * consistency, weight/state consistency, no overlapping blocks,
+ * total size equals sum of blocks.
+ *
+ * @see docs/test_matrix.md — C1–C8
+ * @see docs/core_invariants.md — B1a, B1b, B3b, B4a, B4b
+ */
+
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+using AT  = pmm::DefaultAddressTraits;
+using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25820>;
+
+// ─── Helper: walk the linked list and collect block info ─────────────────────
+
+struct BlockInfo
+{
+    AT::index_type idx;
+    AT::index_type prev;
+    AT::index_type next;
+    AT::index_type weight;
+    AT::index_type root_offset;
+    AT::index_type total_granules;
+    bool           is_free;
+};
+
+static std::vector<BlockInfo> walk_blocks( std::uint8_t* base, std::size_t total_size )
+{
+    using BlockState = pmm::BlockStateBase<AT>;
+    constexpr std::size_t kGranSz = AT::granule_size;
+
+    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
+
+    std::vector<BlockInfo> blocks;
+    AT::index_type         idx = hdr->first_block_offset;
+
+    while ( idx != AT::no_block )
+    {
+        void* blk_raw = base + static_cast<std::size_t>( idx ) * kGranSz;
+
+        BlockInfo bi;
+        bi.idx         = idx;
+        bi.prev        = BlockState::get_prev_offset( blk_raw );
+        bi.next        = BlockState::get_next_offset( blk_raw );
+        bi.weight      = BlockState::get_weight( blk_raw );
+        bi.root_offset = BlockState::get_root_offset( blk_raw );
+        bi.is_free     = ( bi.weight == 0 && bi.root_offset == 0 );
+
+        AT::index_type total_gran = static_cast<AT::index_type>( total_size / kGranSz );
+        if ( bi.next != AT::no_block )
+            bi.total_granules = bi.next - idx;
+        else
+            bi.total_granules = total_gran - idx;
+
+        blocks.push_back( bi );
+        idx = bi.next;
+    }
+
+    return blocks;
+}
+
+// ─── C1: Linked-list topology ───────────────────────────────────────────────
+
+TEST_CASE( "structural: linked-list prev/next consistency", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 10 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 20 );
+    auto p3 = Mgr::allocate_typed<std::uint32_t>( 30 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+    REQUIRE( !p3.is_null() );
+    Mgr::deallocate_typed( p2 );
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+    REQUIRE( blocks.size() >= 3 );
+
+    for ( std::size_t i = 0; i < blocks.size(); ++i )
+    {
+        if ( i == 0 )
+        {
+            REQUIRE( blocks[i].prev == AT::no_block );
+        }
+        else
+        {
+            REQUIRE( blocks[i].prev == blocks[i - 1].idx );
+        }
+
+        if ( i < blocks.size() - 1 )
+        {
+            REQUIRE( blocks[i].next == blocks[i + 1].idx );
+        }
+        else
+        {
+            REQUIRE( blocks[i].next == AT::no_block );
+        }
+    }
+
+    Mgr::destroy();
+}
+
+// ─── C2: Block count consistency ────────────────────────────────────────────
+
+TEST_CASE( "structural: block count matches walk count", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 8 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 16 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+
+    REQUIRE( blocks.size() == Mgr::block_count() );
+
+    std::size_t free_count  = 0;
+    std::size_t alloc_count = 0;
+    for ( const auto& b : blocks )
+    {
+        if ( b.is_free )
+            ++free_count;
+        else
+            ++alloc_count;
+    }
+    REQUIRE( free_count == Mgr::free_block_count() );
+    REQUIRE( alloc_count == Mgr::alloc_block_count() );
+
+    Mgr::destroy();
+}
+
+// ─── C4: Tree ownership (root_offset match) ─────────────────────────────────
+
+TEST_CASE( "structural: root_offset consistency for all blocks", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    auto p1 = Mgr::allocate_typed<std::uint64_t>( 4 );
+    auto p2 = Mgr::allocate_typed<std::uint64_t>( 8 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+    Mgr::deallocate_typed( p1 );
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+
+    for ( const auto& b : blocks )
+    {
+        if ( b.is_free )
+        {
+            REQUIRE( b.weight == 0 );
+            REQUIRE( b.root_offset == 0 );
+        }
+        else
+        {
+            REQUIRE( b.weight > 0 );
+            REQUIRE( b.root_offset == b.idx );
+        }
+    }
+
+    Mgr::destroy();
+}
+
+// ─── C5: Domain membership consistency ──────────────────────────────────────
+
+TEST_CASE( "structural: system domains exist and have correct flags", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    REQUIRE( Mgr::has_domain( pmm::detail::kSystemDomainFreeTree ) );
+    REQUIRE( Mgr::has_domain( pmm::detail::kSystemDomainSymbols ) );
+    REQUIRE( Mgr::has_domain( pmm::detail::kSystemDomainRegistry ) );
+
+    REQUIRE( Mgr::find_domain_by_name( pmm::detail::kSystemDomainFreeTree ) != 0 );
+    REQUIRE( Mgr::find_domain_by_name( pmm::detail::kSystemDomainSymbols ) != 0 );
+    REQUIRE( Mgr::find_domain_by_name( pmm::detail::kSystemDomainRegistry ) != 0 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE( v.ok );
+
+    Mgr::destroy();
+}
+
+// ─── C6: Weight/state consistency for all blocks after operations ───────────
+
+TEST_CASE( "structural: weight/state consistent after alloc/dealloc mix", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    std::vector<typename Mgr::template pptr<std::uint32_t>> ptrs;
+    for ( int i = 0; i < 10; ++i )
+    {
+        auto p = Mgr::allocate_typed<std::uint32_t>( 4 + i * 2 );
+        REQUIRE( !p.is_null() );
+        ptrs.push_back( p );
+    }
+
+    for ( int i = 0; i < 10; i += 2 )
+    {
+        Mgr::deallocate_typed( ptrs[static_cast<std::size_t>( i )] );
+    }
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+
+    for ( const auto& b : blocks )
+    {
+        if ( b.weight == 0 )
+        {
+            REQUIRE( b.root_offset == 0 );
+        }
+        else
+        {
+            REQUIRE( b.root_offset == b.idx );
+        }
+    }
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE( v.ok );
+
+    Mgr::destroy();
+}
+
+// ─── C7: No overlapping blocks ──────────────────────────────────────────────
+
+TEST_CASE( "structural: no overlapping blocks", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 16 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 32 );
+    auto p3 = Mgr::allocate_typed<std::uint32_t>( 64 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+    REQUIRE( !p3.is_null() );
+    Mgr::deallocate_typed( p2 );
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+
+    for ( std::size_t i = 0; i + 1 < blocks.size(); ++i )
+    {
+        AT::index_type end_of_block = blocks[i].idx + blocks[i].total_granules;
+        REQUIRE( end_of_block == blocks[i + 1].idx );
+    }
+
+    Mgr::destroy();
+}
+
+// ─── C8: Total size equals sum of blocks ────────────────────────────────────
+
+TEST_CASE( "structural: total size equals sum of all block sizes", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    auto p1 = Mgr::allocate_typed<std::uint32_t>( 10 );
+    auto p2 = Mgr::allocate_typed<std::uint32_t>( 20 );
+    REQUIRE( !p1.is_null() );
+    REQUIRE( !p2.is_null() );
+    Mgr::deallocate_typed( p1 );
+
+    auto blocks = walk_blocks( Mgr::backend().base_ptr(), Mgr::total_size() );
+
+    std::size_t sum_granules = 0;
+    for ( const auto& b : blocks )
+        sum_granules += b.total_granules;
+
+    // First block starts at first_block_offset, not at 0
+    // The area before first_block_offset is Block_0 + ManagerHeader
+    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>(
+        Mgr::backend().base_ptr() + sizeof( pmm::Block<AT> ) );
+    AT::index_type total_granules = static_cast<AT::index_type>( Mgr::total_size() / AT::granule_size );
+    AT::index_type block_area    = total_granules - hdr->first_block_offset;
+    REQUIRE( sum_granules == block_area );
+
+    Mgr::destroy();
+}

--- a/tests/test_issue258_structural.cpp
+++ b/tests/test_issue258_structural.cpp
@@ -36,7 +36,7 @@ struct BlockInfo
 
 static std::vector<BlockInfo> walk_blocks( std::uint8_t* base, std::size_t total_size )
 {
-    using BlockState = pmm::BlockStateBase<AT>;
+    using BlockState              = pmm::BlockStateBase<AT>;
     constexpr std::size_t kGranSz = AT::granule_size;
 
     auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
@@ -282,10 +282,10 @@ TEST_CASE( "structural: total size equals sum of all block sizes", "[issue258][s
 
     // First block starts at first_block_offset, not at 0
     // The area before first_block_offset is Block_0 + ManagerHeader
-    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>(
-        Mgr::backend().base_ptr() + sizeof( pmm::Block<AT> ) );
+    auto* hdr =
+        reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( Mgr::backend().base_ptr() + sizeof( pmm::Block<AT> ) );
     AT::index_type total_granules = static_cast<AT::index_type>( Mgr::total_size() / AT::granule_size );
-    AT::index_type block_area    = total_granules - hdr->first_block_offset;
+    AT::index_type block_area     = total_granules - hdr->first_block_offset;
     REQUIRE( sum_granules == block_area );
 
     Mgr::destroy();

--- a/tests/test_issue258_structural.cpp
+++ b/tests/test_issue258_structural.cpp
@@ -3,8 +3,8 @@
  * @brief Structural invariant tests.
  *
  * Covers test matrix group C: linked-list topology, block count
- * consistency, weight/state consistency, no overlapping blocks,
- * total size equals sum of blocks.
+ * consistency, free-tree AVL balance, weight/state consistency,
+ * no overlapping blocks, total size equals sum of blocks.
  *
  * @see docs/test_matrix.md — C1–C8
  * @see docs/core_invariants.md — B1a, B1b, B3b, B4a, B4b
@@ -16,6 +16,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
+#include <map>
 #include <vector>
 
 using AT  = pmm::DefaultAddressTraits;
@@ -138,6 +139,72 @@ TEST_CASE( "structural: block count matches walk count", "[issue258][structural]
     }
     REQUIRE( free_count == Mgr::free_block_count() );
     REQUIRE( alloc_count == Mgr::alloc_block_count() );
+
+    Mgr::destroy();
+}
+
+// ─── C3: Free-tree AVL balance ──────────────────────────────────────────────
+
+TEST_CASE( "structural: free-tree AVL balance factor within [-1,+1]", "[issue258][structural]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+
+    // Create several free blocks of varying sizes to build a non-trivial tree.
+    std::vector<typename Mgr::template pptr<std::uint32_t>> ptrs;
+    for ( int i = 0; i < 12; ++i )
+    {
+        auto p = Mgr::allocate_typed<std::uint32_t>( 8 + i * 4 );
+        REQUIRE( !p.is_null() );
+        ptrs.push_back( p );
+    }
+    // Insert barriers to prevent coalescing of freed blocks.
+    std::vector<typename Mgr::template pptr<std::uint8_t>> barriers;
+    for ( int i = 0; i < 6; ++i )
+    {
+        auto b = Mgr::allocate_typed<std::uint8_t>( 16 );
+        REQUIRE( !b.is_null() );
+        barriers.push_back( b );
+    }
+    // Free every other block to populate the free tree with varied-size entries.
+    for ( int i = 0; i < 12; i += 2 )
+    {
+        Mgr::deallocate_typed( ptrs[static_cast<std::size_t>( i )] );
+    }
+
+    // Collect all free-tree nodes with their structural info.
+    std::map<std::ptrdiff_t, pmm::FreeBlockView> nodes;
+    Mgr::for_each_free_block( [&]( const pmm::FreeBlockView& v ) { nodes[v.offset] = v; } );
+
+    REQUIRE( nodes.size() >= 2 );
+
+    for ( const auto& [off, v] : nodes )
+    {
+        int left_h  = 0;
+        int right_h = 0;
+
+        if ( v.left_offset != -1 )
+        {
+            auto it = nodes.find( v.left_offset );
+            REQUIRE( it != nodes.end() );
+            left_h = it->second.avl_height;
+        }
+        if ( v.right_offset != -1 )
+        {
+            auto it = nodes.find( v.right_offset );
+            REQUIRE( it != nodes.end() );
+            right_h = it->second.avl_height;
+        }
+
+        int balance = left_h - right_h;
+        // AVL invariant: balance factor must be -1, 0, or +1.
+        REQUIRE( balance >= -1 );
+        REQUIRE( balance <= 1 );
+
+        // Stored height must equal max(left_h, right_h) + 1.
+        int expected_h = ( ( left_h > right_h ) ? left_h : right_h ) + 1;
+        REQUIRE( v.avl_height == expected_h );
+    }
 
     Mgr::destroy();
 }

--- a/tests/test_issue258_verify_behavior.cpp
+++ b/tests/test_issue258_verify_behavior.cpp
@@ -1,0 +1,247 @@
+/**
+ * @file test_issue258_verify_behavior.cpp
+ * @brief Verify/repair behavior tests.
+ *
+ * Covers test matrix group E: diagnostics reflect real action,
+ * verify is idempotent, repair is idempotent, verify clean after repair.
+ *
+ * @see docs/test_matrix.md — E4–E8
+ * @see docs/verify_repair_contract.md — operational contract
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using AT  = pmm::DefaultAddressTraits;
+using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25840>;
+
+static void setup_clean( std::size_t arena = 64 * 1024 )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( arena ) );
+}
+
+// ─── E4: Diagnostics reflect real action ────────────────────────────────────
+
+TEST_CASE( "verify_behavior: diagnostics reflect verify-only action", "[issue258][verify]" )
+{
+    setup_clean();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          orig    = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + 77 );
+
+    pmm::VerifyResult v = Mgr::verify();
+    REQUIRE_FALSE( v.ok );
+    REQUIRE( v.mode == pmm::RecoveryMode::Verify );
+
+    // All entries must have NoAction (verify never repairs)
+    for ( std::size_t i = 0; i < v.entry_count; ++i )
+    {
+        REQUIRE( v.entries[i].action == pmm::DiagnosticAction::NoAction );
+    }
+
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+TEST_CASE( "verify_behavior: diagnostics reflect load/repair action", "[issue258][verify]" )
+{
+    using MgrA = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25841>;
+    using MgrB = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25842>;
+
+    const char*       kFile = "test_issue258_vb_repair.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( MgrA::create( arena ) );
+    auto p = MgrA::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset
+    std::uint8_t* base    = MgrA::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          blk_idx = static_cast<AT::index_type>(
+        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 333 );
+
+    REQUIRE( pmm::save_manager<MgrA>( kFile ) );
+    MgrA::destroy();
+
+    REQUIRE( MgrB::create( arena ) );
+    pmm::VerifyResult result;
+    REQUIRE( pmm::load_manager_from_file<MgrB>( kFile, result ) );
+
+    REQUIRE( result.mode == pmm::RecoveryMode::Repair );
+
+    // At least one entry should have Repaired or Rebuilt action
+    bool found_repair = false;
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+    {
+        if ( result.entries[i].action == pmm::DiagnosticAction::Repaired ||
+             result.entries[i].action == pmm::DiagnosticAction::Rebuilt )
+        {
+            found_repair = true;
+            break;
+        }
+    }
+    REQUIRE( found_repair );
+
+    MgrB::destroy();
+    std::remove( kFile );
+}
+
+// ─── E5: Verify is idempotent ───────────────────────────────────────────────
+
+TEST_CASE( "verify_behavior: verify is idempotent on clean image", "[issue258][verify]" )
+{
+    setup_clean();
+
+    auto p = Mgr::allocate_typed<std::uint32_t>( 16 );
+    REQUIRE( !p.is_null() );
+
+    pmm::VerifyResult v1 = Mgr::verify();
+    pmm::VerifyResult v2 = Mgr::verify();
+    pmm::VerifyResult v3 = Mgr::verify();
+
+    REQUIRE( v1.ok );
+    REQUIRE( v2.ok );
+    REQUIRE( v3.ok );
+    REQUIRE( v1.violation_count == v2.violation_count );
+    REQUIRE( v2.violation_count == v3.violation_count );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "verify_behavior: verify is idempotent on corrupted image", "[issue258][verify]" )
+{
+    setup_clean();
+
+    auto p = Mgr::allocate_typed<std::uint64_t>( 4 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt root_offset
+    std::uint8_t* base    = Mgr::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          orig    = pmm::BlockStateBase<AT>::get_root_offset( blk_raw );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig + 55 );
+
+    pmm::VerifyResult v1 = Mgr::verify();
+    pmm::VerifyResult v2 = Mgr::verify();
+
+    REQUIRE_FALSE( v1.ok );
+    REQUIRE_FALSE( v2.ok );
+    REQUIRE( v1.violation_count == v2.violation_count );
+    REQUIRE( v1.entry_count == v2.entry_count );
+
+    for ( std::size_t i = 0; i < v1.entry_count; ++i )
+    {
+        REQUIRE( v1.entries[i].type == v2.entries[i].type );
+        REQUIRE( v1.entries[i].action == v2.entries[i].action );
+    }
+
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, orig );
+    Mgr::destroy();
+}
+
+// ─── E6: Repair is idempotent (verify clean after repair) ───────────────────
+
+TEST_CASE( "verify_behavior: verify clean after load repair", "[issue258][verify]" )
+{
+    using MgrC = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25843>;
+    using MgrD = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25844>;
+
+    const char*       kFile = "test_issue258_vb_clean.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( MgrC::create( arena ) );
+
+    // Create several blocks, deallocate some, create fragmentation
+    auto a1 = MgrC::allocate_typed<std::uint32_t>( 10 );
+    auto a2 = MgrC::allocate_typed<std::uint32_t>( 20 );
+    auto a3 = MgrC::allocate_typed<std::uint32_t>( 30 );
+    REQUIRE( !a1.is_null() );
+    REQUIRE( !a2.is_null() );
+    REQUIRE( !a3.is_null() );
+    MgrC::deallocate_typed( a2 );
+
+    REQUIRE( pmm::save_manager<MgrC>( kFile ) );
+    MgrC::destroy();
+
+    REQUIRE( MgrD::create( arena ) );
+    pmm::VerifyResult load_result;
+    REQUIRE( pmm::load_manager_from_file<MgrD>( kFile, load_result ) );
+
+    // Verify once => should be clean
+    pmm::VerifyResult v1 = MgrD::verify();
+    REQUIRE( v1.ok );
+
+    // Verify again => still clean (idempotent)
+    pmm::VerifyResult v2 = MgrD::verify();
+    REQUIRE( v2.ok );
+    REQUIRE( v2.violation_count == 0 );
+
+    MgrD::destroy();
+    std::remove( kFile );
+}
+
+// ─── E8: Verify after repair shows clean state ─────────────────────────────
+
+TEST_CASE( "verify_behavior: verify after repair shows clean state", "[issue258][verify]" )
+{
+    using MgrE = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25845>;
+    using MgrF = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25846>;
+
+    const char*       kFile = "test_issue258_vb_afterrepair.dat";
+    const std::size_t arena = 64 * 1024;
+
+    REQUIRE( MgrE::create( arena ) );
+    auto p = MgrE::allocate_typed<std::uint64_t>( 8 );
+    REQUIRE( !p.is_null() );
+
+    // Corrupt block state before save
+    std::uint8_t* base    = MgrE::backend().base_ptr();
+    std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
+    void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
+    auto          blk_idx = static_cast<AT::index_type>(
+        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 999 );
+
+    REQUIRE( pmm::save_manager<MgrE>( kFile ) );
+    MgrE::destroy();
+
+    REQUIRE( MgrF::create( arena ) );
+    pmm::VerifyResult load_result;
+    REQUIRE( pmm::load_manager_from_file<MgrF>( kFile, load_result ) );
+
+    // Load must have found violations
+    REQUIRE_FALSE( load_result.ok );
+    REQUIRE( load_result.violation_count > 0 );
+
+    // But after repair, verify shows clean
+    pmm::VerifyResult post = MgrF::verify();
+    REQUIRE( post.ok );
+    REQUIRE( post.violation_count == 0 );
+
+    // Allocator still works after repair
+    auto q = MgrF::allocate_typed<std::uint32_t>( 4 );
+    REQUIRE( !q.is_null() );
+    MgrF::deallocate_typed( q );
+
+    MgrF::destroy();
+    std::remove( kFile );
+}

--- a/tests/test_issue258_verify_behavior.cpp
+++ b/tests/test_issue258_verify_behavior.cpp
@@ -74,8 +74,7 @@ TEST_CASE( "verify_behavior: diagnostics reflect load/repair action", "[issue258
     std::uint8_t* base    = MgrA::backend().base_ptr();
     std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
     void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
-    auto          blk_idx = static_cast<AT::index_type>(
-        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    auto          blk_idx = static_cast<AT::index_type>( p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
     pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 333 );
 
     REQUIRE( pmm::save_manager<MgrA>( kFile ) );
@@ -217,8 +216,7 @@ TEST_CASE( "verify_behavior: verify after repair shows clean state", "[issue258]
     std::uint8_t* base    = MgrE::backend().base_ptr();
     std::size_t   usr_off = static_cast<std::size_t>( p.offset() ) * AT::granule_size;
     void*         blk_raw = base + usr_off - sizeof( pmm::Block<AT> );
-    auto          blk_idx = static_cast<AT::index_type>(
-        p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
+    auto          blk_idx = static_cast<AT::index_type>( p.offset() - sizeof( pmm::Block<AT> ) / AT::granule_size );
     pmm::BlockStateBase<AT>::set_root_offset_of( blk_raw, blk_idx + 999 );
 
     REQUIRE( pmm::save_manager<MgrE>( kFile ) );


### PR DESCRIPTION
## Summary

Closes netkeep80/PersistMemoryManager#258

Adds a comprehensive test matrix covering 6 test groups with 36 new test cases across 6 test files, plus a test map document.

### Deliverables

1. **`docs/test_matrix.md`** — full test coverage map organized by group (A–F), listing what each test checks, which invariant it covers, and what mode (verify/load) is exercised.

2. **6 new test suites:**

| File | Group | Tests | Coverage |
|------|-------|-------|----------|
| `test_issue258_bootstrap.cpp` | A. Bootstrap | 6 | Preset configs (Cache, Embedded, EmbeddedStatic, SmallEmbedded), memory stats consistency, minimal arena |
| `test_issue258_reload.cpp` | B. Reload | 5 | Different base address, multi-preset round-trip, user domain survival, pstringview persistence |
| `test_issue258_structural.cpp` | C. Structural | 8 | Linked-list topology, block count, free-tree AVL balance, root_offset, domain membership, weight/state, no-overlap, total-size sum |
| `test_issue258_corruption.cpp` | D. Corruption | 12 | All 8 ViolationTypes, multiple simultaneous, repair via load, out-of-range indices |
| `test_issue258_verify_behavior.cpp` | E. Verify/Repair | 6 | Diagnostics accuracy, verify idempotency (clean + corrupted), repair idempotency, post-repair allocator |
| `test_issue258_property.cpp` | F. Property | 6 | Random alloc/dealloc+verify, save/load round-trip, corruption injection, repeated verify, mixed pstringview, multi-reload cycles |

3. **Changelog fragment** for automated release.

### Key design decisions

- **Deterministic seeds** for property tests (reproducible failures).
- **InstanceId separation** — every manager instantiation uses a unique InstanceId to avoid static state collisions.
- **Restore-after-corrupt** pattern — all corruption tests restore the original value before `destroy()` to avoid interference.
- **No modifications to library code** — tests only exercise existing public API and documented internal accessors (`BlockStateBase`, `ForestDomainRegistry`).

### Review feedback addressed

- **B7 "different base address" test** (feedback from @netkeep80): Reworked so both managers are alive simultaneously, guaranteeing separate heap buffers. Added explicit `REQUIRE( base1_ptr != base2_ptr )` assertion.
- **C3 "free-tree AVL balance" test** (feedback from @netkeep80): Added the missing test that was documented in test_matrix.md but not implemented. The test walks all free-tree nodes and verifies AVL balance factor ∈ [-1, +1] and height consistency for every node.

### Verification

- All 82 tests pass locally (76 existing + 6 new executables).
- clang-format clean.
- All files under 1500-line limit (largest: 396 lines).

## Test plan

- [x] All new tests compile without errors on GCC 13
- [x] All 82 tests pass via `ctest --output-on-failure`
- [x] clang-format compliant
- [x] File size within limits
- [x] B7 test reliably exercises relocation (asserts different base addresses)
- [x] C3 test verifies AVL balance invariant for free-tree nodes
- [ ] CI passes on all platforms (Linux/macOS/Windows)
- [ ] Sanitizer builds pass (ASan, UBSan, TSan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)