### PR TITLE
docs: prepare storage seams and mutation ordering (#259)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T21:24:46.306Z for PR creation at branch issue-259-bde6708a70d5 for issue https://github.com/netkeep80/PersistMemoryManager/issues/259

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T21:24:46.306Z for PR creation at branch issue-259-bde6708a70d5 for issue https://github.com/netkeep80/PersistMemoryManager/issues/259

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(PersistMemoryManager VERSION 0.52.0 LANGUAGES CXX)
+project(PersistMemoryManager VERSION 0.53.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/changelog.d/20260411_120000_storage_seams.md
+++ b/changelog.d/20260411_120000_storage_seams.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+- `docs/storage_seams.md` — canonical design document defining storage-layer extension points (seams) for encryption, compression, journaling, and crash-consistency support
+- `docs/mutation_ordering.md` — write ordering rules for all critical mutation paths with crash-consistency analysis, trust anchor identification, and partial-state tolerance specification

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,8 @@ Single entry point for all PMM documentation. Each topic is covered by exactly o
 | [Verify/Repair Contract](verify_repair_contract.md) | Operational boundary between verify, repair, and load — frozen contract for tasks 08–10 |
 | [Diagnostics Taxonomy](diagnostics_taxonomy.md) | Violation types, severity levels, repair policies, diagnostic entry format |
 | [Validation Model](validation_model.md) | Low-level pointer and block validation: cheap vs full modes, conversion paths, error categories |
+| [Storage Seams](storage_seams.md) | Extension points for encryption, compression, journaling; operating modes; separation from upper layers |
+| [Mutation Ordering](mutation_ordering.md) | Write ordering rules for all critical mutations; crash-consistency analysis; trust anchors vs. derived data |
 | [Atomic Writes](atomic_writes.md) | Write criticality analysis, block state transitions, interruption guarantees |
 | [Thread Safety](thread_safety.md) | Lock policies, operation contracts, resolve() fast path, concurrent patterns |
 
@@ -44,4 +46,5 @@ For newcomers, the recommended path is:
 5. **[API Reference](api_reference.md)** — use the library
 6. **[Bootstrap](bootstrap.md)** / **[Recovery](recovery.md)** — understand lifecycle guarantees
 7. **[Verify/Repair Contract](verify_repair_contract.md)** / **[Diagnostics Taxonomy](diagnostics_taxonomy.md)** — understand verify/repair boundary
-8. **[Thread Safety](thread_safety.md)** — for concurrent usage
+8. **[Storage Seams](storage_seams.md)** / **[Mutation Ordering](mutation_ordering.md)** — understand extension points and crash consistency
+9. **[Thread Safety](thread_safety.md)** — for concurrent usage

--- a/docs/mutation_ordering.md
+++ b/docs/mutation_ordering.md
@@ -338,11 +338,21 @@ guaranteed by the bootstrap sequence (Block_0 is the first block).
 ### M5c. `magic`
 
 Written once during `init_layout()` (`layout_mixin.inc:30`). Zeroed on
-`destroy()` (`layout_mixin.inc:410`).
+`destroy()` (`persist_memory_manager.h:410`).
 
-**Ordering rule:** `magic` must be the last field written during
-bootstrap (signals that the header is complete) and the first field
-zeroed during destroy (signals that the image is invalidated).
+`magic` is an **identity / format check**, not a bootstrap-completion
+marker. In the current implementation `init_layout()` writes `magic`
+**first** (immediately after `memset`-zeroing the header), followed by
+`total_size`, `first_block_offset`, and the remaining header fields.
+A crash after the `magic` write but before the rest of `init_layout()`
+or the full bootstrap sequence completes would leave an image that
+passes the magic check yet is only partially initialized.
+
+**Current ordering rule:** `magic` is the first header field written
+during `init_layout()` and the first field zeroed during `destroy()`.
+On `load()`, `magic` is checked in Phase 1 to reject images that were
+never initialized or that have already been destroyed — it does **not**
+guarantee that bootstrap ran to completion.
 
 ### M5d. `total_size` and `granule_size`
 
@@ -463,5 +473,5 @@ Phase 7: validate_bootstrap_invariants_unlocked()
 | **O5** | `recompute_counters()` before `rebuild_free_tree()` | Free-tree rebuild depends on correct block states |
 | **O6** | `rebuild_free_tree()` before forest registry bootstrap | Bootstrap allocates blocks via the free-tree |
 | **O7** | Trust anchors must be written before dependent data | `first_block_offset` before blocks; `total_size` before expansion |
-| **O8** | `magic` is the last bootstrap write and first destroy write | Signals image validity boundary |
+| **O8** | `magic` is the first header write during `init_layout()` and first zeroed on `destroy()` | Identity / format check — does not signal bootstrap completion |
 | **O9** | Atomic rename is the last step in `save_manager()` | File integrity — old file is never partially overwritten |

--- a/docs/mutation_ordering.md
+++ b/docs/mutation_ordering.md
@@ -1,0 +1,453 @@
+# Mutation Ordering Rules
+
+## Document status
+
+Canonical specification for the order of persistent-state mutations in
+PersistMemoryManager. For each critical mutation path this document
+specifies: the exact write sequence, which partial states are tolerable,
+which are corruption, and what verify/repair observes after an
+interrupted update.
+
+This document is the companion to [storage_seams.md](storage_seams.md)
+and builds on the write-criticality analysis in [atomic_writes.md](atomic_writes.md).
+
+Related documents:
+
+- storage seams: [storage_seams.md](storage_seams.md)
+- write criticality: [atomic_writes.md](atomic_writes.md)
+- core invariants: [core_invariants.md](core_invariants.md)
+- verify/repair contract: [verify_repair_contract.md](verify_repair_contract.md)
+- diagnostics taxonomy: [diagnostics_taxonomy.md](diagnostics_taxonomy.md)
+- recovery: [recovery.md](recovery.md)
+- bootstrap: [bootstrap.md](bootstrap.md)
+
+---
+
+## Terminology
+
+- **CRITICAL write** — interruption after this write, before the next,
+  leaves the image in a state that requires `repair_linked_list()` or
+  `recover_state()` to fix.
+- **NON-CRITICAL write** — interruption after this write is safe because
+  the affected data is rebuilt from scratch on `load()` (AVL tree,
+  counters, `last_block_offset`).
+- **Trust anchor** — data that `load()` trusts unconditionally and cannot
+  reconstruct: `magic`, `total_size`, `granule_size`, `next_offset` chain,
+  `first_block_offset`.
+- **Derived data** — data reconstructed deterministically from the trust
+  anchors: counters, AVL tree, `prev_offset`, `last_block_offset`.
+
+---
+
+## M1. Root updates
+
+### M1a. `hdr->root_offset` — forest registry pointer
+
+The header's `root_offset` field points to the `ForestDomainRegistry`
+block. It is written in two contexts:
+
+**Context 1: `create()` bootstrap**
+
+| Step | Write | Critical? | Code |
+|------|-------|-----------|------|
+| 1 | Allocate registry block (modifies free-tree, counters, linked list) | See M4 (allocation) | `forest_domain_mixin.inc:275` |
+| 2 | Initialize registry (magic, version, domain_count) | NON-CRITICAL | `forest_domain_mixin.inc:293–296` |
+| 3 | Lock block permanently (`node_type = kNodeReadOnly`) | NON-CRITICAL | `forest_domain_mixin.inc:300` |
+| 4 | `W(hdr->root_offset, registry_granule_idx)` | **CRITICAL** | `forest_domain_mixin.inc:306` |
+| 5 | Register system domains in registry | See M2 | `forest_domain_mixin.inc:309–326` |
+
+**Interruption between steps 3 and 4:**
+- Registry block is allocated and locked but `hdr->root_offset` is still
+  `no_block`.
+- **Partial state:** tolerable. On next `load()`,
+  `validate_or_bootstrap_forest_registry_unlocked()` detects the missing
+  registry and creates a new one.
+- **Verify observation:** `ForestRegistryMissing`.
+- **Repair action:** `Repaired` — bootstrap fresh registry.
+
+**Interruption between steps 4 and 5:**
+- `hdr->root_offset` points to a valid registry, but system domains are
+  not yet registered.
+- **Partial state:** tolerable. `validate_or_bootstrap_forest_registry_unlocked()`
+  re-registers missing system domains.
+- **Verify observation:** `ForestDomainMissing`.
+- **Repair action:** `Repaired` — register missing domains.
+
+**Context 2: `load()` recovery**
+
+During `load()`, `hdr->root_offset` may be updated if the existing
+registry is missing or invalid. The update follows the same bootstrap
+sequence. Since `load()` holds a unique write lock, no concurrent
+mutations are possible.
+
+### M1b. `ForestDomainRecord::root_offset` — per-domain root
+
+Each domain in the `ForestDomainRegistry` has a `root_offset` field
+pointing to the root of that domain's AVL tree.
+
+**Updated by:** `set_domain_root()` (`persist_memory_manager.h:928`).
+
+| Step | Write | Critical? |
+|------|-------|-----------|
+| 1 | `W(rec->root_offset, new_root.offset())` | **CRITICAL** |
+
+This is a single atomic write to a `uint32_t` field. On most
+architectures, a naturally aligned 4-byte write is atomic. However, PMM
+does not rely on hardware atomicity — the forest registry is a system
+block that persists across saves, and if the write is interrupted:
+
+- **Partial state:** the domain root may be stale (pointing to the
+  previous root or containing a partial value).
+- **Verify observation:** no direct detection — domain root validity is
+  not checked by the current verify pass.
+- **Repair:** not automatically repairable. Upper-layer journal (see
+  [storage_seams.md](storage_seams.md) Seam 5) is needed for domain-root
+  atomicity across crash.
+
+---
+
+## M2. Registry updates
+
+### M2a. Domain registration
+
+Adding a new domain to the `ForestDomainRegistry`.
+
+| Step | Write | Critical? | Code |
+|------|-------|-----------|------|
+| 1 | `W(rec->binding_id, id)` | **CRITICAL** | `forest_domain_mixin.inc:163` |
+| 2 | `W(rec->binding_kind, kind)` | **CRITICAL** | `forest_domain_mixin.inc:164` |
+| 3 | `W(rec->root_offset, root)` | **CRITICAL** | `forest_domain_mixin.inc:165` |
+| 4 | `W(rec->flags, flags)` | **CRITICAL** | `forest_domain_mixin.inc:166` |
+| 5 | `W(rec->symbol_offset, 0)` | NON-CRITICAL | `forest_domain_mixin.inc:167` |
+| 6 | `W(reg->domain_count, count + 1)` | **CRITICAL** | `forest_domain_mixin.inc:178` |
+
+**Interruption between steps 1–5 and step 6:**
+- Domain record is partially or fully written, but `domain_count` has
+  not incremented — the new domain is invisible.
+- **Partial state:** tolerable. The partially written record occupies a
+  slot that will be overwritten on the next registration attempt.
+- **Verify observation:** `ForestDomainMissing` (if it was a required
+  system domain).
+- **Repair action:** `Repaired` — re-register the missing domain.
+
+**Interruption after step 6:**
+- Domain is fully registered.
+
+### M2b. Domain update (existing domain)
+
+Updating an existing domain's fields (e.g., changing root, flags).
+
+| Step | Write | Critical? | Code |
+|------|-------|-----------|------|
+| 1 | `W(rec->flags, new_flags)` | **CRITICAL** | `forest_domain_mixin.inc:147` |
+| 2 | `W(rec->binding_kind, new_kind)` | **CRITICAL** | `forest_domain_mixin.inc:148` |
+| 3 | `W(rec->root_offset, new_root)` | **CRITICAL** | `forest_domain_mixin.inc:149` |
+
+Each field update is independent. Partial update leaves a mix of old
+and new values.
+
+- **Partial state:** partially updated domain record.
+- **Verify observation:** `ForestDomainFlagsMissing` (if system flags
+  were being set).
+- **Repair action:** `Repaired` — re-apply correct flags on `load()`.
+
+---
+
+## M3. Dictionary / symbol updates
+
+### M3a. Symbol interning (`intern_symbol_unlocked`)
+
+Interning a new symbol in the `system/symbols` pstringview dictionary.
+
+| Step | Write | Critical? | Code |
+|------|-------|-----------|------|
+| 1 | Allocate block for pstringview | See M4 | `forest_domain_mixin.inc:206` |
+| 2 | Initialize pstringview header (length, flags) | **CRITICAL** | `forest_domain_mixin.inc:213` |
+| 3 | Copy string content into block | **CRITICAL** | `forest_domain_mixin.inc:214–215` |
+| 4 | AVL insert into symbol tree (updates tree links) | NON-CRITICAL | `forest_domain_mixin.inc:223–230` |
+| 5 | Lock block permanently (`kNodeReadOnly`) | NON-CRITICAL | `forest_domain_mixin.inc:218` |
+| 6 | Update `symbol_domain->root_offset` (AVL root) | **CRITICAL** | `forest_domain_mixin.inc:229` |
+
+**Interruption between steps 1 and 2:**
+- Block is allocated but not initialized as a pstringview.
+- **Partial state:** allocated block with garbage content. On `load()`,
+  the block remains allocated (`weight > 0, root_offset == own_idx`).
+- **Verify observation:** none (block appears as a normal allocated block).
+- **Repair:** not automatically repairable — leaked block. The upper
+  layer can detect this via `for_each_block()` audit.
+
+**Interruption between steps 3 and 4:**
+- pstringview block is initialized but not in the AVL tree.
+- **Partial state:** symbol is not discoverable via tree search but
+  occupies a permanently locked block.
+- **Verify observation:** none (block is valid).
+- **Repair:** on next `load()`, `bootstrap_system_symbols_unlocked()`
+  re-interns system symbols, which will find the existing block via
+  content comparison and re-insert it.
+
+**Interruption after step 6:**
+- Symbol is fully interned.
+
+### M3b. Bootstrap symbol sequence
+
+During bootstrap, symbols are interned in a fixed order
+(`forest_domain_mixin.inc:245–249`):
+
+1. `system/free_tree`
+2. `system/symbols`
+3. `system/domain_registry`
+4. `type/forest_registry`
+5. `type/forest_domain_record`
+6. `type/pstringview`
+7. `service/legacy_root`
+8. `service/domain_root`
+9. `service/domain_symbol`
+
+This order is deterministic — identical `create()` calls produce
+identical symbol layouts (invariant D1d).
+
+---
+
+## M4. Free-tree updates
+
+### M4a. Allocation with splitting
+
+The full write sequence is documented in [atomic_writes.md](atomic_writes.md)
+Algorithm 1. The ordering rules relevant to crash consistency:
+
+| Phase | Writes | Critical? | Recovery if interrupted |
+|-------|--------|-----------|------------------------|
+| 1 | Remove block from AVL | NON-CRITICAL | AVL rebuilt on `load()` |
+| 2 | Initialize new split-block header | NON-CRITICAL | New block invisible |
+| 3 | Link new block: `W(new->next, old_next)` | **CRITICAL** | See below |
+| 4 | Link new block: `W(new->prev, blk_idx)` | **CRITICAL** | See below |
+| 5 | Update old next: `W(old_next->prev, new_idx)` | **CRITICAL** | `repair_linked_list()` |
+| 6 | Update split block: `W(blk->next, new_idx)` | **CRITICAL** | `repair_linked_list()` |
+| 7 | Update `last_block_offset` | NON-CRITICAL | Rebuilt on `load()` |
+| 8 | Update counters | NON-CRITICAL | Recomputed on `load()` |
+| 9 | Insert new free block into AVL | NON-CRITICAL | AVL rebuilt on `load()` |
+| 10 | Mark block allocated: `W(blk->weight, N)` + `W(blk->root_offset, blk_idx)` | **CRITICAL** | `recover_state()` |
+| 11 | Clear AVL fields of allocated block | NON-CRITICAL | AVL rebuilt on `load()` |
+| 12 | Update counters | NON-CRITICAL | Recomputed on `load()` |
+
+**Critical ordering rule:** steps 3–6 must occur in this order. The
+linked-list forward chain (`next_offset`) is the trust anchor. Steps 3–4
+prepare the new block's links before it becomes visible. Steps 5–6 splice
+the new block into the list.
+
+**Interruption between steps 6 and 10:**
+- New block is linked, but the original block is still marked free
+  (`weight == 0`).
+- **Partial state:** tolerable. On `load()`, the block is treated as
+  free and returned to the free list. User data from the partially
+  completed allocation is lost.
+- **Verify observation:** no violation (block is in a valid free state).
+
+### M4b. Deallocation with coalescing
+
+The full write sequence is documented in [atomic_writes.md](atomic_writes.md)
+Algorithm 2.
+
+| Phase | Writes | Critical? | Recovery if interrupted |
+|-------|--------|-----------|------------------------|
+| 1 | Mark free: `W(blk->weight, 0)` + `W(blk->root_offset, 0)` | **CRITICAL** | `recover_state()` |
+| 2 | Update counters | NON-CRITICAL | Recomputed on `load()` |
+| 3 | Coalesce with next: remove next from AVL | NON-CRITICAL | AVL rebuilt |
+| 4 | Coalesce: `W(blk->next, nxt->next)` | **CRITICAL** | `repair_linked_list()` |
+| 5 | Coalesce: `W(nxt_nxt->prev, blk_idx)` | **CRITICAL** | `repair_linked_list()` |
+| 6 | Coalesce: `memset(nxt_header, 0)` | **CRITICAL** | Merged area covered by new block |
+| 7 | Coalesce with prev: analogous to steps 3–6 | See above | See above |
+| 8 | Insert result into AVL | NON-CRITICAL | AVL rebuilt |
+
+**Critical ordering rule:** step 1 must precede all coalescing. The
+block must be marked free before any neighbor merging begins. This
+ensures that if coalescing is interrupted, the freed block is in a
+valid free state.
+
+**Interruption between steps 4 and 5 (forward coalesce):**
+- `blk->next_offset` is updated but `nxt_nxt->prev_offset` is stale.
+- **Partial state:** linked-list forward/backward inconsistency.
+- **Verify observation:** `PrevOffsetMismatch`.
+- **Repair action:** `Repaired` by `repair_linked_list()`.
+
+### M4c. Free-tree AVL operations
+
+All AVL insertions and removals (rotations, height updates, parent
+pointer updates) are **NON-CRITICAL**. The entire AVL tree is rebuilt
+from scratch during `load()` via `rebuild_free_tree()`.
+
+**Ordering rule:** AVL mutations have no ordering requirements relative
+to each other. They may be interrupted at any point.
+
+### M4d. `rebuild_free_tree()` sequence
+
+During `load()`, the free-tree is rebuilt in a strict order
+(`allocator_policy.h:303–329`):
+
+| Step | Write | Purpose |
+|------|-------|---------|
+| 1 | `W(hdr->free_tree_root, no_block)` | Reset AVL root |
+| 2 | `W(hdr->last_block_offset, no_block)` | Reset last-block tracker |
+| 3 | For each block: reset AVL fields (left/right/parent/height) | Clear stale tree links |
+| 4 | For each block: `recover_state()` | Fix weight/root_offset inconsistencies |
+| 5 | For each free block: `avl_insert()` | Rebuild AVL tree |
+| 6 | Track and set `last_block_offset` | Restore last-block pointer |
+
+**Ordering rule:** step 4 (recover_state) must precede step 5
+(avl_insert) — a block's free/allocated status must be correct before
+it is considered for AVL insertion.
+
+---
+
+## M5. Header / state transitions
+
+### M5a. Counter updates
+
+The four counters (`block_count`, `free_count`, `alloc_count`,
+`used_size`) are updated during allocation, deallocation, splitting,
+and coalescing. All counter updates are **NON-CRITICAL** because
+`recompute_counters()` rebuilds them from scratch on `load()`.
+
+**Ordering rule:** no ordering constraints. Counters may be stale after
+any interruption.
+
+### M5b. `first_block_offset`
+
+Set during `init_layout()` (`layout_mixin.inc:32`) and during `expand()`
+(`layout_mixin.inc:135`). This is a trust anchor — it is the starting
+point of the linked-list traversal.
+
+**Ordering rule:** `first_block_offset` must be written before any block
+that depends on it is linked into the list. In practice, this is
+guaranteed by the bootstrap sequence (Block_0 is the first block).
+
+### M5c. `magic`
+
+Written once during `init_layout()` (`layout_mixin.inc:30`). Zeroed on
+`destroy()` (`layout_mixin.inc:410`).
+
+**Ordering rule:** `magic` must be the last field written during
+bootstrap (signals that the header is complete) and the first field
+zeroed during destroy (signals that the image is invalidated).
+
+### M5d. `total_size` and `granule_size`
+
+Written during `init_layout()`. Updated during `expand()` (total_size
+only). These are trust anchors validated on `load()`.
+
+**Ordering rule:** `total_size` must be updated before any new blocks
+are created in the expanded region.
+
+---
+
+## M6. Load repair sequence
+
+The `load()` repair phases have a strict ordering:
+
+```
+Phase 1: Validate header (magic, total_size, granule_size)
+  │  ↓ fail → Aborted
+Phase 2: Reset runtime fields (owns_memory, prev_total_size)
+  │
+Phase 3: repair_linked_list()
+  │  → fixes prev_offset using next_offset as trust anchor
+  │
+Phase 4: recompute_counters()
+  │  → recalculates block_count, free_count, alloc_count, used_size
+  │  → depends on correct linked list from Phase 3
+  │
+Phase 5: rebuild_free_tree()
+  │  → resets all AVL fields
+  │  → calls recover_state() for each block
+  │  → inserts free blocks into AVL
+  │  → depends on correct linked list (Phase 3) and counters (Phase 4)
+  │
+Phase 6: validate_or_bootstrap_forest_registry_unlocked()
+  │  → validates or re-creates the forest registry
+  │  → registers system domains
+  │  → interns system symbols
+  │  → depends on working allocator (Phase 5)
+  │
+Phase 7: validate_bootstrap_invariants_unlocked()
+         → final consistency check
+```
+
+**Ordering rules:**
+- Phase 3 before Phase 4: counters depend on a correct linked list.
+- Phase 4 before Phase 5: `rebuild_free_tree()` uses the linked list
+  and correct block states.
+- Phase 5 before Phase 6: forest registry bootstrap requires a
+  functioning allocator (to allocate registry and symbol blocks).
+- Phase 7 is always last: validates the entire post-repair state.
+
+---
+
+## Crash-consistency summary
+
+### Trust anchors (not reconstructible)
+
+| Data | Where | Why trusted |
+|------|-------|-------------|
+| `magic` | ManagerHeader | Image identity; if wrong, image is rejected |
+| `total_size` | ManagerHeader | Defines address space boundary |
+| `granule_size` | ManagerHeader | Defines addressing granularity |
+| `first_block_offset` | ManagerHeader | Start of linked-list traversal |
+| `next_offset` chain | Every block header | Forward linked-list traversal; `repair_linked_list()` trusts this |
+
+### Derived data (reconstructed on `load()`)
+
+| Data | Reconstructed by | Source of truth |
+|------|-------------------|-----------------|
+| `prev_offset` | `repair_linked_list()` | `next_offset` chain |
+| `block_count` | `recompute_counters()` | Linked-list walk |
+| `free_count` | `recompute_counters()` | Linked-list walk (weight == 0) |
+| `alloc_count` | `recompute_counters()` | Linked-list walk (weight > 0) |
+| `used_size` | `recompute_counters()` | Linked-list walk |
+| `last_block_offset` | `rebuild_free_tree()` | Linked-list walk |
+| AVL tree (all fields) | `rebuild_free_tree()` | Free blocks from linked-list walk |
+| Block state (root_offset) | `recover_state()` | Determined by `weight` |
+
+### Partial states by operation
+
+| Operation | Interrupted at | Partial state | Tolerable? | Repair |
+|-----------|---------------|---------------|------------|--------|
+| **Allocate** | Before linking new block | New block invisible | Yes | No repair needed |
+| **Allocate** | During linked-list splice | Forward/backward mismatch | Yes | `repair_linked_list()` |
+| **Allocate** | After splice, before mark allocated | Block remains free | Yes | Returned to free list |
+| **Deallocate** | Before mark free | Block remains allocated | Yes | No action (not freed) |
+| **Deallocate** | After mark free, before coalesce | Free block not in AVL | Yes | `rebuild_free_tree()` |
+| **Coalesce** | During linked-list update | Forward/backward mismatch | Yes | `repair_linked_list()` |
+| **Coalesce** | After list update, before header zero | Old header unreachable | Yes | Covered by merged block |
+| **Bootstrap** | Before `root_offset` update | No registry visible | Yes | Bootstrap on `load()` |
+| **Bootstrap** | After registry, before domains | Missing system domains | Yes | Re-register on `load()` |
+| **Symbol intern** | Before AVL insert | Block allocated but not in tree | Yes | Re-intern on `load()` |
+| **Symbol intern** | After AVL insert | Fully interned | Yes | No repair needed |
+| **Save** | Before atomic rename | Old file intact | Yes | `.tmp` file can be deleted |
+| **Save** | After atomic rename | New file complete | Yes | No repair needed |
+
+### Corruption states (not tolerable)
+
+| Condition | Detection | Recovery |
+|-----------|-----------|----------|
+| `magic` overwritten | `load()` Phase 1 | **None** — image rejected |
+| `total_size` wrong | `load()` Phase 1 | **None** — image rejected |
+| `granule_size` wrong | `load()` Phase 1 | **None** — image rejected |
+| `next_offset` corrupted | `repair_linked_list()` walks into invalid memory | **None** — linked-list traversal terminates |
+| `first_block_offset` wrong | `load()` starts at wrong location | **None** — entire linked-list traversal is wrong |
+| Block header in the middle of user data | Not detected | **None** — structural assumption violated |
+
+---
+
+## Ordering rules summary
+
+| Rule | Description | Rationale |
+|------|-------------|-----------|
+| **O1** | New block links (`next`, `prev`) must be set before splicing into list | Prevents dangling pointers in linked list |
+| **O2** | `blk->weight` = 0 must precede coalescing with neighbors | Block must be in free state before merging |
+| **O3** | `recover_state()` must precede `avl_insert()` during rebuild | Block state must be correct before tree insertion |
+| **O4** | `repair_linked_list()` before `recompute_counters()` | Counters depend on correct list traversal |
+| **O5** | `recompute_counters()` before `rebuild_free_tree()` | Free-tree rebuild depends on correct block states |
+| **O6** | `rebuild_free_tree()` before forest registry bootstrap | Bootstrap allocates blocks via the free-tree |
+| **O7** | Trust anchors must be written before dependent data | `first_block_offset` before blocks; `total_size` before expansion |
+| **O8** | `magic` is the last bootstrap write and first destroy write | Signals image validity boundary |
+| **O9** | Atomic rename is the last step in `save_manager()` | File integrity — old file is never partially overwritten |

--- a/docs/mutation_ordering.md
+++ b/docs/mutation_ordering.md
@@ -162,11 +162,15 @@ Interning a new symbol in the `system/symbols` pstringview dictionary.
 | Step | Write | Critical? | Code |
 |------|-------|-----------|------|
 | 1 | Allocate block for pstringview | See M4 | `forest_domain_mixin.inc:206` |
-| 2 | Initialize pstringview header (length, flags) | **CRITICAL** | `forest_domain_mixin.inc:213` |
+| 2 | Initialize pstringview header (length) | **CRITICAL** | `forest_domain_mixin.inc:213` |
 | 3 | Copy string content into block | **CRITICAL** | `forest_domain_mixin.inc:214–215` |
-| 4 | AVL insert into symbol tree (updates tree links) | NON-CRITICAL | `forest_domain_mixin.inc:223–230` |
+| 4 | Initialize AVL node fields | NON-CRITICAL | `forest_domain_mixin.inc:217` |
 | 5 | Lock block permanently (`kNodeReadOnly`) | NON-CRITICAL | `forest_domain_mixin.inc:218` |
-| 6 | Update `symbol_domain->root_offset` (AVL root) | **CRITICAL** | `forest_domain_mixin.inc:229` |
+| 6 | AVL insert into symbol tree (updates tree links and `symbol_domain->root_offset`) | NON-CRITICAL (tree) / **CRITICAL** (root) | `forest_domain_mixin.inc:223–230` |
+
+Note: the AVL tree itself is NON-CRITICAL (rebuilt on `load()`), but the
+`symbol_domain->root_offset` update embedded in the `avl_insert()` call
+is **CRITICAL** — it is the only persistent pointer to the symbol tree root.
 
 **Interruption between steps 1 and 2:**
 - Block is allocated but not initialized as a pstringview.
@@ -176,14 +180,24 @@ Interning a new symbol in the `system/symbols` pstringview dictionary.
 - **Repair:** not automatically repairable — leaked block. The upper
   layer can detect this via `for_each_block()` audit.
 
-**Interruption between steps 3 and 4:**
-- pstringview block is initialized but not in the AVL tree.
-- **Partial state:** symbol is not discoverable via tree search but
-  occupies a permanently locked block.
-- **Verify observation:** none (block is valid).
-- **Repair:** on next `load()`, `bootstrap_system_symbols_unlocked()`
-  re-interns system symbols, which will find the existing block via
-  content comparison and re-insert it.
+**Interruption between steps 3 and 6 (after content copy, before AVL insert):**
+- pstringview block is allocated, initialized, and permanently locked,
+  but not inserted into the symbol AVL tree.
+- **Partial state:** the block is valid and permanently locked but
+  unreachable via tree search. On next `load()`,
+  `bootstrap_system_symbols_unlocked()` calls `intern_symbol_unlocked()`
+  for each system symbol. That function searches only the AVL tree
+  (`avl_find()`); it does not scan blocks by content. Since the orphaned
+  block is not in the tree, it will not be found — a **new** block is
+  allocated for the same string, and the orphaned block remains as an
+  **unreachable permanently locked leak**.
+- **Verify observation:** none (orphaned block appears as a valid
+  allocated block).
+- **Repair:** not automatically repairable. The orphaned symbol block
+  persists as a small leak. An upper-layer audit via `for_each_block()`
+  could detect permanently locked blocks that are not reachable from any
+  domain tree. A future recovery scan for orphaned symbol blocks would
+  be needed to reclaim them.
 
 **Interruption after step 6:**
 - Symbol is fully interned.
@@ -420,7 +434,7 @@ Phase 7: validate_bootstrap_invariants_unlocked()
 | **Coalesce** | After list update, before header zero | Old header unreachable | Yes | Covered by merged block |
 | **Bootstrap** | Before `root_offset` update | No registry visible | Yes | Bootstrap on `load()` |
 | **Bootstrap** | After registry, before domains | Missing system domains | Yes | Re-register on `load()` |
-| **Symbol intern** | Before AVL insert | Block allocated but not in tree | Yes | Re-intern on `load()` |
+| **Symbol intern** | Before AVL insert | Block allocated but not in tree (orphaned leak) | Yes | Leaked — new block allocated on `load()` |
 | **Symbol intern** | After AVL insert | Fully interned | Yes | No repair needed |
 | **Save** | Before atomic rename | Old file intact | Yes | `.tmp` file can be deleted |
 | **Save** | After atomic rename | New file complete | Yes | No repair needed |

--- a/docs/storage_seams.md
+++ b/docs/storage_seams.md
@@ -1,0 +1,388 @@
+# Storage Seams
+
+## Document status
+
+Canonical design document for storage-layer extension points (seams) in
+PersistMemoryManager. Defines where future capabilities — encryption,
+compression, journaling, crash-consistency enhancements — can be introduced
+without breaking the existing architecture.
+
+This document completes the task-10 design surface by consolidating
+storage-related concerns currently distributed across
+[atomic_writes.md](atomic_writes.md), [recovery.md](recovery.md),
+[bootstrap.md](bootstrap.md), and [architecture.md](architecture.md).
+
+Related documents:
+
+- mutation ordering: [mutation_ordering.md](mutation_ordering.md)
+- core invariants: [core_invariants.md](core_invariants.md)
+- verify/repair contract: [verify_repair_contract.md](verify_repair_contract.md)
+- diagnostics taxonomy: [diagnostics_taxonomy.md](diagnostics_taxonomy.md)
+- recovery: [recovery.md](recovery.md)
+- atomic writes: [atomic_writes.md](atomic_writes.md)
+
+---
+
+## Design principles
+
+1. **PMM remains a type-erased storage kernel.** Seams must not introduce
+   `pjson` semantics, application-level transaction logic, or database
+   business rules into the PMM layer.
+2. **Seams are extension points, not implementations.** This document
+   identifies *where* hooks can be inserted and *what contracts* they must
+   satisfy. Actual encryption, compression, or journaling implementations
+   are out of scope.
+3. **Structural metadata must remain accessible.** Any transformation
+   (encryption, compression) that hides block headers or linked-list
+   pointers breaks verify, repair, and the entire recovery model. Seams
+   must preserve structural recoverability.
+4. **No premature abstraction.** Seam points are documented for future
+   use. No new interfaces, virtual functions, or template parameters are
+   introduced until a concrete implementation requires them.
+
+---
+
+## Operating modes
+
+PMM images can be used in three distinct modes. Each mode has different
+requirements for storage seams.
+
+### Mode 1: Normal persistent image operation
+
+The primary mode. A single process owns the image (in-memory via
+`HeapStorage` or memory-mapped via `MMapStorage`). Mutations happen
+in-place. Persistence is achieved via periodic `save_manager()` calls
+or through OS-level `mmap` writeback.
+
+**Seam requirements:**
+- Per-block payload processing (encryption/compression) is feasible
+  because the process has exclusive write access.
+- Whole-image processing at save time is feasible.
+- Online structural recovery (`load()` repair) must work on the
+  in-memory image without external metadata.
+
+### Mode 2: Backup / export mode
+
+The image is serialized to a file via `save_manager()` for archival,
+transfer, or cold storage. The file is a complete snapshot — no
+incremental updates.
+
+**Seam requirements:**
+- Whole-image encryption/compression is the natural fit: process the
+  entire buffer before writing to file, reverse before loading.
+- CRC32 (already implemented) provides integrity verification.
+- Per-block processing is possible but adds complexity for backup use.
+
+### Mode 3: Future journal-assisted mode
+
+A write-ahead journal records mutations before they are applied to the
+main image. This enables true atomic multi-block operations and
+point-in-time recovery.
+
+**Seam requirements:**
+- Journal entries must capture pre-images or logical operations.
+- The journal layer sits *above* PMM — PMM provides the mutation
+  ordering rules (see [mutation_ordering.md](mutation_ordering.md));
+  the journal layer uses those rules to record and replay operations.
+- PMM must not become a transaction engine. The journal is an external
+  concern that consumes PMM's mutation stream.
+
+---
+
+## Seam points
+
+### Seam 1: Whole-image processing (save/load pipeline)
+
+**Location in pipeline:**
+
+```
+save path:  PMM image (in-memory) → [SEAM: transform] → write to file
+load path:  read from file → [SEAM: reverse-transform] → PMM image (in-memory)
+```
+
+**Current implementation** (`io.h`):
+
+```
+save_manager<MgrT>(filename):
+  1. Zero hdr->crc32
+  2. Compute CRC32 over entire image
+  3. Store CRC32 in hdr->crc32
+  4. Write image to filename.tmp
+  5. Atomic rename filename.tmp → filename
+
+load_manager_from_file<MgrT>(filename):
+  1. Read file into backend buffer
+  2. Verify CRC32
+  3. Call Mgr::load(result) — 5-phase repair
+```
+
+**Seam insertion points:**
+
+| Point | Location | Hook | Contract |
+|-------|----------|------|----------|
+| S1a | After CRC32 computation, before file write | `transform_image(buffer, size)` | Must be reversible. Output size may differ from input (compression). Buffer must be self-describing (include metadata for reverse transform). |
+| S1b | After file read, before CRC32 verify | `reverse_transform_image(buffer, size)` | Must restore exact original bytes. On failure: report error, do not proceed to `load()`. |
+
+**What this enables:**
+- Whole-image encryption (AES-GCM, ChaCha20-Poly1305).
+- Whole-image compression (LZ4, zstd).
+- Combined encrypt-then-compress or compress-then-encrypt.
+
+**Constraints:**
+- The transform must be invertible — `reverse(transform(image)) == image`.
+- CRC32 must be computed on the *original* (pre-transform) image so that
+  post-`load()` verification works against the structural data.
+- Alternatively, CRC32 can be computed on the *transformed* image if the
+  reverse transform is verified by its own integrity mechanism (e.g.,
+  AEAD authentication tag).
+
+---
+
+### Seam 2: Per-block / payload processing
+
+**Location in pipeline:**
+
+```
+allocate path:  user data → [SEAM: encode payload] → write to block
+resolve path:   read from block → [SEAM: decode payload] → return to user
+```
+
+**Current implementation:**
+
+Block payloads are stored as raw bytes. `resolve<T>()` returns a direct
+pointer to the block's user-data region. There is no encode/decode step.
+
+**Seam insertion points:**
+
+| Point | Location | Hook | Contract |
+|-------|----------|------|----------|
+| S2a | After `allocate_typed<T>()`, before returning pointer | `encode_payload(block_ptr, size)` | Block header must remain untouched. Only user-data region may be transformed. |
+| S2b | Inside `resolve<T>()`, before returning pointer | `decode_payload(block_ptr, size)` | Must return pointer to decoded data. May use a thread-local decode buffer for read-only access. |
+
+**What this enables:**
+- Per-object encryption (encrypt user data, leave headers in clear).
+- Per-object compression.
+- Transparent data-at-rest protection.
+
+**Constraints:**
+- **Block headers must remain in cleartext.** The linked-list pointers
+  (`prev_offset`, `next_offset`), state fields (`weight`, `root_offset`),
+  and AVL tree fields are required for structural recovery. Encrypting
+  them would make `repair_linked_list()` and `rebuild_free_tree()`
+  impossible.
+- **`pstringview` blocks are permanently locked and used as AVL nodes.**
+  Their tree fields and string content must remain readable for the
+  symbol dictionary to function. Per-block encryption of `pstringview`
+  blocks requires careful consideration — the string comparison function
+  used during AVL traversal must operate on decrypted data.
+- **Overhead per block:** encryption/compression adds per-block metadata
+  (nonce, tag, compressed-size). This must fit within the existing
+  granule-aligned block layout or require a layout extension.
+
+---
+
+### Seam 3: Metadata that must remain in cleartext
+
+Regardless of what encryption or compression is applied, the following
+metadata must remain accessible for structural recovery:
+
+| Metadata | Location | Why |
+|----------|----------|-----|
+| `ManagerHeader` (64 bytes) | Block_0 user data | Magic validation, size checks, `first_block_offset` — required by `load()` phase 1. |
+| `prev_offset` / `next_offset` | Every block header | Linked-list traversal — required by `repair_linked_list()` and `recompute_counters()`. |
+| `weight` / `root_offset` | Every block header | Block state determination — required by `recover_state()` and `rebuild_free_tree()`. |
+| `node_type` | Every block header | `kNodeReadOnly` check — prevents deallocation of system blocks. |
+| `ForestDomainRegistry` | Allocated block pointed to by `hdr->root_offset` | Registry magic/version validation, domain enumeration. |
+| `free_tree_root` | ManagerHeader | Not strictly required (rebuilt on `load()`), but useful for hot-path validation. |
+
+**Implication:** whole-image encryption is simpler than per-block
+encryption because it avoids the complexity of selectively encrypting
+payloads while preserving structural headers. Per-block encryption
+requires a clear boundary between "structural header" (always cleartext)
+and "user payload" (encrypted).
+
+---
+
+### Seam 4: Online vs. backup-oriented processing
+
+| Aspect | Online (Mode 1) | Backup (Mode 2) |
+|--------|-----------------|------------------|
+| Transform timing | On every `resolve()` / write | Once at save, once at load |
+| Performance sensitivity | High — on hot path | Low — batch operation |
+| Partial failure | Must handle per-block errors | All-or-nothing |
+| Metadata visibility | Headers always in cleartext | Entire file may be encrypted |
+| Recovery | `load()` repair on in-memory image | `reverse_transform()` then `load()` |
+
+**Design choice:** backup-oriented processing (Seam 1) should be
+implemented first because it has minimal impact on the hot path and
+does not require changes to `resolve<T>()`. Online per-block processing
+(Seam 2) is a future optimization for data-at-rest protection.
+
+---
+
+## Seam points for crash-consistency support
+
+### Seam 5: Mutation journal hook
+
+**Location:**
+
+```
+mutation path:  [SEAM: pre-mutation hook] → apply mutation → [SEAM: post-mutation hook]
+```
+
+**What this enables:**
+- Write-ahead logging (WAL): record pre-images before mutations.
+- Redo logging: record logical operations after mutations.
+- Point-in-time recovery by replaying or undoing journal entries.
+
+**Seam insertion points:**
+
+| Point | When | Data available |
+|-------|------|----------------|
+| S5a | Before `allocate_from_block()` begins | Block index, requested size |
+| S5b | Before `deallocate_block()` begins | Block index, block state |
+| S5c | Before `coalesce()` begins | Block index, neighbor indices |
+| S5d | Before `repair_linked_list()` | Full pre-repair image state |
+| S5e | Before `rebuild_free_tree()` | Full pre-rebuild image state |
+
+**Contract for journal hook:**
+- The hook receives a description of the mutation that is about to happen.
+- The hook may write to an external journal (file, memory-mapped segment).
+- The hook must not modify the PMM image.
+- If the hook fails (e.g., journal full), the mutation must not proceed.
+- The journal is owned by the upper layer, not by PMM.
+
+**Constraints:**
+- PMM does not implement the journal. PMM provides the seam; the journal
+  implementation is an upper-layer concern.
+- The mutation ordering rules in [mutation_ordering.md](mutation_ordering.md)
+  define the exact sequence of writes for each operation. A journal
+  implementation must follow these rules to correctly record mutations.
+
+---
+
+### Seam 6: Snapshot hook
+
+**Location:**
+
+```
+save path:  [SEAM: pre-snapshot hook] → save_manager() → [SEAM: post-snapshot hook]
+```
+
+**What this enables:**
+- Consistent snapshots: notify upper layer before/after a full image save.
+- Incremental snapshots: upper layer tracks dirty pages between snapshots.
+- Journal truncation: after a successful snapshot, journal entries before
+  the snapshot point can be discarded.
+
+**Contract:**
+- Pre-snapshot hook: upper layer may flush pending operations.
+- Post-snapshot hook: upper layer may truncate the journal.
+- Hooks must not modify the PMM image.
+
+---
+
+## Separation from upper layers
+
+This section formally documents what storage seams must NOT do.
+
+### PMM does not become a transaction engine
+
+Storage seams provide hooks for external transaction implementations.
+PMM itself does not implement:
+- `begin()` / `commit()` / `rollback()` semantics.
+- Multi-operation atomicity (beyond single-allocation crash consistency).
+- Conflict detection or serialization guarantees beyond its lock policy.
+
+Transaction semantics belong to upper layers (`pjson_db`, AVM) that
+consume PMM's mutation stream through the journal hook (Seam 5).
+
+### PMM does not absorb `pjson` semantics
+
+Storage seams are type-erased. Encryption, compression, and journaling
+hooks operate on raw byte buffers and block indices — they do not
+interpret user-data structure or schema.
+
+The fact that a block contains a JSON node, a pmap entry, or a
+pstringview symbol is irrelevant to the storage seam layer.
+
+### PMM does not merge with `pjson_db` or AVM
+
+Storage seams are internal to PMM's persistence pipeline. They do not
+create dependencies on:
+- `pjson_db` query engine or indexing.
+- AVM execution model or instruction set.
+- Application-level domain objects.
+
+PMM remains independently testable, deployable, and usable without any
+upper-layer component.
+
+---
+
+## Impact on existing guarantees
+
+### Verify / repair compatibility
+
+| Seam | Impact on verify | Impact on repair |
+|------|-----------------|-----------------|
+| S1 (whole-image) | None — verify operates on decoded image | None — repair operates on decoded image |
+| S2 (per-block) | Verify must skip encrypted payloads (header-only check) | Repair must preserve encrypted payloads during linked-list repair |
+| S5 (journal) | None — journal is external | Journal may enable undo-based repair (future) |
+
+### Pointer validation compatibility
+
+The validation model ([validation_model.md](validation_model.md)) operates
+on block headers and granule indices. All validation checks target
+structural metadata that must remain in cleartext (Seam 3). Therefore:
+
+- Cheap validation (fast-path) is unaffected by any seam.
+- Full validation (verify-level) is unaffected by whole-image seams.
+- Full validation may need to skip per-block payload checks if payloads
+  are encrypted.
+
+### Test matrix compatibility
+
+Existing tests ([test_matrix.md](test_matrix.md)) operate on unencrypted,
+uncompressed images. Storage seams do not invalidate existing tests.
+New tests for each seam implementation should cover:
+
+- Round-trip: `transform → save → load → reverse_transform → verify`.
+- Crash simulation: interrupt at each seam point, verify recovery.
+- Corruption: tamper with transformed data, verify detection.
+
+---
+
+## Summary of seam points
+
+| Seam | Granularity | Pipeline stage | Enables |
+|------|-------------|----------------|---------|
+| S1a/S1b | Whole image | Save/load file I/O | Image encryption, image compression |
+| S2a/S2b | Per block | Allocate/resolve | Payload encryption, payload compression |
+| S3 | N/A (constraint) | All stages | Structural metadata always in cleartext |
+| S4 | N/A (design choice) | Mode selection | Online vs. backup processing strategy |
+| S5a–S5e | Per mutation | Before each critical operation | Write-ahead logging, redo logging |
+| S6 | Per snapshot | Before/after save_manager | Journal truncation, incremental snapshots |
+
+---
+
+## Minimal contract for upper journal/snapshot layer
+
+An upper-layer journal/snapshot implementation that consumes PMM seams
+must satisfy these minimal requirements:
+
+1. **Journal durability:** journal entries must be durable (fsync'd)
+   before the corresponding PMM mutation proceeds.
+2. **Ordering fidelity:** journal entries must be written in the same
+   order as PMM mutation steps (see [mutation_ordering.md](mutation_ordering.md)).
+3. **Snapshot consistency:** a snapshot represents a consistent PMM state
+   — all mutations before the snapshot are fully applied, none after.
+4. **Recovery protocol:**
+   - On crash: read journal entries after the last snapshot.
+   - For each incomplete mutation: either redo (if post-commit marker
+     found) or undo (if no commit marker).
+   - After replay: call `Mgr::load(result)` to verify structural
+     consistency.
+5. **Independence:** the journal must not depend on PMM internals beyond
+   the documented seam hooks and mutation ordering rules. PMM may change
+   internal algorithms as long as seam contracts and mutation ordering
+   are preserved.

--- a/docs/storage_seams.md
+++ b/docs/storage_seams.md
@@ -113,7 +113,7 @@ save_manager<MgrT>(filename):
 load_manager_from_file<MgrT>(filename):
   1. Read file into backend buffer
   2. Verify CRC32
-  3. Call Mgr::load(result) — 5-phase repair
+  3. Call Mgr::load(result) — 7-phase load/repair (see mutation_ordering.md M6)
 ```
 
 **Seam insertion points:**


### PR DESCRIPTION
## Summary

Closes netkeep80/PersistMemoryManager#259

Adds two canonical design documents to prepare PMM for future encryption, compression, journaling, and crash-consistency layers — without premature implementation.

### Deliverables

1. **`docs/storage_seams.md`** — canonical design document for storage-layer extension points:
   - 3 operating modes (normal persistent, backup/export, future journal-assisted)
   - 6 seam points: whole-image processing (S1), per-block payload processing (S2), metadata cleartext constraints (S3), online vs. backup modes (S4), mutation journal hook (S5), snapshot hook (S6)
   - Explicit list of metadata that must remain in cleartext for structural recovery
   - Separation from upper layers (no pjson semantics, no transaction engine, no pjson_db/AVM merge)
   - Minimal contract for upper journal/snapshot layer
   - Impact analysis on verify/repair, pointer validation, and test matrix

2. **`docs/mutation_ordering.md`** — write ordering rules for all critical mutations:
   - **M1**: Root updates (header root_offset, per-domain root_offset)
   - **M2**: Registry updates (domain registration, domain update)
   - **M3**: Dictionary/symbol updates (intern_symbol, bootstrap symbol sequence)
   - **M4**: Free-tree updates (allocation with splitting, deallocation with coalescing, AVL operations, rebuild sequence)
   - **M5**: Header/state transitions (counters, first_block_offset, magic, total_size)
   - **M6**: Load repair sequence (7-phase ordering with dependencies)
   - Trust anchors vs. derived data classification
   - Partial-state tolerance for every interruption point
   - 9 ordering rules (O1–O9) summarized

3. **Updated `docs/index.md`** — new documents in canonical set and reading order.

4. **Changelog fragment** and version bump `0.52.0` → `0.53.0`.

### Acceptance criteria verification

- [x] One canonical doc for storage seams exists (`docs/storage_seams.md`)
- [x] Mutation ordering described for critical updates (registry, dictionary, free-tree, root)
- [x] Crash consistency analyzed at registry/dictionary/free-tree/root level
- [x] PMM remains type-erased storage kernel (no pjson semantics introduced)
- [x] Result prepares ground for future journal/snapshot layer without implementing it
- [x] Seam points defined for: image encryption, block/object payload encryption hooks, compression hooks, partial-write/crash-consistency support

### Verification

- All 82 tests pass with no regressions.
- No source code changes to library headers — docs-only (plus version bump).
- No new public API surface added.

## Test plan

- [x] `cmake -B build && cmake --build build` — compiles cleanly
- [x] `ctest --test-dir build --output-on-failure` — all 82 tests pass
- [x] No uncommitted changes
- [ ] CI passes on fork
- [ ] Review completeness of seam points and mutation ordering against issue requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)