### PR TITLE
feat: introduce repo-guard in audit mode

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -32,7 +32,8 @@ jobs:
         run: node /tmp/repo-guard/src/repo-guard.mjs
 
       - name: Run PR policy check (audit)
-        run: node /tmp/repo-guard/src/repo-guard.mjs check-pr
+        run: |
+          node /tmp/repo-guard/src/repo-guard.mjs check-pr || echo "::warning::repo-guard audit found issues (non-blocking)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_DIR: ${{ github.workspace }}/.git

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -15,7 +15,10 @@ jobs:
           fetch-depth: 0
 
       - name: Clone repo-guard
-        run: git clone --depth 1 https://github.com/netkeep80/repo-guard.git /tmp/repo-guard
+        run: |
+          git clone https://github.com/netkeep80/repo-guard.git /tmp/repo-guard
+          cd /tmp/repo-guard
+          git checkout 539484836dcc5b3bdf5ea099cfabd9e65ccb2a0d
 
       - uses: actions/setup-node@v4
         with:
@@ -32,8 +35,7 @@ jobs:
         run: node /tmp/repo-guard/src/repo-guard.mjs
 
       - name: Run PR policy check (audit)
-        run: |
-          node /tmp/repo-guard/src/repo-guard.mjs check-pr || echo "::warning::repo-guard audit found issues (non-blocking)"
+        run: node /tmp/repo-guard/src/repo-guard.mjs check-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_DIR: ${{ github.workspace }}/.git

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,39 @@
+name: repo-guard audit
+
+on:
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  audit:
+    name: repo-guard audit check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone repo-guard
+        run: git clone --depth 1 https://github.com/netkeep80/repo-guard.git /tmp/repo-guard
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install repo-guard dependencies
+        working-directory: /tmp/repo-guard
+        run: npm ci
+
+      - name: Inject PMM policy into repo-guard
+        run: cp repo-policy.json /tmp/repo-guard/repo-policy.json
+
+      - name: Validate repo-policy.json
+        run: node /tmp/repo-guard/src/repo-guard.mjs
+
+      - name: Run PR policy check (audit)
+        run: node /tmp/repo-guard/src/repo-guard.mjs check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_DIR: ${{ github.workspace }}/.git
+          GIT_WORK_TREE: ${{ github.workspace }}

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T14:47:07.493Z for PR creation at branch issue-267-3c26ab4d59bf for issue https://github.com/netkeep80/PersistMemoryManager/issues/267

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T14:47:07.493Z for PR creation at branch issue-267-3c26ab4d59bf for issue https://github.com/netkeep80/PersistMemoryManager/issues/267

--- a/changelog.d/20260412_120000_repo_guard_audit.md
+++ b/changelog.d/20260412_120000_repo_guard_audit.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+- Initial `repo-policy.json` for repo-guard audit integration
+- GitHub Actions workflow (`repo-guard.yml`) running repo-guard checks in non-blocking audit mode on PRs

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,0 +1,71 @@
+{
+  "policy_format_version": "0.3.0",
+  "repository_kind": "library",
+  "paths": {
+    "forbidden": [
+      "docs/phase-*",
+      "docs/phase[0-9]*",
+      "*.bak",
+      "*.tmp",
+      "*.orig",
+      "imgui.ini",
+      "demo.bat",
+      "test.bat",
+      "demo.md"
+    ],
+    "canonical_docs": [
+      "README.md",
+      "CONTRIBUTING.md",
+      "CHANGELOG.md",
+      "docs/index.md",
+      "docs/architecture.md",
+      "docs/api_reference.md",
+      "docs/pmm_avl_forest.md",
+      "docs/block_and_treenode_semantics.md",
+      "docs/bootstrap.md",
+      "docs/free_tree_forest_policy.md",
+      "docs/recovery.md",
+      "docs/thread_safety.md",
+      "docs/mutation_ordering.md",
+      "docs/storage_seams.md",
+      "docs/core_invariants.md",
+      "docs/diagnostics_taxonomy.md",
+      "docs/validation_model.md",
+      "docs/verify_repair_contract.md",
+      "docs/repository_shape.md",
+      "docs/deletion_policy.md",
+      "docs/comment_policy.md"
+    ],
+    "governance_paths": [
+      "repo-policy.json",
+      "CONTRIBUTING.md",
+      "docs/repository_shape.md",
+      "docs/deletion_policy.md",
+      "docs/comment_policy.md"
+    ],
+    "operational_paths": [
+      ".claude/**",
+      ".gitkeep",
+      "tasks/**"
+    ]
+  },
+  "diff_rules": {
+    "max_new_docs": 3,
+    "max_new_files": 20,
+    "max_net_added_lines": 3000
+  },
+  "content_rules": [
+    {
+      "id": "no-todo-without-issue",
+      "glob": "**/*.{h,cpp,inc}",
+      "mode": "added_lines",
+      "forbid_regex": ["TODO(?!\\(#\\d+\\))"]
+    }
+  ],
+  "cochange_rules": [
+    {
+      "if_changed": ["include/**"],
+      "must_change_any": ["tests/**"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First production rollout of [repo-guard](https://github.com/netkeep80/repo-guard) on PersistMemoryManager in **audit mode** (non-blocking).

Fixes netkeep80/PersistMemoryManager#267

## What this PR adds

- **`repo-policy.json`** — initial conservative policy for PMM:
  - Forbidden paths: temp/backup files (`*.bak`, `*.tmp`, `*.orig`), process noise (`imgui.ini`), misplaced root files (`demo.bat`, `test.bat`, `demo.md`)
  - Canonical docs whitelist: all 17 existing docs in `docs/` plus root `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`
  - Governance paths: `repo-policy.json`, `CONTRIBUTING.md`, and policy docs
  - Operational paths excluded from checks: `.claude/**`, `.gitkeep`, `tasks/**`
  - Diff budgets: 3 new docs, 20 new files, 3000 net added lines
  - Content rule: no `TODO` without issue number in C++ source files
  - Co-change rule: `include/**` changes require `tests/**` changes
- **`.github/workflows/repo-guard.yml`** — audit workflow:
  - Runs on all PRs
  - Validates `repo-policy.json` against repo-guard schema
  - Runs `check-pr` for contract extraction and diff enforcement
  - **Pinned to repo-guard commit `539484836dcc`** for reproducible CI runs
  - Uses `continue-on-error: true` at job level — audit failures surface as visible soft-fail / neutral outcome, but do not block merge
  - No `|| echo` masking — step failure is transparent
  - Uses `GIT_DIR`/`GIT_WORK_TREE` env vars to direct git operations to the PMM checkout
- **Changelog fragment** for the addition

## Review feedback addressed

1. **repo-guard pinned to specific commit** (`539484836dcc5b3bdf5ea099cfabd9e65ccb2a0d`) — CI is now reproducible and won't drift with upstream repo-guard changes
2. **Removed `|| echo` fallback** — audit failures are no longer masked as success; `continue-on-error: true` at job level provides the non-blocking behavior while keeping failures visible as soft-fail

## Audit mode rollout notes

This is an **observational rollout**, not final enforcement:
- Checks run and produce visible results in CI logs
- Merge is **not blocked** by repo-guard failures
- False positives are expected and will inform policy tuning
- Goal: establish a baseline for which rules work well and which need adjustment

### Change contract convention

PRs to PMM should include a change contract block (fenced as `repo-guard-json`) in the PR body containing fields: `change_type`, `scope`, `budgets`, `must_touch`, `must_not_touch`, `expected_effects`, `overrides`.

Fallback: if no contract in PR body, repo-guard will look in the linked issue body.

## Success criteria

- [x] `repo-policy.json` exists and validates against repo-guard schema
- [x] `repo-guard.yml` workflow runs on PRs
- [x] `check-pr` executes contract extraction and diff enforcement
- [x] Job does not block merge (`continue-on-error: true`)
- [x] repo-guard pinned to specific commit for reproducibility
- [x] Audit failures visible as soft-fail (not masked)
- [ ] Audit findings from real PRs are collected for next iteration

## Out of scope

- Blocking enforcement
- Large governance documentation
- Custom contract formats
- CI architecture changes
- Final policy tuning

```repo-guard-json
{
  "change_type": "feature",
  "scope": [".github/workflows/**", "repo-policy.json", "changelog.d/**"],
  "budgets": {
    "max_new_files": 5,
    "max_new_docs": 1,
    "max_net_added_lines": 200
  },
  "must_touch": ["repo-policy.json"],
  "must_not_touch": ["LICENSE", "include/**", "tests/**"],
  "expected_effects": ["repo-guard runs in audit mode on PRs without blocking merge"],
  "overrides": []
}
```