### PR TITLE
fix: align PMM canonical docs/versioning with repo-guard audit baseline (#269)

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -1,0 +1,29 @@
+name: Docs Consistency
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "**/*.md"
+      - "CMakeLists.txt"
+      - "repo-policy.json"
+      - "scripts/check-docs-consistency.sh"
+      - ".github/workflows/docs-consistency.yml"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "**/*.md"
+      - "CMakeLists.txt"
+      - "repo-policy.json"
+      - "scripts/check-docs-consistency.sh"
+      - ".github/workflows/docs-consistency.yml"
+
+jobs:
+  docs-consistency:
+    name: Docs consistency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version and docs consistency
+        run: bash scripts/check-docs-consistency.sh

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T17:28:42.006Z for PR creation at branch issue-269-b2cdf45c281f for issue https://github.com/netkeep80/PersistMemoryManager/issues/269

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T17:28:42.006Z for PR creation at branch issue-269-b2cdf45c281f for issue https://github.com/netkeep80/PersistMemoryManager/issues/269

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![CI](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml/badge.svg)](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
-[![Version](https://img.shields.io/badge/version-0.26.0-green.svg)](CHANGELOG.md)
-[![Docs](https://img.shields.io/badge/docs-Doxygen-informational)](https://netkeep80.github.io/PersistMemoryManager/)
+[![Version](https://img.shields.io/badge/version-0.55.0-green.svg)](CHANGELOG.md)
 
 ## Обзор
 
@@ -866,17 +865,21 @@ cmake -B build && cmake --build build && ctest --test-dir build
 
 ## Документация
 
+Каноническая документация — Markdown-файлы в `docs/`.
 Полный указатель: **[docs/index.md](docs/index.md)**
 
-- [API Reference (Doxygen)](https://netkeep80.github.io/PersistMemoryManager/)
 - [PMM AVL-Forest](docs/pmm_avl_forest.md) — каноническая архитектурная модель
 - [Block and TreeNode Semantics](docs/block_and_treenode_semantics.md) — семантика полей
 - [Архитектура](docs/architecture.md) — слои, layout, алгоритмы
-- [API Reference (Markdown)](docs/api_reference.md) — справочник API
+- [API Reference](docs/api_reference.md) — справочник API
 - [Bootstrap](docs/bootstrap.md) — инициализация ПАП
 - [Recovery](docs/recovery.md) — восстановление после сбоев
 - [Thread Safety](docs/thread_safety.md) — потокобезопасность
 - [Changelog](CHANGELOG.md)
+
+**Doxygen** — вторичная автогенерируемая документация, доступна по адресу
+[netkeep80.github.io/PersistMemoryManager](https://netkeep80.github.io/PersistMemoryManager/).
+Она не является каноническим источником; при расхождениях приоритет у Markdown-документов.
 
 ## Лицензия
 

--- a/changelog.d/20260412_120000_docs_consistency.md
+++ b/changelog.d/20260412_120000_docs_consistency.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+- Synchronized README version badge (`0.26.0` → `0.55.0`) with CMakeLists.txt and CHANGELOG.md
+- Clarified Doxygen as secondary generated documentation; Markdown docs are the canonical surface
+- Added lightweight `docs-consistency` CI workflow to detect version and doc drift on markdown changes

--- a/scripts/check-docs-consistency.sh
+++ b/scripts/check-docs-consistency.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAILED=0
+
+# --- 1. Extract version from each canonical source ---
+
+# CMakeLists.txt: project(PersistMemoryManager VERSION X.Y.Z ...)
+cmake_version=$(grep -oP 'project\(PersistMemoryManager VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt) || {
+  echo "FAIL: could not extract version from CMakeLists.txt"
+  exit 1
+}
+
+# README.md: badge like version-X.Y.Z-green
+readme_version=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md) || {
+  echo "FAIL: could not extract version badge from README.md"
+  exit 1
+}
+
+# CHANGELOG.md: first ## [X.Y.Z] entry
+changelog_version=$(grep -oP '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1) || {
+  echo "FAIL: could not extract latest version from CHANGELOG.md"
+  exit 1
+}
+
+echo "CMakeLists.txt version: $cmake_version"
+echo "README.md badge version: $readme_version"
+echo "CHANGELOG.md latest version: $changelog_version"
+
+# --- 2. Check consistency ---
+
+if [ "$cmake_version" != "$readme_version" ]; then
+  echo "FAIL: README badge version ($readme_version) does not match CMakeLists.txt ($cmake_version)"
+  FAILED=1
+fi
+
+if [ "$cmake_version" != "$changelog_version" ]; then
+  echo "FAIL: CHANGELOG latest version ($changelog_version) does not match CMakeLists.txt ($cmake_version)"
+  FAILED=1
+fi
+
+# --- 3. Check that canonical docs listed in repo-policy.json exist ---
+
+if [ -f repo-policy.json ]; then
+  in_canonical=false
+  while IFS= read -r line; do
+    if echo "$line" | grep -q '"canonical_docs"'; then
+      in_canonical=true
+      continue
+    fi
+    if $in_canonical && echo "$line" | grep -q '^\s*\]'; then
+      in_canonical=false
+      continue
+    fi
+    if $in_canonical; then
+      doc_path=$(echo "$line" | grep -oP '"[^"]*\.md"' | tr -d '"')
+      if [ -n "$doc_path" ] && [ ! -f "$doc_path" ]; then
+        echo "FAIL: canonical doc listed in repo-policy.json does not exist: $doc_path"
+        FAILED=1
+      fi
+    fi
+  done < repo-policy.json
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "OK: all docs-consistency checks passed"
+else
+  echo ""
+  echo "Docs-consistency checks failed. Please fix the inconsistencies above."
+fi
+
+exit $FAILED


### PR DESCRIPTION
## Summary

Closes #269

Aligns the PMM canonical layer (README, versioning, documentation surface) before the next selective enforcement step. This is a cleanup-before-tightening task — repo-guard audit mode remains non-blocking and unchanged.

### Concrete observations fixed

1. **README version badge was stale** — `0.26.0` in README vs `0.55.0` in CMakeLists.txt and CHANGELOG.md. Fixed: badge now shows `0.55.0`.

2. **Doxygen status was ambiguous** — README had a Doxygen badge and listed Doxygen API Reference as the first documentation link, implying it was the primary surface. Fixed: Doxygen badge removed from header; Doxygen explicitly marked as secondary generated surface; Markdown docs declared as canonical.

3. **README doc surface was misaligned with repo-policy.json** — README listed "API Reference (Doxygen)" as primary and "(Markdown)" as secondary, contradicting `repo-policy.json` which lists only Markdown files as canonical. Fixed: doc section reconciled.

4. **Markdown-only changes were CI-invisible** — main CI (`ci.yml`) ignores `**/*.md`. Fixed: new lightweight `docs-consistency.yml` workflow triggers on markdown/version file changes and checks:
   - Version consistency across README badge, CMakeLists.txt, and latest CHANGELOG.md entry
   - All canonical docs listed in `repo-policy.json` actually exist on disk

5. **repo-guard audit mode unchanged** — no enforcement tightening in this PR.

## Changes

- `README.md` — version badge `0.26.0` → `0.55.0`; Doxygen badge removed; Documentation section reconciled with canonical Markdown surface; Doxygen explicitly demoted to secondary
- `.github/workflows/docs-consistency.yml` — new lightweight CI workflow for doc drift detection
- `scripts/check-docs-consistency.sh` — version and canonical-docs consistency checker
- `changelog.d/20260412_120000_docs_consistency.md` — changelog fragment

## Acceptance criteria verification

- [x] README.md, CMakeLists.txt, and latest CHANGELOG.md no longer disagree on version
- [x] Doxygen status explicitly reflected (secondary generated surface)
- [x] README no longer diverges from canonical documentation surface
- [x] Markdown-only canonical drift is CI-visible via docs-consistency check
- [x] repo-guard audit mode remains non-blocking (unchanged)
- [x] Implementation is compact (4 files changed)

## Test plan

- [x] `scripts/check-docs-consistency.sh` passes locally
- [x] Version consistency verified: README = CMakeLists.txt = CHANGELOG.md = `0.55.0`
- [x] All canonical docs from `repo-policy.json` exist on disk
- [ ] CI workflows pass on fork

```repo-guard-json
{
  "change_type": "chore",
  "scope": ["README.md", ".github/workflows/**", "scripts/**", "changelog.d/**"],
  "budgets": {
    "max_new_files": 3,
    "max_new_docs": 1,
    "max_net_added_lines": 200
  },
  "must_touch": ["README.md"],
  "must_not_touch": ["LICENSE", "include/**", "tests/**", "CMakeLists.txt"],
  "expected_effects": ["README version badge matches CMakeLists.txt; doc drift becomes CI-visible"],
  "overrides": []
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
