### PR TITLE
chore: roll out repo-guard reusable action baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-contract.yml
+++ b/.github/ISSUE_TEMPLATE/change-contract.yml
@@ -1,0 +1,34 @@
+name: Change contract
+description: Propose a change with a repo-guard YAML contract.
+title: "[change] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the proposed change and include a YAML change contract block.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should change and why?
+    validations:
+      required: true
+  - type: textarea
+    id: contract
+    attributes:
+      label: Change Contract
+      description: Paste a repo-guard YAML change contract block.
+      value: |
+        ```repo-guard-yaml
+        change_type: feature
+        scope:
+          - include/
+        budgets: {}
+        must_touch: []
+        must_not_touch:
+          - LICENSE
+        expected_effects:
+          - Describe the expected effect
+        ```
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+Describe the change and the user-visible effect.
+
+## Change Contract
+
+Keep this YAML block aligned with the intended diff so repo-guard can validate the PR.
+
+```repo-guard-yaml
+change_type: chore
+scope:
+  - README.md
+budgets:
+  max_new_files: 1
+  max_new_docs: 1
+  max_net_added_lines: 200
+must_touch: []
+must_not_touch:
+  - LICENSE
+expected_effects:
+  - Describe the expected effect
+```
+
+## Verification
+
+- [ ] Local checks run

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -8,7 +8,11 @@ on:
       - "CMakeLists.txt"
       - "repo-policy.json"
       - "scripts/check-docs-consistency.sh"
+      - "scripts/check-repo-guard-rollout.sh"
       - ".github/workflows/docs-consistency.yml"
+      - ".github/workflows/repo-guard.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     branches: ["**"]
     paths:
@@ -16,7 +20,11 @@ on:
       - "CMakeLists.txt"
       - "repo-policy.json"
       - "scripts/check-docs-consistency.sh"
+      - "scripts/check-repo-guard-rollout.sh"
       - ".github/workflows/docs-consistency.yml"
+      - ".github/workflows/repo-guard.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".github/ISSUE_TEMPLATE/**"
 
 jobs:
   docs-consistency:
@@ -27,3 +35,6 @@ jobs:
 
       - name: Check version and docs consistency
         run: bash scripts/check-docs-consistency.sh
+
+      - name: Check repo-guard rollout wiring
+        run: bash scripts/check-repo-guard-rollout.sh

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,37 +1,36 @@
-name: repo-guard audit
+name: repo-guard policy check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
-  audit:
-    name: repo-guard audit check
+  policy-check:
+    name: repo-guard advisory check
     runs-on: ubuntu-latest
-    continue-on-error: true
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Clone repo-guard
-        run: |
-          git clone https://github.com/netkeep80/repo-guard.git /tmp/repo-guard
-          cd /tmp/repo-guard
-          git checkout 7877108e84fcc6539ded13ac09ad9358bc9cf529
-
-      - uses: actions/setup-node@v4
+      - name: Run repo-guard
+        id: repo_guard
+        uses: netkeep80/repo-guard@b1d16b8eb69755898c248d6e3dde31fa03d1becc
         with:
-          node-version: "20"
-
-      - name: Install repo-guard dependencies
-        working-directory: /tmp/repo-guard
-        run: npm ci
-
-      - name: Validate repo-policy.json
-        run: node /tmp/repo-guard/src/repo-guard.mjs --repo-root ${{ github.workspace }}
-
-      - name: Run PR policy check (audit)
-        run: node /tmp/repo-guard/src/repo-guard.mjs check-pr --repo-root ${{ github.workspace }}
+          mode: check-pr
+          enforcement: advisory
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish repo-guard summary
+        if: always()
+        run: |
+          echo "repo-guard result: ${{ steps.repo_guard.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.repo_guard.outputs.summary }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T12:27:32.705Z for PR creation at branch issue-273-d168cf1f3056 for issue https://github.com/netkeep80/PersistMemoryManager/issues/273

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-16T12:27:32.705Z for PR creation at branch issue-273-d168cf1f3056 for issue https://github.com/netkeep80/PersistMemoryManager/issues/273

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml/badge.svg)](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
-[![Version](https://img.shields.io/badge/version-0.55.1-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.55.2-green.svg)](CHANGELOG.md)
 
 ## Обзор
 

--- a/changelog.d/20260416_123156_repo_guard_rollout.md
+++ b/changelog.d/20260416_123156_repo_guard_rollout.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Changed
+- Updated the repo-guard policy workflow to the current reusable Action baseline in advisory mode.
+- Added YAML change-contract templates for pull requests and issues.

--- a/docs/repository_shape.md
+++ b/docs/repository_shape.md
@@ -21,7 +21,7 @@
 | Категория | Элементы | Роль |
 |-----------|----------|------|
 | Build / release | `CMakeLists.txt`, `.clang-format`, `.pre-commit-config.yaml`, `.gitignore` | Конфигурация сборки, форматирования, CI |
-| CI / CD | `.github/` | GitHub Actions workflows |
+| CI / CD | `.github/` | GitHub Actions workflows and repository templates |
 | Changelog | `changelog.d/`, `CHANGELOG.md` | Фрагменты и собранная история релизов |
 | Library source | `include/` | Публичные заголовки библиотеки (canonical source) |
 | Amalgamated headers | `single_include/` | Генерируемые single-header варианты |
@@ -102,11 +102,16 @@
 - **Не является first-class частью target shape** (см. § 2.1 style guide).
 - Будет удалён после завершения всех задач компактификации.
 
+#### `.github/`
+
+- Pull request template: `PULL_REQUEST_TEMPLATE.md` — repo-guard YAML change contract template.
+- Issue template: `ISSUE_TEMPLATE/change-contract.yml` — issue form for changes with repo-guard contracts.
+
 #### `.github/workflows/`
 
 - CI: `ci.yml` — сборка, тесты, проверки.
-- Docs-consistency: `docs-consistency.yml` — проверка консистентности документации.
-- Repo-guard: `repo-guard.yml` — аудит политики репозитория.
+- Docs-consistency: `docs-consistency.yml` — проверка консистентности документации и repo-guard rollout wiring.
+- Repo-guard: `repo-guard.yml` — advisory policy check through the reusable repo-guard Action.
 - Release: `release.yml` — автоматический релиз.
 
 ## Rules / contracts
@@ -120,7 +125,7 @@
 | Элемент | Обоснование |
 |---------|-------------|
 | `.clang-format` | Конфигурация стиля кода |
-| `.github/` | CI/CD workflows |
+| `.github/` | CI/CD workflows and repository templates |
 | `.gitignore` | Конфигурация Git |
 | `.pre-commit-config.yaml` | Pre-commit hooks |
 | `CHANGELOG.md` | История релизов |

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,6 +1,9 @@
 {
   "policy_format_version": "0.3.0",
   "repository_kind": "library",
+  "enforcement": {
+    "mode": "advisory"
+  },
   "paths": {
     "forbidden": [
       "docs/phase-*",
@@ -35,6 +38,11 @@
     "governance_paths": [
       "repo-policy.json",
       "CONTRIBUTING.md",
+      ".github/workflows/repo-guard.yml",
+      ".github/workflows/docs-consistency.yml",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/ISSUE_TEMPLATE/change-contract.yml",
+      "scripts/check-repo-guard-rollout.sh",
       "docs/repository_shape.md",
       "docs/deletion_policy.md",
       "docs/comment_policy.md"

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/repo-guard.yml"
+policy="$repo_root/repo-policy.json"
+
+python3 - "$workflow" "$policy" <<'PY'
+import json
+import pathlib
+import sys
+
+workflow_path = pathlib.Path(sys.argv[1])
+policy_path = pathlib.Path(sys.argv[2])
+
+workflow = workflow_path.read_text(encoding="utf-8")
+policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+expected_action = "netkeep80/repo-guard@b1d16b8eb69755898c248d6e3dde31fa03d1becc"
+required_governance_paths = {
+    ".github/workflows/repo-guard.yml",
+    ".github/workflows/docs-consistency.yml",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/ISSUE_TEMPLATE/change-contract.yml",
+    "scripts/check-repo-guard-rollout.sh",
+}
+
+checks = [
+    (
+        expected_action in workflow,
+        f"repo-guard workflow must use the pinned reusable Action {expected_action}",
+    ),
+    ("mode: check-pr" in workflow, "repo-guard workflow must run check-pr mode"),
+    (
+        "enforcement: advisory" in workflow,
+        "repo-guard workflow must run in advisory enforcement mode",
+    ),
+    ("fetch-depth: 0" in workflow, "repo-guard workflow must use full checkout history"),
+    (
+        "continue-on-error" not in workflow,
+        "repo-guard workflow must not mask runtime/configuration failures with continue-on-error",
+    ),
+    (
+        "git clone https://github.com/netkeep80/repo-guard.git" not in workflow,
+        "repo-guard workflow must not use the legacy manual clone integration",
+    ),
+    (
+        "npm ci" not in workflow and "npm install" not in workflow,
+        "repo-guard workflow must not install repo-guard manually",
+    ),
+    (
+        "node /tmp/repo-guard/src/repo-guard.mjs" not in workflow,
+        "repo-guard workflow must not invoke the cloned CLI directly",
+    ),
+]
+
+policy_mode = policy.get("enforcement", {}).get("mode")
+checks.append((policy_mode == "advisory", "repo-policy.json must default to advisory enforcement"))
+
+governance_paths = set(policy.get("paths", {}).get("governance_paths", []))
+missing_governance = sorted(required_governance_paths - governance_paths)
+checks.append(
+    (
+        not missing_governance,
+        "repo-policy.json governance_paths must include: " + ", ".join(missing_governance),
+    )
+)
+
+missing_files = [
+    path for path in required_governance_paths if not (policy_path.parent / path).exists()
+]
+checks.append(
+    (
+        not missing_files,
+        "governed repo-guard rollout files must exist: " + ", ".join(sorted(missing_files)),
+    )
+)
+
+failures = [message for ok, message in checks if not ok]
+if failures:
+    print("Repo-guard rollout check failed:")
+    for failure in failures:
+        print(f"  - {failure}")
+    sys.exit(1)
+
+print("Repo-guard rollout wiring is current.")
+PY


### PR DESCRIPTION
## Summary

Fixes netkeep80/PersistMemoryManager#273.

Rolls PMM forward to the current repo-guard baseline and integration model.

- Replaces the legacy manual clone / `npm ci` / direct `node` workflow with the reusable Action pinned to `netkeep80/repo-guard@b1d16b8eb69755898c248d6e3dde31fa03d1becc`.
- Moves PMM policy checks from masked `continue-on-error` audit mode to explicit `advisory` enforcement, so policy violations remain non-blocking while configuration/runtime failures are no longer hidden.
- Adds YAML change-contract templates for PRs and issues to match the improved contract UX.
- Adds `scripts/check-repo-guard-rollout.sh` and wires it into docs-consistency so stale integration patterns are caught.
- Fixes the README version badge drift (`0.55.1` -> `0.55.2`) found while running docs consistency.

## Rollout Notes

- Advisory: repo-guard policy violations are reported as advisory results and do not block PMM PRs yet.
- Enforced: invalid policy JSON, broken Action setup, missing runtime context, or other execution/configuration errors still fail the workflow because `continue-on-error` was removed.
- Deferred: broader PMM policy redesign, stricter budgets, and blocking enforcement are intentionally left for separate follow-up work after observing advisory output.
- Legacy patterns removed: the workflow no longer clones repo-guard into `/tmp`, copies policy files, injects git worktree environment variables, installs repo-guard manually, or calls the cloned CLI directly.

## Verification

- `bash scripts/check-repo-guard-rollout.sh` first failed against the old workflow, reproducing the stale integration state.
- `bash scripts/check-repo-guard-rollout.sh`
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-file-size.sh`
- YAML parse check for `.github/workflows/repo-guard.yml`, `.github/workflows/docs-consistency.yml`, and `.github/ISSUE_TEMPLATE/change-contract.yml`
- `node /tmp/repo-guard-latest/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776342444727`
- `node /tmp/repo-guard-latest/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776342444727 --enforcement advisory check-diff`
- `git diff --check upstream/main...HEAD`
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (82/82 passed)

```repo-guard-yaml
change_type: chore
scope:
  - .github/workflows/repo-guard.yml
  - .github/workflows/docs-consistency.yml
  - .github/PULL_REQUEST_TEMPLATE.md
  - .github/ISSUE_TEMPLATE/change-contract.yml
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
  - docs/repository_shape.md
  - README.md
  - changelog.d/**
budgets:
  max_new_files: 4
  max_new_docs: 2
  max_net_added_lines: 250
must_touch:
  - .github/workflows/repo-guard.yml
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
must_not_touch:
  - include/**
  - tests/**
  - single_include/**
  - CMakeLists.txt
expected_effects:
  - PMM repo-guard workflow uses the pinned reusable Action baseline in advisory mode.
  - YAML contract templates make the improved contract UX available to future PMM changes.
  - Local and CI rollout wiring checks prevent stale manual integration patterns from returning.
```
