### PR TITLE
ci(docs): split docs-consistency from version-consistency

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -1,5 +1,14 @@
 name: Docs Consistency
 
+# Two independent concerns live here, split to remove a governance deadlock:
+#
+#   docs-consistency      — docs-owned invariants. Runs on any docs/governance
+#                           change. Must NOT require a README version bump.
+#   version-consistency   — release-owned invariants (CMakeLists ↔ README badge
+#                           ↔ CHANGELOG). Runs only when release-related files
+#                           change, so docs-only PRs are not blocked by a stale
+#                           badge the release workflow is responsible for.
+
 on:
   push:
     branches: ["**"]
@@ -8,6 +17,7 @@ on:
       - "CMakeLists.txt"
       - "repo-policy.json"
       - "scripts/check-docs-consistency.sh"
+      - "scripts/check-version-consistency.sh"
       - "scripts/check-repo-guard-rollout.sh"
       - ".github/workflows/docs-consistency.yml"
       - ".github/workflows/repo-guard.yml"
@@ -20,6 +30,7 @@ on:
       - "CMakeLists.txt"
       - "repo-policy.json"
       - "scripts/check-docs-consistency.sh"
+      - "scripts/check-version-consistency.sh"
       - "scripts/check-repo-guard-rollout.sh"
       - ".github/workflows/docs-consistency.yml"
       - ".github/workflows/repo-guard.yml"
@@ -33,8 +44,49 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check version and docs consistency
+      - name: Check docs-owned invariants
         run: bash scripts/check-docs-consistency.sh
 
       - name: Check repo-guard rollout wiring
         run: bash scripts/check-repo-guard-rollout.sh
+
+  version-consistency:
+    name: Version consistency check (release-owned)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect release-related changes
+        id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # Release-owned surface: files that encode the published version
+          # triple. Touching any of these signals a release-state change and
+          # triggers the check. Changelog fragments, governance scripts and
+          # the workflow itself are intentionally NOT in this list — they do
+          # not alter the published version and must not force a README bump.
+          release_paths='^(CMakeLists\.txt|README\.md|CHANGELOG\.md)'
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=1
+            changed=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+          else
+            # push event: compare against previous commit
+            changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)
+          fi
+
+          if echo "$changed" | grep -Eq "$release_paths"; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Release-related paths changed — running version-consistency check."
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No release-related paths changed — skipping version-consistency check."
+          fi
+
+      - name: Check version-consistency (release-owned)
+        if: steps.detect.outputs.should_run == 'true'
+        run: bash scripts/check-version-consistency.sh

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T21:23:04.214Z for PR creation at branch issue-278-29cc0938fa2c for issue https://github.com/netkeep80/PersistMemoryManager/issues/278

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T21:23:04.214Z for PR creation at branch issue-278-29cc0938fa2c for issue https://github.com/netkeep80/PersistMemoryManager/issues/278

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,31 @@ The CI will fail if source files change without a changelog fragment. Source fil
 
 Docs-only changes (`docs/`, `*.md`, `.github/workflows/`) do not require a fragment.
 
+## Docs-owned vs Release-owned Surface
+
+The repository distinguishes two CI surfaces so that atomic docs-only PRs are
+not blocked by release-state drift:
+
+| Surface            | Owned by                 | Checked in                          |
+|--------------------|--------------------------|-------------------------------------|
+| **Docs-owned**     | Contributors             | `scripts/check-docs-consistency.sh` |
+| **Release-owned**  | Release workflow (bot)   | `scripts/check-version-consistency.sh` |
+
+**Docs-owned** means docs/governance invariants that every PR touching docs
+must honour (for example, every canonical doc listed in `repo-policy.json`
+must exist).
+
+**Release-owned** means state that the release workflow is responsible for
+keeping in sync. The canonical example is the version triple:
+
+- `CMakeLists.txt` `project(... VERSION X.Y.Z ...)`
+- `README.md` version badge
+- `CHANGELOG.md` latest `## [X.Y.Z]` heading
+
+A docs-only PR **must not** bump the README version badge — that belongs to
+the release cut. The version-consistency check only runs when a PR actually
+touches release-owned paths, so docs-only work never inherits a forced bump.
+
 ## Pull Request Process
 
 1. Create a feature branch from `main`

--- a/changelog.d/20260418_212500_split_docs_version_consistency.md
+++ b/changelog.d/20260418_212500_split_docs_version_consistency.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+---
+
+### Changed
+- Split `docs-consistency` CI into two independent concerns to remove a
+  governance deadlock for atomic docs-only PRs:
+  - `scripts/check-docs-consistency.sh` now only enforces docs-owned
+    invariants (canonical docs existence).
+  - `scripts/check-version-consistency.sh` (new) enforces release-owned
+    invariants: `CMakeLists.txt` ↔ `README.md` badge ↔ `CHANGELOG.md`.
+- The version-consistency check runs only when release-owned paths change,
+  so docs-only PRs no longer require a forced `README.md` version bump.
+- Documented the docs-owned vs release-owned surface split in
+  `CONTRIBUTING.md`.

--- a/scripts/check-docs-consistency.sh
+++ b/scripts/check-docs-consistency.sh
@@ -1,45 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# docs-owned invariants only.
+#
+# Scope: governance/docs coherence that must hold for ANY PR touching docs.
+# Out of scope: version/release coherence (README badge, CHANGELOG, CMakeLists
+# version). Those are release-owned and live in scripts/check-version-consistency.sh
+# so that docs-only PRs do not get blocked on a forced README version bump.
+
 FAILED=0
 
-# --- 1. Extract version from each canonical source ---
-
-# CMakeLists.txt: project(PersistMemoryManager VERSION X.Y.Z ...)
-cmake_version=$(grep -oP 'project\(PersistMemoryManager VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt) || {
-  echo "FAIL: could not extract version from CMakeLists.txt"
-  exit 1
-}
-
-# README.md: badge like version-X.Y.Z-green
-readme_version=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md) || {
-  echo "FAIL: could not extract version badge from README.md"
-  exit 1
-}
-
-# CHANGELOG.md: first ## [X.Y.Z] entry
-changelog_version=$(grep -oP '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1) || {
-  echo "FAIL: could not extract latest version from CHANGELOG.md"
-  exit 1
-}
-
-echo "CMakeLists.txt version: $cmake_version"
-echo "README.md badge version: $readme_version"
-echo "CHANGELOG.md latest version: $changelog_version"
-
-# --- 2. Check consistency ---
-
-if [ "$cmake_version" != "$readme_version" ]; then
-  echo "FAIL: README badge version ($readme_version) does not match CMakeLists.txt ($cmake_version)"
-  FAILED=1
-fi
-
-if [ "$cmake_version" != "$changelog_version" ]; then
-  echo "FAIL: CHANGELOG latest version ($changelog_version) does not match CMakeLists.txt ($cmake_version)"
-  FAILED=1
-fi
-
-# --- 3. Check that canonical docs listed in repo-policy.json exist ---
+# --- Canonical docs listed in repo-policy.json must exist ---
 
 if [ -f repo-policy.json ]; then
   in_canonical=false

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# release-owned invariants: all three canonical version sources must agree.
+#
+# Sources of truth:
+#   - CMakeLists.txt       (project(... VERSION X.Y.Z ...))
+#   - README.md            (version badge)
+#   - CHANGELOG.md         (latest ## [X.Y.Z] heading)
+#
+# This check is intentionally NOT part of docs-consistency so that a docs-only
+# PR never gets blocked by a stale README badge. The badge is bumped by the
+# release workflow, not by contributors writing docs.
+
+FAILED=0
+
+cmake_version=$(grep -oP 'project\(PersistMemoryManager VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt) || {
+  echo "FAIL: could not extract version from CMakeLists.txt"
+  exit 1
+}
+
+readme_version=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md) || {
+  echo "FAIL: could not extract version badge from README.md"
+  exit 1
+}
+
+changelog_version=$(grep -oP '^\#\# \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1) || {
+  echo "FAIL: could not extract latest version from CHANGELOG.md"
+  exit 1
+}
+
+echo "CMakeLists.txt version: $cmake_version"
+echo "README.md badge version: $readme_version"
+echo "CHANGELOG.md latest version: $changelog_version"
+
+if [ "$cmake_version" != "$readme_version" ]; then
+  echo "FAIL: README badge version ($readme_version) does not match CMakeLists.txt ($cmake_version)"
+  FAILED=1
+fi
+
+if [ "$cmake_version" != "$changelog_version" ]; then
+  echo "FAIL: CHANGELOG latest version ($changelog_version) does not match CMakeLists.txt ($cmake_version)"
+  FAILED=1
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "OK: version-consistency checks passed"
+else
+  echo ""
+  echo "Version-consistency checks failed. These are release-owned — typically"
+  echo "fixed by running the release workflow, not by hand-editing docs."
+fi
+
+exit $FAILED


### PR DESCRIPTION
## Summary

Fixes #278.

Splits CI for docs governance into two independent concerns so that atomic docs-only PRs no longer deadlock on a stale README version badge.

## Problem

`docs-consistency.yml` triggered on any `*.md` change and `check-docs-consistency.sh` unconditionally required the README badge to match `CMakeLists.txt` (and `CHANGELOG.md`). A docs-only PR with the allowed scope `README.md: forbidden` could not pass CI while the badge was behind the project version, because the only way to green CI was a scope-violating manual README bump.

## Solution

Introduce a boundary between **docs-owned** and **release-owned** surface:

| Surface | Owner | Script |
|---|---|---|
| docs-owned | contributors | `scripts/check-docs-consistency.sh` — only checks canonical-docs existence now |
| release-owned | release workflow (bot) | `scripts/check-version-consistency.sh` *(new)* — checks `CMakeLists.txt` ↔ `README.md` badge ↔ `CHANGELOG.md` |

`docs-consistency.yml` keeps its existing path triggers but runs two independent jobs:

1. **`docs-consistency`** — always runs on docs/governance changes.
2. **`version-consistency`** — gated on a `detect` step that only fires when the PR actually touches the published-version surface (`CMakeLists.txt`, `README.md`, `CHANGELOG.md`). Docs-only PRs skip it.

`CONTRIBUTING.md` documents the split and names the README badge as release-owned.

## Files changed

- `scripts/check-docs-consistency.sh` — narrowed to docs-owned invariants
- `scripts/check-version-consistency.sh` — **new**, release-owned version triple check
- `.github/workflows/docs-consistency.yml` — added `version-consistency` job with path-aware `detect` gate
- `CONTRIBUTING.md` — added "Docs-owned vs Release-owned Surface" section
- `changelog.d/20260418_212500_split_docs_version_consistency.md` — changelog fragment (required by CI for script changes)

## Surface budget

- `max_new_files: 1` — 1 new script (`check-version-consistency.sh`). The changelog fragment is forced by `check-changelog-fragment.sh` for any `scripts/**` change; it is release-plumbing, not new design surface.
- `max_new_docs: 0` — 0 new doc files (CONTRIBUTING.md edited in place).
- `max_net_added_lines: 140` — net +116 lines (155 additions − 39 deletions).
- `generated_surface` — untouched (`single_include/**`, `include/**`, `tests/**`).

## Acceptance criteria

- [x] Docs-only PR touching only `docs/*.md` does **not** trigger the version-consistency check (verified by path regex `^(CMakeLists\.txt|README\.md|CHANGELOG\.md)`).
- [x] Release/version-related PR touching `CMakeLists.txt`, `README.md`, or `CHANGELOG.md` still runs the full version triple check.
- [x] This PR itself is docs/governance-only and skips the version-consistency job — which is how the deadlock is visibly broken (README is 0.55.2, CMakeLists is 0.55.3, and CI still passes because the badge mismatch is now release-owned).
- [x] Governance rule about release-owned surface is fixed in `CONTRIBUTING.md`.

## Non-goals respected

- Kernel (`include/**`, `tests/**`, `single_include/**`, `examples/**`, `demo/**`) not touched.
- Release workflow unchanged.
- Changelog system unchanged.
- `repo-policy.json` unchanged.
- No manual README bump.

## Test plan

- [x] `bash scripts/check-docs-consistency.sh` — passes locally despite README 0.55.2 vs CMakeLists 0.55.3, proving the deadlock is broken.
- [x] `bash scripts/check-version-consistency.sh` — correctly fails on the current pre-existing badge drift, proving the release-owned check still works where it is supposed to run.
- [x] `bash scripts/check-repo-guard-rollout.sh` — still passes.
- [x] `bash scripts/check-changelog-fragment.sh` — passes (fragment included).
- [ ] CI on this PR: `docs-consistency` job green; `version-consistency` job green (skipped, since no release-owned paths touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)