### PR TITLE
docs: add PMM transformation rules as operational rulebook

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T21:48:31.689Z for PR creation at branch issue-277-324f0e34c248 for issue https://github.com/netkeep80/PersistMemoryManager/issues/277

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T21:48:31.689Z for PR creation at branch issue-277-324f0e34c248 for issue https://github.com/netkeep80/PersistMemoryManager/issues/277

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Single entry point for all PMM documentation. Each topic is covered by exactly o
 | Document | Role |
 |----------|------|
 | [PMM Target Model](pmm_target_model.md) | Normative top-level model: PMM as compact persistent storage kernel; boundary vs `pjson` / `pjson_db` / execution / product layers |
+| [PMM Transformation Rules](pmm_transformation_rules.md) | Normative operational rulebook: allowed issue types, atomic-issue / no-mixed-PR / extraction-first / surface-compression rules, PR review semantics |
 | [PMM AVL-Forest](pmm_avl_forest.md) | Canonical architectural model: AVL-forest as first-class abstraction, forest-domains, design constraints |
 | [Block and TreeNode Semantics](block_and_treenode_semantics.md) | Field-level specification of `Block` and `TreeNode` headers |
 | [Core Invariants](core_invariants.md) | Frozen invariant set after issues 01–07: model boundary, block semantics, forest, bootstrap, free-tree, verify/repair |

--- a/docs/pmm_transformation_rules.md
+++ b/docs/pmm_transformation_rules.md
@@ -1,0 +1,110 @@
+# PMM Transformation Rules
+
+## Document status
+
+This is the **canonical operational rulebook** that governs how `PersistMemoryManager`
+may be transformed. It is normative: every issue, PR, review decision, and future
+`repo-guard` policy must be consistent with it.
+
+It does not restate the target model — that lives in
+[pmm_target_model.md](pmm_target_model.md). This document adds only the
+operational discipline that keeps PMM evolving toward that target.
+
+If a rule here conflicts with a weaker convention elsewhere, this document wins.
+
+## 1. Allowed issue types
+
+PMM accepts only the following issue types:
+
+- **kernel-hardening** — stronger invariants, validation, recovery, verify/repair;
+- **kernel-compaction** — fewer files, fewer primitives, fewer code paths;
+- **extraction-prep** — clean seams toward future separation of concerns;
+- **governance/repo-guard** — rules, contracts, policy, review semantics;
+- **docs-comments-cleanup** — removal of noise from docs and comments.
+
+Any issue that does not fit one of these types is out of scope for PMM.
+
+## 2. Atomic issue rule
+
+- One issue = one engineering intent.
+- One PR = one reason for change.
+
+A PR that cannot be summarized by a single intent must be split before merge.
+
+## 3. No mixed PR rule
+
+A single PR must not combine changes from more than one of the following buckets:
+
+- kernel-hardening;
+- docs / comments cleanup;
+- packaging / build / release;
+- generated surface updates (e.g. `single_include/**`);
+- governance / repo-guard.
+
+Mixing these buckets in one PR is an automatic review rejection, even if every
+individual change is correct in isolation.
+
+## 4. Extraction-first rule
+
+If a capability does not belong to PMM as a persistent storage kernel, it must
+either:
+
+- stay outside PMM, or
+- be prepared for extraction (clean seams, no new coupling),
+
+but it must not grow into PMM. PMM does not absorb upper-layer concerns.
+
+Reference boundary: [pmm_target_model.md § 2–3](pmm_target_model.md).
+
+## 5. Surface compression rule
+
+- Every issue must aim for a **non-positive surface delta** by default
+  (new files, net added lines, comments, docs).
+- A temporary surface increase is allowed only as explicitly declared
+  **surface debt**, recorded in the issue and the PR description.
+- Surface debt must name the issue that will repay it.
+
+Convenience surface is not a valid justification for growth.
+
+## 6. Source / generated separation rule
+
+- Generated surface (`single_include/**` and comparable artifacts) must not be
+  updated in the same PR as kernel or governance changes.
+- Regeneration PRs are their own change type and must be minimal and isolated.
+- Hand-edits of generated surface are forbidden.
+
+## 7. Text discipline rule
+
+- Documents and comments must not accumulate as process-noise.
+- Every new document must have a **canonical place** and a **clear purpose**,
+  and must be listed in [index.md](index.md).
+- Historical notes, phase logs, and design diaries do not belong in `docs/`.
+  They belong in Git history, issues, and pull requests.
+- Comments follow [comment_policy.md](comment_policy.md); if they do not fit
+  one of its allowed types, they are removed.
+
+## 8. PR review semantics
+
+A PR is first assessed on **contract conformance**, not on local code quality:
+
+- does it match the declared issue type;
+- does it stay inside the declared scope;
+- does it respect the declared surface budget;
+- does it avoid forbidden scope;
+- does it avoid scope creep beyond the issue intent.
+
+A technically correct PR that violates its issue contract is rejected.
+A minimal PR that respects its contract is preferred over a broader one that
+"also fixes a few other things".
+
+## Success criterion
+
+These rules are working if, over time, PMM issues become:
+
+- smaller in scope;
+- cleaner in intent;
+- safer for repository surface;
+- oriented toward collapsing PMM, not expanding it.
+
+If this document itself starts to grow into a long guide, that growth violates
+rule 5 and must be reversed.


### PR DESCRIPTION
## Summary

Adds one new canonical top-level document — `docs/pmm_transformation_rules.md` — that fixes the **operational rules for transforming PMM** and makes controlled development the default mode of work.

The document is intentionally short and normative: it complements [pmm_target_model.md](https://github.com/netkeep80/PersistMemoryManager/blob/main/docs/pmm_target_model.md) without restating it, and it gives subsequent issues, PRs, reviews, and future repo-guard policy a single place to cite.

Fixes #277

## Change Contract

```repo-guard-yaml
change_type: governance/repo-guard
scope:
  - docs/pmm_transformation_rules.md
  - docs/index.md
budgets:
  max_new_files: 1
  max_new_docs: 1
  max_net_added_lines: 220
must_touch:
  - docs/pmm_transformation_rules.md
must_not_touch:
  - include/
  - tests/
  - single_include/
  - scripts/
  - .github/
  - repo-policy.json
  - README.md
expected_effects:
  - Introduces a normative operational rulebook for PMM transformation
  - Surfaces the new document from the canonical docs index
  - Does not change code, tests, scripts, generated surface, or governance files
```

## Surface delta

- **New files:** 1 (`docs/pmm_transformation_rules.md`)
- **Modified files:** 1 (`docs/index.md` — one index row)
- **Net added lines:** 111 (110 new doc + 1 index row), well under the 220-line budget
- **Docs delta:** +1 canonical document, +1 index row
- **Comments delta:** none
- **Code delta:** none
- **Generated surface:** untouched (`single_include/**` not modified)
- **Touched forbidden scope:** none
- **README.md:** untouched

## Document sections

Per the issue contract, `docs/pmm_transformation_rules.md` contains exactly the required rules:

1. **Allowed issue types** — `kernel-hardening`, `kernel-compaction`, `extraction-prep`, `governance/repo-guard`, `docs-comments-cleanup`
2. **Atomic issue rule** — one issue = one intent, one PR = one reason
3. **No mixed PR rule** — kernel-hardening, docs cleanup, packaging, generated updates, and governance must not be combined
4. **Extraction-first rule** — non-substrate capabilities stay outside PMM or are prepared for extraction, never absorbed
5. **Surface compression rule** — non-positive surface delta by default; growth only as declared surface debt
6. **Source/generated separation rule** — `single_include/**` regenerations stay isolated from kernel/governance PRs
7. **Text discipline rule** — every new doc has a canonical place and clear purpose; no process-noise accumulation
8. **PR review semantics** — contract conformance is assessed above local code quality

## Verification

- [x] Exactly one new file under `docs/` (scope respected)
- [x] No changes to `include/`, `tests/`, `single_include/`, `scripts/`, `.github/`, `repo-policy.json`, or `README.md`
- [x] Net added lines within the 220-line surface budget (111)
- [x] Document remains short and structural — not an architectural essay (≈ 110 lines)
- [x] Does not duplicate `pmm_target_model.md`; adds only operational rules
- [x] Introduces allowed issue types explicitly
- [x] Introduces atomic issue / no-mixed-PR / extraction-first / surface-compression rules
- [x] No new markdown files other than `docs/pmm_transformation_rules.md`
- [x] Generated surface not touched

## Governance notes

Following the precedent from #276, this PR does not bump the `README.md` version badge. The README is release-owned surface and out of scope per the issue contract; the `0.55.x` drift between `CMakeLists.txt` and `README.md` on `main` is a pre-existing concern for a separate governance PR.

No changelog fragment is added: `scripts/check-changelog-fragment.sh` exempts docs-only PRs, and the issue explicitly forbids changes outside `docs/pmm_transformation_rules.md` and a minimal docs index entry.

`repo-policy.json` is deliberately not updated — the issue places it in the forbidden scope. Promoting the new document into `canonical_docs` can happen in a follow-up governance PR.

## Test plan

- [x] File count matches contract (1 new doc, 1 index line)
- [x] Byte-level diff stays within `docs/` only
- [x] Local `git diff --stat` matches declared surface delta
- [ ] CI: docs-consistency, repo-guard advisory, build/test workflows pass on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)