### PR TITLE
[governance/repo-guard] Tighten controlled compaction policy

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T22:54:30.137Z for PR creation at branch issue-285-1d60ede731b0 for issue https://github.com/netkeep80/PersistMemoryManager/issues/285

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T22:54:30.137Z for PR creation at branch issue-285-1d60ede731b0 for issue https://github.com/netkeep80/PersistMemoryManager/issues/285

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Single entry point for PMM documentation. The canonical set below must match
 |----------|------|
 | [PMM Target Model](pmm_target_model.md) | Normative top-level model: PMM as compact persistent storage kernel; boundary vs `pjson` / `pjson_db` / execution / product layers |
 | [PMM Transformation Rules](pmm_transformation_rules.md) | Normative operational rulebook: allowed issue types, atomic-issue / no-mixed-PR / extraction-first / surface-compression rules, PR review semantics |
+| [Comment Policy](comment_policy.md) | Canonical text discipline for comments, docs placement, and text-surface review |
 | [Block and TreeNode Semantics](block_and_treenode_semantics.md) | Field-level specification of `Block` and `TreeNode` headers |
 | [Architecture](architecture.md) | Layer stack, memory layout, algorithms, storage backends, configuration |
 | [API Reference](api_reference.md) | Complete public API: lifecycle, allocation, containers, I/O, error codes |
@@ -31,7 +32,6 @@ Single entry point for PMM documentation. The canonical set below must match
 | [Mutation Ordering](mutation_ordering.md) | Write ordering rules and crash-consistency analysis |
 | [Repository Shape](repository_shape.md) | Target directory structure and file placement rules |
 | [Deletion Policy](deletion_policy.md) | Rules for file lifecycle: keep, move, archive, delete |
-| [Comment Policy](comment_policy.md) | Canonical text discipline for comments, docs placement, and text-surface review |
 | [Code Reduction Report](code_reduction_report.md) | Supporting report on code-volume reduction |
 | [Compatibility Audit](compatibility_audit.md) | Supporting compatibility inventory |
 | [Internal Structure](internal_structure.md) | Supporting implementation structure notes |

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -14,8 +14,7 @@
       "imgui.ini",
       "demo.bat",
       "test.bat",
-      "demo.md",
-      "single_include/**"
+      "demo.md"
     ],
     "canonical_docs": [
       "docs/pmm_target_model.md",
@@ -50,7 +49,7 @@
   },
   "diff_rules": {
     "max_new_docs": 0,
-    "max_new_files": 0,
+    "max_new_files": 3,
     "max_net_added_lines": 35
   },
   "content_rules": [

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -14,11 +14,13 @@
       "imgui.ini",
       "demo.bat",
       "test.bat",
-      "demo.md"
+      "demo.md",
+      "single_include/**"
     ],
     "canonical_docs": [
       "docs/pmm_target_model.md",
       "docs/pmm_transformation_rules.md",
+      "docs/comment_policy.md",
       "docs/block_and_treenode_semantics.md",
       "docs/architecture.md",
       "docs/api_reference.md",
@@ -34,6 +36,8 @@
       ".github/PULL_REQUEST_TEMPLATE.md",
       ".github/ISSUE_TEMPLATE/change-contract.yml",
       "scripts/check-repo-guard-rollout.sh",
+      "docs/pmm_target_model.md",
+      "docs/pmm_transformation_rules.md",
       "docs/repository_shape.md",
       "docs/deletion_policy.md",
       "docs/comment_policy.md"
@@ -45,9 +49,9 @@
     ]
   },
   "diff_rules": {
-    "max_new_docs": 3,
-    "max_new_files": 20,
-    "max_net_added_lines": 3000
+    "max_new_docs": 0,
+    "max_new_files": 0,
+    "max_net_added_lines": 35
   },
   "content_rules": [
     {


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#285

## Summary

Tightens PMM repo-guard policy toward controlled compaction without touching kernel, tests, examples, or generated headers.

- Adds `docs/comment_policy.md` to `paths.canonical_docs` and moves it from Supporting to Canonical in `docs/index.md`.
- Adds `docs/pmm_target_model.md` and `docs/pmm_transformation_rules.md` to `paths.governance_paths`, matching their accepted governance role.
- Reduces default surface budgets while avoiding governance deadlocks: docs growth is locked down, new files are reduced to a small non-zero default, and net line growth is sharply limited.
- Keeps `single_include/**` out of `paths.forbidden` so isolated generated-header regeneration PRs remain possible; generated surface separation stays enforced through issue/PR contracts and review under `pmm_transformation_rules.md`.
- Removes the temporary PR bootstrap `.gitkeep`; final PR diff against `main` contains only `repo-policy.json` and `docs/index.md`.

## Policy Fields Changed

| Field | Before | After |
| --- | ---: | ---: |
| `diff_rules.max_new_docs` | 3 | 0 |
| `diff_rules.max_new_files` | 20 | 3 |
| `diff_rules.max_net_added_lines` | 3000 | 35 |

Path/registry changes:

- `paths.forbidden`: unchanged; `single_include/**` is intentionally not globally forbidden.
- `paths.canonical_docs`: added `docs/comment_policy.md`; removed none.
- `paths.governance_paths`: added `docs/pmm_target_model.md` and `docs/pmm_transformation_rules.md`; removed none.

## Surface Contract

- New files: 0
- New markdown files: 0
- Generated surface touched: no
- Code/test/example/demo surface touched: no
- Final diff against `main`: 2 files, 7 insertions, 4 deletions

This helps reduce future repo surface by making docs growth exceptional by default, shrinking the default new-file allowance from broad to narrow, and keeping large net additions outside the default policy budget. Generated headers remain isolated by contract/review instead of being made globally impossible.

## Verification

- `python3 -m json.tool repo-policy.json`
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-file-size.sh`
- `git diff --check`
- `node /tmp/repo-guard-pinned/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776554252056`
- `node /tmp/repo-guard-pinned/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776554252056 --enforcement advisory check-diff --format summary`
- `node /tmp/repo-guard-pinned/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776554252056 --enforcement advisory check-diff --base upstream/main --head HEAD --format summary`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build` (passed; existing generated-header warnings only)
- `ctest --test-dir build --output-on-failure` (82/82 passed)

```repo-guard-yaml
change_type: chore
scope:
  - repo-policy.json
  - docs/index.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 35
must_touch:
  - repo-policy.json
must_not_touch:
  - include/**
  - tests/**
  - single_include/**
  - examples/**
  - demo/**
  - CMakeLists.txt
  - README.md
  - CHANGELOG.md
  - changelog.d/**
expected_effects:
  - PMM repo-guard policy defaults to controlled compaction budgets without blocking isolated generated-header regeneration.
  - Canonical governance docs are represented in policy registries.
  - Generated single-header surface is kept out of this governance PR by contract rather than global path prohibition.
```
