### PR TITLE
Compact public header comments for IO and presets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T00:06:07.486Z for PR creation at branch issue-289-ef9e11a014da for issue https://github.com/netkeep80/PersistMemoryManager/issues/289

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T00:06:07.486Z for PR creation at branch issue-289-ef9e11a014da for issue https://github.com/netkeep80/PersistMemoryManager/issues/289

--- a/changelog.d/20260419_002500_compact_public_header_comments.md
+++ b/changelog.d/20260419_002500_compact_public_header_comments.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Compact public header comments and refresh generated single-header output.

--- a/include/pmm/io.h
+++ b/include/pmm/io.h
@@ -2,33 +2,11 @@
  * @file pmm/io.h
  * @brief Утилиты файлового ввода/вывода для PersistMemoryManager
  *
- * Вспомогательный заголовочный файл с функциями сохранения и загрузки
- * образа памяти в/из файла. Вынесен в отдельный файл, так как файловый
- * ввод/вывод не является основной функциональностью менеджера памяти,
- * но необходим для тестов и примеров использования персистентности.
+ * Save/load helpers for a manager image.
  *
- * CRC32 checksum — save_manager computes and stores CRC32
- * in the ManagerHeader.crc32 field; load_manager_from_file verifies it.
- *
- * Atomic save — save_manager writes to a temporary file
- * (filename + ".tmp") and atomically renames it to the target on success.
- *
- * Использование:
- * @code
- * #include "pmm/manager_configs.h"
- * #include "pmm/persist_memory_manager.h"
- * #include "pmm/io.h"
- *
- * using MyMgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig>;
- * MyMgr::create(64 * 1024);
- *
- * // Сохранить образ в файл
- * bool ok = pmm::save_manager<MyMgr>("heap.dat");
- *
- * // Загрузить образ из файла (сначала нужно выделить буфер нужного размера)
- * MyMgr::create(64 * 1024);
- * bool ok2 = pmm::load_manager_from_file<MyMgr>("heap.dat");
- * @endcode
+ * save_manager stores ManagerHeader.crc32 and writes through filename + ".tmp"
+ * before an atomic rename. load_manager_from_file requires VerifyResult& and
+ * verifies CRC before loading manager state.
  *
  * @version 0.3
  */

--- a/include/pmm/pmm_presets.h
+++ b/include/pmm/pmm_presets.h
@@ -2,25 +2,7 @@
  * @file pmm/pmm_presets.h
  * @brief pmm_presets — готовые инстанции PersistMemoryManager.
  *
- * Предоставляет набор готовых псевдонимов для наиболее распространённых
- * конфигураций менеджера персистентной памяти:
- *
- *   --- Embedded (статические, однопоточные) ---
- *   - `SmallEmbeddedStaticHeap<N>` — 16-bit, NoLock, StaticStorage<N> (до ~1 МБ, small embedded)
- *   - `EmbeddedStaticHeap<N>`      — 32-bit, NoLock, StaticStorage<N> (без heap, фиксированный пул)
- *   - `EmbeddedHeap`               — 32-bit, NoLock, HeapStorage, рост 50% (embedded с heap)
- *
- *   --- Desktop (динамические, однопоточные/многопоточные) ---
- *   - `SingleThreadedHeap`      — 32-bit/16B, NoLock, HeapStorage, рост 25%
- *   - `MultiThreadedHeap`       — 32-bit/16B, SharedMutexLock, HeapStorage, рост 25%
- *
- *   --- Industrial DB (высоконагруженные, многопоточные) ---
- *   - `IndustrialDBHeap`        — 32-bit/16B, SharedMutexLock, HeapStorage, рост 100%
- *
- *   --- Large DB (крупные базы данных, 64-bit) ---
- *   - `LargeDBHeap`             — 64-bit/64B, SharedMutexLock, HeapStorage, рост 100%
- *
- * Использует унифицированный `PersistMemoryManager<ConfigT, InstanceId>`.
+ * Public aliases over PersistMemoryManager<ConfigT, InstanceId>.
  *
  * @see persist_memory_manager.h — PersistMemoryManager
  * @see manager_configs.h — готовые конфигурации менеджеров
@@ -39,151 +21,33 @@ namespace presets
 
 // ─── Embedded пресеты ─────────────────────────────────────────────────────────
 
-/**
- * @brief Tiny embedded-менеджер с фиксированным статическим буфером и 16-bit индексом.
- *
- * - 16-bit адресация (SmallAddressTraits), 16-байтная гранула
- * - pptr<T> хранит 2-байтный индекс — экономия памяти на ARM Cortex-M, AVR, ESP32
- * - StaticStorage<BufferSize, SmallAddressTraits> — фиксированный буфер, нет malloc
- * - Максимальный пул: 65535 × 16 = ~1 МБ
- * - Без блокировок (для однопоточных embedded-систем без heap)
- * - Не расширяется (expand() всегда false)
- * - InstanceId=0 (по умолчанию)
- *
- * @tparam BufferSize Размер статического буфера в байтах (кратно 16, максимум ~1 МБ).
- *                    По умолчанию 1024 байт (1 КБ).
- *
- * Использование:
- * @code
- *   using TinyMgr = pmm::presets::SmallEmbeddedStaticHeap<1024>;
- *   TinyMgr::create(1024);
- *   void* ptr = TinyMgr::allocate(32);
- *   TinyMgr::deallocate(ptr);
- *   // sizeof(TinyMgr::pptr<int>) == 2  (16-bit индекс)
- * @endcode
- */
+/// Static NoLock manager with 16-bit indexes, 16-byte granules, and no growth.
 template <std::size_t BufferSize = 1024>
 using SmallEmbeddedStaticHeap = PersistMemoryManager<SmallEmbeddedStaticConfig<BufferSize>, 0>;
 
-/**
- * @brief Embedded-менеджер с фиксированным статическим буфером (без heap).
- *
- * - 32-bit адресация (DefaultAddressTraits), 16-байтная гранула
- * - StaticStorage<BufferSize> — фиксированный буфер в BSS/глобальной области, нет malloc
- * - Без блокировок (для однопоточных embedded-систем без heap)
- * - Не расширяется (expand() всегда false)
- * - InstanceId=0 (по умолчанию)
- *
- * @tparam BufferSize Размер статического буфера в байтах (кратно 16).
- *                    По умолчанию 4096 байт (4 КБ).
- *
- * Использование:
- * @code
- *   using MyEmbMgr = pmm::presets::EmbeddedStaticHeap<8192>; // 8 KiB статический пул
- *   MyEmbMgr::create(8192);
- *   void* ptr = MyEmbMgr::allocate(64);
- *   MyEmbMgr::deallocate(ptr);
- * @endcode
- */
+/// Static NoLock manager with 32-bit indexes, 16-byte granules, and no growth.
 template <std::size_t BufferSize = 4096>
 using EmbeddedStaticHeap = PersistMemoryManager<EmbeddedStaticConfig<BufferSize>, 0>;
 
-/**
- * @brief Стандартный embedded-менеджер с динамической памятью.
- *
- * - 32-bit адресация, 16-байтная гранула
- * - Динамическая память через HeapStorage
- * - Без блокировок (однопоточный доступ)
- * - Консервативный коэффициент роста 3/2 (50%) для экономии памяти
- * - InstanceId=0 (по умолчанию)
- *
- * Использование:
- * @code
- *   pmm::presets::EmbeddedHeap::create(4 * 1024); // 4 KiB начальный размер
- *   void* ptr = pmm::presets::EmbeddedHeap::allocate(64);
- *   pmm::presets::EmbeddedHeap::deallocate(ptr);
- * @endcode
- */
+/// HeapStorage NoLock manager with 32-bit indexes, 16-byte granules, and 50% growth.
 using EmbeddedHeap = PersistMemoryManager<EmbeddedManagerConfig, 0>;
 
 // ─── Desktop пресеты ──────────────────────────────────────────────────────────
 
-/**
- * @brief Стандартный однопоточный динамический менеджер.
- *
- * - 32-bit адресация, 16-байтная гранула
- * - Динамическая память через HeapStorage (std::malloc)
- * - Без блокировок (для однопоточных приложений)
- * - Коэффициент роста 5/4 (25%)
- * - InstanceId=0 (по умолчанию)
- *
- * Использование:
- * @code
- *   pmm::presets::SingleThreadedHeap::create(64 * 1024); // 64 KiB начальный размер
- *   void* ptr = pmm::presets::SingleThreadedHeap::allocate(256);
- *   pmm::presets::SingleThreadedHeap::deallocate(ptr);
- * @endcode
- */
+/// HeapStorage NoLock manager with 32-bit indexes, 16-byte granules, and 25% growth.
 using SingleThreadedHeap = PersistMemoryManager<CacheManagerConfig, 0>;
 
-/**
- * @brief Стандартный многопоточный динамический менеджер.
- *
- * - 32-bit адресация, 16-байтная гранула
- * - Динамическая память через HeapStorage
- * - Блокировки через std::shared_mutex
- * - Коэффициент роста 5/4 (25%)
- * - InstanceId=0 (по умолчанию)
- *
- * Использование:
- * @code
- *   pmm::presets::MultiThreadedHeap::create(64 * 1024);
- *   void* ptr = pmm::presets::MultiThreadedHeap::allocate(256);
- *   pmm::presets::MultiThreadedHeap::deallocate(ptr);
- * @endcode
- */
+/// HeapStorage SharedMutexLock manager with 32-bit indexes, 16-byte granules, and 25% growth.
 using MultiThreadedHeap = PersistMemoryManager<PersistentDataConfig, 0>;
 
 // ─── Industrial DB пресеты ────────────────────────────────────────────────────
 
-/**
- * @brief Менеджер для промышленных баз данных с высокой нагрузкой (32-bit).
- *
- * - 32-bit адресация, 16-байтная гранула, поддержка до 64 ГБ
- * - Динамическая память через HeapStorage
- * - Блокировки через std::shared_mutex
- * - Агрессивный коэффициент роста 2/1 (100%) для минимизации перевыделений
- * - InstanceId=0 (по умолчанию)
- *
- * Использование:
- * @code
- *   pmm::presets::IndustrialDBHeap::create(256 * 1024 * 1024); // 256 MiB начальный размер
- *   void* ptr = pmm::presets::IndustrialDBHeap::allocate(4096);
- *   pmm::presets::IndustrialDBHeap::deallocate(ptr);
- * @endcode
- */
+/// HeapStorage SharedMutexLock manager with 32-bit indexes, 16-byte granules, and 100% growth.
 using IndustrialDBHeap = PersistMemoryManager<IndustrialDBConfig, 0>;
 
 // ─── Large DB пресеты (64-bit индекс) ────────────────────────────────────────
 
-/**
- * @brief Менеджер для крупных баз данных с 64-bit индексом.
- *
- * - 64-bit адресация (LargeAddressTraits), 64-байтная гранула
- * - pptr<T> хранит 8-байтный индекс — адресует петабайтный масштаб
- * - Динамическая память через HeapStorage
- * - Блокировки через std::shared_mutex
- * - Агрессивный коэффициент роста 2/1 (100%) для минимизации перевыделений
- * - InstanceId=0 (по умолчанию)
- *
- * Использование:
- * @code
- *   pmm::presets::LargeDBHeap::create(256 * 1024 * 1024); // 256 MiB начальный размер
- *   void* ptr = pmm::presets::LargeDBHeap::allocate(4096);
- *   pmm::presets::LargeDBHeap::deallocate(ptr);
- *   // sizeof(LargeDBHeap::pptr<int>) == 8  (64-bit индекс)
- * @endcode
- */
+/// HeapStorage SharedMutexLock manager with 64-bit indexes, 64-byte granules, and 100% growth.
 using LargeDBHeap = PersistMemoryManager<LargeDBConfig, 0>;
 
 } // namespace presets

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -8958,33 +8958,11 @@ static bool do_expand( std::size_t user_size ) noexcept
  * @file pmm/io.h
  * @brief Утилиты файлового ввода/вывода для PersistMemoryManager
  *
- * Вспомогательный заголовочный файл с функциями сохранения и загрузки
- * образа памяти в/из файла. Вынесен в отдельный файл, так как файловый
- * ввод/вывод не является основной функциональностью менеджера памяти,
- * но необходим для тестов и примеров использования персистентности.
+ * Save/load helpers for a manager image.
  *
- * CRC32 checksum — save_manager computes and stores CRC32
- * in the ManagerHeader.crc32 field; load_manager_from_file verifies it.
- *
- * Atomic save — save_manager writes to a temporary file
- * (filename + ".tmp") and atomically renames it to the target on success.
- *
- * Использование:
- * @code
- * #include "pmm/manager_configs.h"
- * #include "pmm/persist_memory_manager.h"
- * #include "pmm/io.h"
- *
- * using MyMgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig>;
- * MyMgr::create(64 * 1024);
- *
- * // Сохранить образ в файл
- * bool ok = pmm::save_manager<MyMgr>("heap.dat");
- *
- * // Загрузить образ из файла (сначала нужно выделить буфер нужного размера)
- * MyMgr::create(64 * 1024);
- * bool ok2 = pmm::load_manager_from_file<MyMgr>("heap.dat");
- * @endcode
+ * save_manager stores ManagerHeader.crc32 and writes through filename + ".tmp"
+ * before an atomic rename. load_manager_from_file requires VerifyResult& and
+ * verifies CRC before loading manager state.
  *
  * @version 0.3
  */


### PR DESCRIPTION
Fixes #289.\n\n## Summary\n- Compact public header comments in io/preset headers.\n- Regenerate single_include/pmm/pmm.h so generated headers match source headers.\n- Add a patch changelog fragment for the public-header documentation cleanup.\n\n## Verification\n- bash scripts/check-changelog-fragment.sh\n- bash scripts/generate-single-headers.sh --strip-comments --output-dir /tmp/pmm-generated-check, then diff all generated headers against single_include/pmm/*.h\n- git diff --check HEAD~1..HEAD\n- cmake --build build\n- ctest --test-dir build --output-on-failure