### PR TITLE
[governance/repo-guard] Clarify source-generated closure rule

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T00:59:09.306Z for PR creation at branch issue-291-27288c594291 for issue https://github.com/netkeep80/PersistMemoryManager/issues/291

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T00:59:09.306Z for PR creation at branch issue-291-27288c594291 for issue https://github.com/netkeep80/PersistMemoryManager/issues/291

--- a/docs/pmm_transformation_rules.md
+++ b/docs/pmm_transformation_rules.md
@@ -70,8 +70,15 @@ Convenience surface is not a valid justification for growth.
 
 - Generated surface (`single_include/**` and comparable artifacts) must not be
   updated in the same PR as kernel or governance changes.
-- Regeneration PRs are their own change type and must be minimal and isolated.
+- Regeneration PRs are their own change type and must be minimal and isolated,
+  except when the generated diff is the mechanically required closure of an
+  allowed canonical source change in the same PR.
 - Hand-edits of generated surface are forbidden.
+- Closure means the source diff is primary, the generated diff is directly
+  derivable from it, and no independent logic or unrelated churn appears in the
+  generated layer.
+- Issue contracts that mark generated surface `must_not_touch` still allow this
+  minimal source -> generated closure unless they explicitly forbid it.
 
 ## 7. Text discipline rule
 
@@ -96,6 +103,8 @@ A PR is first assessed on **contract conformance**, not on local code quality:
 A technically correct PR that violates its issue contract is rejected.
 A minimal PR that respects its contract is preferred over a broader one that
 "also fixes a few other things".
+For generated closure, reviewers check that the generated diff is mechanically
+explained by the allowed source diff and is not a disguised mixed change.
 
 ## Success criterion
 


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#291

## Summary
- Clarifies `docs/pmm_transformation_rules.md` so required source -> generated closure is distinct from forbidden mixed generated changes.
- Keeps regeneration PRs isolated by default while allowing minimal mechanically required generated sync when it directly follows an allowed canonical source diff.
- Adds reviewer semantics for checking that generated diffs are mechanically explained and not disguised independent churn.

## Surface Contract
- Changed files: `docs/pmm_transformation_rules.md` only
- New files: 0
- New markdown files: 0
- Code/test/example/demo surface touched: no
- Generated surface touched: no
- Diff size: 10 insertions, 1 deletion

## Verification
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `bash scripts/check-file-size.sh`
- `git diff --check`

## Notes
No automated reproducing test was added because this issue explicitly forbids `tests/**` and asks for a governance wording update only.