### PR TITLE
Forbid include-shard file-size bypasses in PMM policy

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T09:14:22.769Z for PR creation at branch issue-293-8159ba0e9788 for issue https://github.com/netkeep80/PersistMemoryManager/issues/293

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T09:14:22.769Z for PR creation at branch issue-293-8159ba0e9788 for issue https://github.com/netkeep80/PersistMemoryManager/issues/293

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ Each source file must not exceed **1500 lines**. This constraint:
 - Encourages modular design
 - Ensures AI tools can read entire files within their context window
 
+Do not satisfy this limit by splitting `include/pmm/**` headers into `.inc`,
+`.inl`, `.ipp`, or similar include shards. A large header is a signal for real
+compaction or extraction into a normal `.h` module with its own responsibility.
+
 ## Changelog Fragments
 
 Every pull request that modifies source code must include a **changelog fragment** in `changelog.d/`. This system prevents merge conflicts between parallel PRs and automates release notes.

--- a/docs/pmm_transformation_rules.md
+++ b/docs/pmm_transformation_rules.md
@@ -66,6 +66,18 @@ Reference boundary: [pmm_target_model.md § 2–3](pmm_target_model.md).
 
 Convenience surface is not a valid justification for growth.
 
+Header/file surface must not be reduced by moving parts of the same
+`include/pmm/**` module into `.inc`, `.inl`, `.ipp`, or similar textual include
+shards. A shorter parent header after such a split is not compaction; it is the
+same module fragmented across more files and is a policy violation.
+
+When a header approaches an operational limit such as 1500 lines, reviewers
+expect one of two outcomes:
+
+- **compaction**: less code, less duplication, or simpler responsibility;
+- **real module extraction**: a normal `.h` module with its own role and a
+  genuine boundary, not the second half of the original file.
+
 ## 6. Source / generated separation rule
 
 - Generated surface (`single_include/**` and comparable artifacts) must not be

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -8,6 +8,9 @@
     "forbidden": [
       "docs/phase-*",
       "docs/phase[0-9]*",
+      "include/pmm/**/*.inc",
+      "include/pmm/**/*.inl",
+      "include/pmm/**/*.ipp",
       "*.bak",
       "*.tmp",
       "*.orig",


### PR DESCRIPTION
## Summary
- Add canonical transformation-rule text forbidding `include/pmm/**` header surface reduction through `.inc`, `.inl`, `.ipp`, or similar textual include shards.
- Clarify that file-size pressure should lead to compaction or real extraction into a normal `.h` module with its own responsibility.
- Add `repo-policy.json` forbidden path globs for new `include/pmm/**/*.inc`, `include/pmm/**/*.inl`, and `include/pmm/**/*.ipp` files.

## Verification
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `git diff --check`
- `python3 -m json.tool repo-policy.json >/dev/null`

Fixes netkeep80/PersistMemoryManager#293