### PR TITLE
[governance/repo-guard] Roll out staged PMM policy

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@b1d16b8eb69755898c248d6e3dde31fa03d1becc
+        uses: netkeep80/repo-guard@c8491872866c33e0ecd04f809dcfd0489047d13f
         with:
           mode: check-pr
           enforcement: advisory

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T10:43:41.865Z for PR creation at branch issue-297-6c7136baca09 for issue https://github.com/netkeep80/PersistMemoryManager/issues/297

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T10:43:41.865Z for PR creation at branch issue-297-6c7136baca09 for issue https://github.com/netkeep80/PersistMemoryManager/issues/297

--- a/changelog.d/20260419_104900_repo_guard_staged_rollout.md
+++ b/changelog.d/20260419_104900_repo_guard_staged_rollout.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Roll out staged repo-guard policy rules for PMM governance checks.

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -78,6 +78,7 @@
     "governance": [".github/**", "scripts/check-*.sh", "repo-policy.json"],
     "release": ["changelog.d/*.md"],
     "generated": ["single_include/**"],
+    "kernel_module": ["include/pmm/*.h"],
     "kernel_shard": ["include/pmm/**/*.inc", "include/pmm/**/*.inl", "include/pmm/**/*.ipp"]
   },
   "new_file_rules": {
@@ -90,9 +91,10 @@
       "max_new_files": 0
     },
     "kernel-compaction": {
-      "allow_classes": ["test", "release"],
+      "allow_classes": ["test", "release", "kernel_module"],
       "max_per_class": {
-        "release": 1
+        "release": 1,
+        "kernel_module": 1
       }
     },
     "kernel-hardening": {
@@ -102,9 +104,10 @@
       }
     },
     "extraction-prep": {
-      "allow_classes": ["test", "release"],
+      "allow_classes": ["test", "release", "kernel_module"],
       "max_per_class": {
-        "release": 1
+        "release": 1,
+        "kernel_module": 1
       }
     },
     "generated-refresh": {

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -55,6 +55,124 @@
     "max_new_files": 3,
     "max_net_added_lines": 35
   },
+  "surfaces": {
+    "kernel": ["include/**", "CMakeLists.txt"],
+    "tests": ["tests/**"],
+    "docs": ["docs/**", "README.md", "CONTRIBUTING.md"],
+    "governance": ["repo-policy.json", ".github/**", "scripts/check-*.sh"],
+    "release": ["CHANGELOG.md", "changelog.d/**", "scripts/check-version-consistency.sh"],
+    "generated": ["single_include/**"]
+  },
+  "change_classes": [
+    "governance",
+    "docs-comments-cleanup",
+    "kernel-compaction",
+    "kernel-hardening",
+    "extraction-prep",
+    "generated-refresh",
+    "release"
+  ],
+  "new_file_classes": {
+    "test": ["tests/**"],
+    "canonical_doc": ["docs/**", "README.md", "CONTRIBUTING.md"],
+    "governance": [".github/**", "scripts/check-*.sh", "repo-policy.json"],
+    "release": ["changelog.d/*.md"],
+    "generated": ["single_include/**"],
+    "kernel_shard": ["include/pmm/**/*.inc", "include/pmm/**/*.inl", "include/pmm/**/*.ipp"]
+  },
+  "new_file_rules": {
+    "governance": {
+      "allow_classes": ["governance", "release"],
+      "max_new_files": 1
+    },
+    "docs-comments-cleanup": {
+      "allow_classes": [],
+      "max_new_files": 0
+    },
+    "kernel-compaction": {
+      "allow_classes": ["test", "release"],
+      "max_per_class": {
+        "release": 1
+      }
+    },
+    "kernel-hardening": {
+      "allow_classes": ["test", "release"],
+      "max_per_class": {
+        "release": 1
+      }
+    },
+    "extraction-prep": {
+      "allow_classes": ["test", "release"],
+      "max_per_class": {
+        "release": 1
+      }
+    },
+    "generated-refresh": {
+      "allow_classes": ["generated", "release"],
+      "max_per_class": {
+        "generated": 20,
+        "release": 1
+      }
+    },
+    "release": {
+      "allow_classes": ["release"],
+      "max_per_class": {
+        "release": 1
+      }
+    }
+  },
+  "change_type_rules": {
+    "governance": {
+      "forbid_surfaces": ["kernel", "generated"],
+      "max_new_docs": 0,
+      "max_new_files": 1,
+      "max_net_added_lines": 80
+    },
+    "docs-comments-cleanup": {
+      "forbid_surfaces": ["kernel", "generated", "release"],
+      "max_new_docs": 0,
+      "max_new_files": 0
+    },
+    "kernel-compaction": {
+      "forbid_surfaces": ["docs", "governance", "release"]
+    },
+    "kernel-hardening": {
+      "forbid_surfaces": ["docs", "governance", "release"],
+      "require_surfaces": ["tests"]
+    },
+    "extraction-prep": {
+      "forbid_surfaces": ["governance", "release"]
+    },
+    "generated-refresh": {
+      "allow_surfaces": ["generated", "release"]
+    },
+    "release": {
+      "allow_surfaces": ["release"],
+      "max_new_docs": 0
+    }
+  },
+  "registry_rules": [
+    {
+      "id": "canonical-docs-sync",
+      "kind": "set_equality",
+      "left": {
+        "type": "json_array",
+        "file": "repo-policy.json",
+        "json_pointer": "/paths/canonical_docs"
+      },
+      "right": {
+        "type": "markdown_section_links",
+        "file": "docs/index.md",
+        "section": "Canonical Documents",
+        "prefix": "docs/"
+      }
+    }
+  ],
+  "advisory_text_rules": {
+    "canonical_files": ["docs/index.md", "docs/*.md"],
+    "warn_on_similarity_above": 0.78,
+    "max_reported_matches": 3
+  },
   "content_rules": [
     {
       "id": "no-todo-without-issue",

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -85,6 +85,25 @@ checks.append((expected_change_classes <= change_classes, "repo-policy.json chan
 new_file_rules = policy.get("new_file_rules", {})
 checks.append((expected_change_classes <= set(new_file_rules), "new_file_rules must cover PMM v1 classes"))
 
+new_file_classes = policy.get("new_file_classes", {})
+checks.append(
+    (
+        "kernel_module" in new_file_classes,
+        "new_file_classes must distinguish legitimate kernel modules from forbidden shard files",
+    )
+)
+
+for change_type in ("kernel-compaction", "extraction-prep"):
+    rule = new_file_rules.get(change_type, {})
+    allowed_classes = set(rule.get("allow_classes", []))
+    max_per_class = rule.get("max_per_class", {})
+    checks.append(
+        (
+            "kernel_module" in allowed_classes and max_per_class.get("kernel_module") == 1,
+            f"{change_type} must allow exactly one legitimate kernel module extraction file",
+        )
+    )
+
 change_type_rules = policy.get("change_type_rules", {})
 checks.append((expected_change_classes <= set(change_type_rules), "change_type_rules must cover PMM v1 types"))
 checks.append(("surface_matrix" not in policy, "surface_matrix is intentionally deferred in this rollout"))

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -16,7 +16,7 @@ policy_path = pathlib.Path(sys.argv[2])
 workflow = workflow_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-expected_action = "netkeep80/repo-guard@b1d16b8eb69755898c248d6e3dde31fa03d1becc"
+expected_action = "netkeep80/repo-guard@c8491872866c33e0ecd04f809dcfd0489047d13f"
 required_governance_paths = {
     ".github/workflows/repo-guard.yml",
     ".github/workflows/docs-consistency.yml",
@@ -63,6 +63,37 @@ checks.append(
     (
         not missing_governance,
         "repo-policy.json governance_paths must include: " + ", ".join(missing_governance),
+    )
+)
+
+expected_surfaces = {"kernel", "tests", "docs", "governance", "release", "generated"}
+surfaces = set(policy.get("surfaces", {}))
+checks.append((expected_surfaces <= surfaces, "repo-policy.json surfaces must include PMM v1 surfaces"))
+
+expected_change_classes = {
+    "governance",
+    "docs-comments-cleanup",
+    "kernel-compaction",
+    "kernel-hardening",
+    "extraction-prep",
+    "generated-refresh",
+    "release",
+}
+change_classes = set(policy.get("change_classes", []))
+checks.append((expected_change_classes <= change_classes, "repo-policy.json change_classes must include PMM v1 types"))
+
+new_file_rules = policy.get("new_file_rules", {})
+checks.append((expected_change_classes <= set(new_file_rules), "new_file_rules must cover PMM v1 classes"))
+
+change_type_rules = policy.get("change_type_rules", {})
+checks.append((expected_change_classes <= set(change_type_rules), "change_type_rules must cover PMM v1 types"))
+checks.append(("surface_matrix" not in policy, "surface_matrix is intentionally deferred in this rollout"))
+
+registry_rules = policy.get("registry_rules", [])
+checks.append(
+    (
+        any(rule.get("id") == "canonical-docs-sync" for rule in registry_rules),
+        "repo-policy.json registry_rules must include canonical-docs-sync",
     )
 )
 


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#297

## Summary

Staged PMM rollout for the newer repo-guard policy model without touching kernel, generated headers, tests, examples, or demo code.

Implemented v1 features:

- `surfaces` for the minimal PMM ownership map: kernel, tests, docs, governance, release, generated.
- `change_classes` / `change_type_rules` for PMM issue classes: governance, docs-comments-cleanup, kernel-compaction, kernel-hardening, extraction-prep, generated-refresh, release.
- `new_file_classes` / `new_file_rules` so new tests, release fragments, generated files, governance plumbing, docs, and forbidden include shards are classified instead of handled only by flat budgets.
- `registry_rules` for canonical-doc drift between `repo-policy.json` and `docs/index.md`.
- `advisory_text_rules` as non-blocking markdown duplication/canonical-place heuristics.

Intentionally deferred:

- `surface_matrix`, because PMM has enough ontology for type-aware rules in this rollout but not enough evidence to make every change carry a separate `change_class` matrix contract without adding workflow friction.
- Broader registries and release/version coupling, because those would recreate docs-owned vs release-owned deadlocks.
- Any PMM kernel/API/generation changes.

## Mapping

| Policy area | PMM v1 mapping |
| --- | --- |
| `change_type` / `change_classes` | `governance`, `docs-comments-cleanup`, `kernel-compaction`, `kernel-hardening`, `extraction-prep`, `generated-refresh`, `release` |
| `surfaces` | `kernel`, `tests`, `docs`, `governance`, `release`, `generated` |
| `new_file_classes` | `test`, `canonical_doc`, `governance`, `release`, `generated`, `kernel_module`, `kernel_shard` |
| `registry_rules` | `canonical-docs-sync` keeps `paths.canonical_docs` aligned with `docs/index.md` Canonical Documents |

## Deadlock-sensitive contracts

- Docs-only atomic PR remains viable: docs cleanup forbids kernel/generated/release touches and new docs, but does not require release-owned sync.
- Governance-only PR remains viable: governance may update policy/plumbing while forbidding kernel/generated touches and keeping new-file growth capped.
- Source -> generated closure remains viable: `generated-refresh` is limited to generated plus release surface, while generated files are not globally forbidden.
- Real module extraction remains viable: `kernel-compaction` and `extraction-prep` may add one normal `include/pmm/*.h` module while `.inc`/`.inl`/`.ipp` shard files stay forbidden.
- Advisory text checks remain advisory-only under repo-guard v1 and do not change PR exit status.

## Verification

- `python3 -m json.tool repo-policy.json`
- `bash scripts/check-repo-guard-rollout.sh` (also verifies `kernel_module` is allowed exactly once for compaction/extraction prep)
- `GITHUB_EVENT_PATH=/tmp/event-pr298.json GH_TOKEN=$(gh auth token) node /tmp/repo-guard-issue297/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776595414313 --enforcement advisory check-pr`
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-file-size.sh`
- `node /tmp/repo-guard-issue297/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776595414313`
- `node /tmp/repo-guard-issue297/src/repo-guard.mjs --repo-root /tmp/gh-issue-solver-1776595414313 --enforcement advisory check-diff --base upstream/main --head HEAD --format summary`
- `git diff --check`

```repo-guard-yaml
change_type: governance
change_class: governance
scope:
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
  - .github/workflows/repo-guard.yml
  - changelog.d/20260419_104900_repo_guard_staged_rollout.md
budgets:
  max_new_files: 1
  max_new_docs: 1
  max_net_added_lines: 180
must_touch:
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
must_not_touch:
  - include/**
  - single_include/**
  - tests/**
  - examples/**
  - demo/**
  - docs/**
  - CHANGELOG.md
expected_effects:
  - PMM has a staged repo-guard v1 rollout for change_type_rules, new_file_rules, registry_rules, and advisory_text_rules.
  - repo-guard CI uses a schema-compatible pinned Action SHA for the staged policy keys.
  - surface_matrix remains intentionally deferred until PMM has a lower-friction matrix contract.
  - Canonical docs drift is checked by repo-guard without reintroducing docs-owned versus release-owned deadlocks.
  - Advisory governance rollout warnings are expected while the new rules are staged and do not block CI.
  - Legitimate kernel module extraction remains allowed while include shard files remain forbidden.
```


