### PR TITLE
ci: cache demo FetchContent dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,14 +318,12 @@ jobs:
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DPMM_BUILD_DEMO=ON \
+            -DPMM_BUILD_DEMO_TESTS=OFF \
             -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.cmake-fetchcontent
 
       - name: Configure (Windows)
         if: runner.os == 'Windows'
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DPMM_BUILD_DEMO=ON -DFETCHCONTENT_BASE_DIR="${{ github.workspace }}\\.cmake-fetchcontent"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DPMM_BUILD_DEMO=ON -DPMM_BUILD_DEMO_TESTS=OFF -DFETCHCONTENT_BASE_DIR="${{ github.workspace }}\\.cmake-fetchcontent"
 
       - name: Build
         run: cmake --build build --config Release
-
-      - name: Test (all 23 tests)
-        run: ctest --test-dir build --build-config Release --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache CMake FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cmake-fetchcontent
+          key: ${{ runner.os }}-demo-fetchcontent-${{ hashFiles('CMakeLists.txt', 'demo/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-demo-fetchcontent-
+
       - name: Install OpenGL dev (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -309,11 +317,12 @@ jobs:
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DPMM_BUILD_DEMO=ON
+            -DPMM_BUILD_DEMO=ON \
+            -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.cmake-fetchcontent
 
       - name: Configure (Windows)
         if: runner.os == 'Windows'
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DPMM_BUILD_DEMO=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DPMM_BUILD_DEMO=ON -DFETCHCONTENT_BASE_DIR="${{ github.workspace }}\\.cmake-fetchcontent"
 
       - name: Build
         run: cmake --build build --config Release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T11:48:08.565Z for PR creation at branch issue-299-d78513bce2fa for issue https://github.com/netkeep80/PersistMemoryManager/issues/299

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T11:48:08.565Z for PR creation at branch issue-299-d78513bce2fa for issue https://github.com/netkeep80/PersistMemoryManager/issues/299

--- a/changelog.d/20260419_121938_demo_ci_tests.md
+++ b/changelog.d/20260419_121938_demo_ci_tests.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Stop building and running headless demo tests in the demo-only CI job.

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -89,6 +89,8 @@ endif()
 
 # ─── Phase 8: Headless demo tests ─────────────────────────────────────────────
 # These tests exercise demo logic without opening a window.
+option(PMM_BUILD_DEMO_TESTS "Build headless demo tests when PMM_BUILD_DEMO is enabled" ${BUILD_TESTING})
+if(PMM_BUILD_DEMO_TESTS)
 
 function(pmm_demo_test name source)
     add_executable(${name} ${source})
@@ -109,3 +111,5 @@ pmm_demo_test(test_scenario_coordinator  ${CMAKE_CURRENT_SOURCE_DIR}/../tests/te
 pmm_demo_test(test_background_validator  ${CMAKE_CURRENT_SOURCE_DIR}/../tests/test_background_validator.cpp)
 pmm_demo_test(test_avl_tree_view         ${CMAKE_CURRENT_SOURCE_DIR}/../tests/test_avl_tree_view.cpp)
 pmm_demo_test(test_manual_alloc_view     ${CMAKE_CURRENT_SOURCE_DIR}/../tests/test_manual_alloc_view.cpp)
+
+endif()


### PR DESCRIPTION
## Summary

Fixes netkeep80/PersistMemoryManager#299.

The slowest CI path is the `Build Demo` matrix. A recent upstream CI run (`24627194350`, 2026-04-19T10:42:09Z) showed demo job durations around 9m04s on Windows, 6m54s on Ubuntu, and 3m37s on macOS.

The root cause is twofold:

- The demo build pulls GLFW and Dear ImGui through CMake `FetchContent`, and the root project pulls Catch2 the same way. Those downloads previously lived only inside each fresh build tree.
- Enabling `PMM_BUILD_DEMO=ON` also built and ran the headless demo test executables in the demo-only CI job, duplicating work that belongs to the normal test jobs.

## Changes

- Added `actions/cache@v4` to the `build-demo` job for a stable `.cmake-fetchcontent` directory.
- Passed `-DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.cmake-fetchcontent` during demo configure on Linux/macOS, with the equivalent Windows path on Windows.
- Scoped the cache key by OS and the dependency declaration files: `CMakeLists.txt` and `demo/CMakeLists.txt`.
- Added `PMM_BUILD_DEMO_TESTS` in `demo/CMakeLists.txt`, defaulting to the normal `BUILD_TESTING` value, so local full builds still include demo tests by default without touching release-owned root version metadata.
- Set `PMM_BUILD_DEMO_TESTS=OFF` in the demo-only CI job and removed that job's `ctest` step, so `Build Demo` builds the visual demo instead of rebuilding/rerunning tests.
- Added a changelog fragment for the CI/demo build behavior change.

## Verification

- [x] Inspected recent CI job timing via `gh run view 24627194350 --json jobs`.
- [x] `git diff --check`
- [x] `cmake -B build-core-test -DCMAKE_BUILD_TYPE=Release`
- [x] `cmake --build build-core-test --config Release`
- [x] `ctest --test-dir build-core-test --build-config Release --output-on-failure` (`83/83` passed)
- [x] Demo configure was attempted locally with `PMM_BUILD_DEMO=ON`, `PMM_BUILD_DEMO_TESTS=OFF`, and the shared `FETCHCONTENT_BASE_DIR`; this container is missing GLFW Linux development prerequisites (`wayland-scanner`, then XRandR headers when Wayland is disabled), which CI installs in the Linux demo job.

## Expected CI Impact

The first run on a new OS cache key still downloads dependencies. Later runs should restore the cached `FetchContent` sources for Catch2, GLFW, and ImGui. The demo job should also stop spending time building and running the headless demo tests, leaving test execution to the dedicated test jobs.
