### PR TITLE
fix: centralize low-level pointer validation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T13:08:55.455Z for PR creation at branch issue-301-1cb1d875d9b1 for issue https://github.com/netkeep80/PersistMemoryManager/issues/301

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T13:08:55.455Z for PR creation at branch issue-301-1cb1d875d9b1 for issue https://github.com/netkeep80/PersistMemoryManager/issues/301

--- a/changelog.d/20260419_131300_validation_entrypoints.md
+++ b/changelog.d/20260419_131300_validation_entrypoints.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Route user-pointer-to-block validation through the canonical validation helper and cover invalid pointer/index rejection cases.

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -481,26 +481,14 @@ template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
     using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
-    static constexpr std::size_t kGranSz    = AddressTraitsT::granule_size;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    if ( ptr == nullptr )
+    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
         return nullptr;
-    std::uint8_t* raw_ptr = reinterpret_cast<std::uint8_t*>( ptr );
-    // First user data starts after Block_0 + ManagerHeader<AddressTraitsT> + Block_1
-    std::uint8_t* min_addr = base + kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( raw_ptr < min_addr )
-        return nullptr;
-    if ( raw_ptr > base + total_size )
-        return nullptr;
-    std::uint8_t* cand_addr = raw_ptr - kBlockSize;
-    if ( ( reinterpret_cast<std::size_t>( cand_addr ) - reinterpret_cast<std::size_t>( base ) ) % kGranSz != 0 )
-        return nullptr;
-    // Validate via BlockState (uses AddressTraitsT::no_block for sentinel checks)
+
+    std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
     if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
-    // Basic sanity: candidate address is within bounds
-    if ( cand_addr < base || cand_addr + kBlockSize > base + total_size )
         return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }

--- a/include/pmm/validation.h
+++ b/include/pmm/validation.h
@@ -77,16 +77,26 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
 {
     if ( ptr == nullptr || base == nullptr )
         return false;
-    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
-    // Must be within managed area.
-    if ( raw_ptr < base || raw_ptr >= base + total_size )
+    if ( min_user_offset < sizeof( pmm::Block<AT> ) )
+        return false;
+    if ( total_size < min_user_offset )
+        return false;
+    const auto*          raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_ptr );
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    if ( raw_addr < base_addr )
+        return false;
+    const std::size_t byte_off = static_cast<std::size_t>( raw_addr - base_addr );
+    // Must be within managed area. Unsigned subtraction keeps foreign pointers as invalid
+    // without forming out-of-object pointer sums such as base + total_size.
+    if ( byte_off >= total_size )
         return false;
     // Must be past minimum user-data address.
-    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+    if ( byte_off < min_user_offset )
         return false;
     // The block header candidate must be granule-aligned relative to base.
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = byte_off - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -1680,16 +1680,26 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
 {
     if ( ptr == nullptr || base == nullptr )
         return false;
-    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
-    // Must be within managed area.
-    if ( raw_ptr < base || raw_ptr >= base + total_size )
+    if ( min_user_offset < sizeof( pmm::Block<AT> ) )
+        return false;
+    if ( total_size < min_user_offset )
+        return false;
+    const auto*          raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_ptr );
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    if ( raw_addr < base_addr )
+        return false;
+    const std::size_t byte_off = static_cast<std::size_t>( raw_addr - base_addr );
+    // Must be within managed area. Unsigned subtraction keeps foreign pointers as invalid
+    // without forming out-of-object pointer sums such as base + total_size.
+    if ( byte_off >= total_size )
         return false;
     // Must be past minimum user-data address.
-    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+    if ( byte_off < min_user_offset )
         return false;
     // The block header candidate must be granule-aligned relative to base.
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = byte_off - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;
@@ -2257,26 +2267,14 @@ template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
     using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
-    static constexpr std::size_t kGranSz    = AddressTraitsT::granule_size;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    if ( ptr == nullptr )
+    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
         return nullptr;
-    std::uint8_t* raw_ptr = reinterpret_cast<std::uint8_t*>( ptr );
-    // First user data starts after Block_0 + ManagerHeader<AddressTraitsT> + Block_1
-    std::uint8_t* min_addr = base + kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( raw_ptr < min_addr )
-        return nullptr;
-    if ( raw_ptr > base + total_size )
-        return nullptr;
-    std::uint8_t* cand_addr = raw_ptr - kBlockSize;
-    if ( ( reinterpret_cast<std::size_t>( cand_addr ) - reinterpret_cast<std::size_t>( base ) ) % kGranSz != 0 )
-        return nullptr;
-    // Validate via BlockState (uses AddressTraitsT::no_block for sentinel checks)
+
+    std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
     if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
-    // Basic sanity: candidate address is within bounds
-    if ( cand_addr < base || cand_addr + kBlockSize > base + total_size )
         return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -755,16 +755,25 @@ inline bool validate_user_ptr( const std::uint8_t* base, std::size_t total_size,
 {
     if ( ptr == nullptr || base == nullptr )
         return false;
-    const auto* raw_ptr = static_cast<const std::uint8_t*>( ptr );
+    if ( min_user_offset < sizeof( pmm::Block<AT> ) )
+        return false;
+    if ( total_size < min_user_offset )
+        return false;
+    const auto*          raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_ptr );
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    if ( raw_addr < base_addr )
+        return false;
+    const std::size_t byte_off = static_cast<std::size_t>( raw_addr - base_addr );
     
-    if ( raw_ptr < base || raw_ptr >= base + total_size )
+    if ( byte_off >= total_size )
         return false;
     
-    if ( static_cast<std::size_t>( raw_ptr - base ) < min_user_offset )
+    if ( byte_off < min_user_offset )
         return false;
     
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AT> );
-    std::size_t                  cand_off   = static_cast<std::size_t>( raw_ptr - base ) - kBlockSize;
+    std::size_t                  cand_off   = byte_off - kBlockSize;
     if ( cand_off % AT::granule_size != 0 )
         return false;
     return true;
@@ -1185,26 +1194,14 @@ template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
     using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
-    static constexpr std::size_t kGranSz    = AddressTraitsT::granule_size;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    if ( ptr == nullptr )
+    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
         return nullptr;
-    std::uint8_t* raw_ptr = reinterpret_cast<std::uint8_t*>( ptr );
-    
-    std::uint8_t* min_addr = base + kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( raw_ptr < min_addr )
-        return nullptr;
-    if ( raw_ptr > base + total_size )
-        return nullptr;
-    std::uint8_t* cand_addr = raw_ptr - kBlockSize;
-    if ( ( reinterpret_cast<std::size_t>( cand_addr ) - reinterpret_cast<std::size_t>( base ) ) % kGranSz != 0 )
-        return nullptr;
-    
+
+    std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
     if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
-    
-    if ( cand_addr < base || cand_addr + kBlockSize > base + total_size )
         return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }

--- a/tests/test_issue257_validation.cpp
+++ b/tests/test_issue257_validation.cpp
@@ -338,6 +338,14 @@ TEST_CASE( "validation: validate_user_ptr rejects pointer before min address", "
     REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + 16, min_offset ) );
 }
 
+TEST_CASE( "validation: validate_user_ptr rejects image-end pointer", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    REQUIRE_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + 256, min_offset ) );
+}
+
 TEST_CASE( "validation: validate_user_ptr rejects misaligned pointer", "[test_issue257]" )
 {
     std::uint8_t dummy[256] = {};
@@ -355,6 +363,25 @@ TEST_CASE( "validation: validate_user_ptr accepts valid pointer", "[test_issue25
     // Valid pointer: at min_offset, and (min_offset - sizeof(Block<AT>)) % granule_size == 0.
     // min_offset = 32 + 64 + 32 = 128. Block header candidate = 128 - 32 = 96. 96 % 16 == 0. Valid.
     REQUIRE( pmm::detail::validate_user_ptr<AT>( dummy, 256, dummy + min_offset, min_offset ) );
+}
+
+TEST_CASE( "validation: header_from_ptr uses validate_user_ptr for cheap rejection", "[test_issue257]" )
+{
+    std::uint8_t dummy[256] = {};
+    std::size_t  min_offset =
+        sizeof( pmm::Block<AT> ) + sizeof( pmm::detail::ManagerHeader<AT> ) + sizeof( pmm::Block<AT> );
+    void* cases[] = {
+        nullptr,
+        dummy + 16,
+        dummy + 256,
+        dummy + min_offset + 1,
+    };
+
+    for ( void* ptr : cases )
+    {
+        CHECK_FALSE( pmm::detail::validate_user_ptr<AT>( dummy, 256, ptr, min_offset ) );
+        CHECK( pmm::detail::header_from_ptr_t<AT>( dummy, ptr, 256 ) == nullptr );
+    }
 }
 
 // ─── E. block_at_checked tests ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#301

## Summary
- Routes `detail::header_from_ptr_t()` through `detail::validate_user_ptr()` for the shared fast-path checks: image membership, minimum user address, granule alignment, and range safety.
- Hardens `validate_user_ptr()` to reject invalid minimum offsets and undersized images before computing the candidate block header offset.
- Adds regression coverage that keeps `header_from_ptr_t()` aligned with the canonical helper for invalid pointer cases, including `nullptr`, pre-user-area pointers, image-end pointers, and misaligned pointers.
- Adds a patch changelog fragment.

## Reproduce / Verification
- The drift was visible in `header_from_ptr_t()` carrying its own independent low-level checks instead of delegating to `validate_user_ptr()`.
- Regression tests are in `tests/test_issue257_validation.cpp`:
  - `validation: validate_user_ptr rejects image-end pointer`
  - `validation: header_from_ptr uses validate_user_ptr for cheap rejection`

## Local Checks
- `cmake --build build --target test_issue257_validation`
- `./build/tests/test_issue257_validation` -> 47 test cases, 120 assertions passed
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` -> 83/83 tests passed
- `clang-format --dry-run --Werror include/pmm/validation.h include/pmm/types.h tests/test_issue257_validation.cpp`
- tracked source file-size check for `include tests demo examples benchmarks scripts`
