### PR TITLE
ci: make demo workflow build only pmm_demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,13 +317,14 @@ jobs:
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=OFF \
             -DPMM_BUILD_DEMO=ON \
             -DPMM_BUILD_DEMO_TESTS=OFF \
             -DFETCHCONTENT_BASE_DIR=${{ github.workspace }}/.cmake-fetchcontent
 
       - name: Configure (Windows)
         if: runner.os == 'Windows'
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DPMM_BUILD_DEMO=ON -DPMM_BUILD_DEMO_TESTS=OFF -DFETCHCONTENT_BASE_DIR="${{ github.workspace }}\\.cmake-fetchcontent"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DPMM_BUILD_DEMO=ON -DPMM_BUILD_DEMO_TESTS=OFF -DFETCHCONTENT_BASE_DIR="${{ github.workspace }}\\.cmake-fetchcontent"
 
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build --config Release --target pmm_demo

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T13:58:43.770Z for PR creation at branch issue-308-deecbdc137b7 for issue https://github.com/netkeep80/PersistMemoryManager/issues/308


### PR DESCRIPTION
## Summary\n- Configure the demo CI job with `-DBUILD_TESTING=OFF` on Linux/macOS and Windows.\n- Build only the `pmm_demo` target in the demo job instead of the default build graph.\n\nFixes netkeep80/PersistMemoryManager#308\n\n## Verification\n- Checked workflow text assertions for `-DBUILD_TESTING=OFF`, `--target pmm_demo`, and absence of the unrestricted demo build command.\n- Ran `git diff --check`.\n- Attempted local demo configure/build with the same demo flags; configure stopped before build because this container is missing `wayland-scanner` (CI installs Wayland packages in the Linux demo job).


Fixes netkeep80/PersistMemoryManager#308