### PR TITLE
Ускорить CI сборки

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
+
 on:
   push:
     branches: ["**"]

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-19T13:58:43.770Z for PR creation at branch issue-308-deecbdc137b7 for issue https://github.com/netkeep80/PersistMemoryManager/issues/308
-# Updated: 2026-04-19T14:15:31.553Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-19T13:58:43.770Z for PR creation at branch issue-308-deecbdc137b7 for issue https://github.com/netkeep80/PersistMemoryManager/issues/308
+# Updated: 2026-04-19T14:15:31.553Z

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 
 # ─── Тесты ────────────────────────────────────────────────────────────────────
-enable_testing()
-add_subdirectory(tests)
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 # ─── Примеры ──────────────────────────────────────────────────────────────────
 add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AVL-based allocator, проверкой структуры и восстанов
 [![CI](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml/badge.svg)](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
-[![Version](https://img.shields.io/badge/version-0.55.5-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.55.10-green.svg)](CHANGELOG.md)
 
 ## Что это
 

--- a/changelog.d/20260419_142349_ci-build-speed.md
+++ b/changelog.d/20260419_142349_ci-build-speed.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Changed
+- Honor `BUILD_TESTING=OFF` in CMake so CI demo builds do not compile the full test suite.
+- Run CI CMake builds and CTest with a fixed parallelism level.


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#310

## Что изменено
- `CMakeLists.txt` теперь использует `include(CTest)` и добавляет `tests/` только при `BUILD_TESTING=ON`.
- В CI добавлены `CMAKE_BUILD_PARALLEL_LEVEL=4` и `CTEST_PARALLEL_LEVEL=4`, чтобы существующие build/test шаги использовали параллельное выполнение.
- Добавлен changelog fragment для изменения `CMakeLists.txt`.
- README version badge синхронизирован с уже текущими `CMakeLists.txt` и `CHANGELOG.md` (`0.55.10`), потому что изменение `CMakeLists.txt` включает release-owned version check.

## Причина
По логам CI run `24630575086` самые долгие шаги были компиляцией:
- `windows-latest / msvc`: build около 7m13s.
- `Build Demo (ubuntu-latest)`: build около 4m55s.
- `Build Demo (windows-latest)`: build около 5m09s.

При этом demo job запускал CMake с `-DBUILD_TESTING=OFF`, но top-level CMake всё равно добавлял `tests/`; в логе demo build были видны компиляции `tests/CMakeFiles/test_*`. Теперь demo build не должен компилировать полный набор тестовых executable.

## Проверка
- Repro до исправления: `cmake -S . -B experiments/build-no-tests-before -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF` всё равно создавал `test_*` targets.
- После исправления: та же конфигурация больше не содержит `test_*` targets.
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` — 83/83 passed.
- `clang-format --dry-run --Werror` по исходникам.
- `bash scripts/check-file-size.sh`
- `GITHUB_BASE_REF=main bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-version-consistency.sh`
- `git diff --check`