### PR TITLE
Verify free-tree structure

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T15:15:14.921Z for PR creation at branch issue-303-b2c1e301bd8d for issue https://github.com/netkeep80/PersistMemoryManager/issues/303

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T15:15:14.921Z for PR creation at branch issue-303-b2c1e301bd8d for issue https://github.com/netkeep80/PersistMemoryManager/issues/303

--- a/changelog.d/20260419_303_free_tree_verifier.md
+++ b/changelog.d/20260419_303_free_tree_verifier.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Hardened free-tree verification to detect structural AVL corruption before load rebuilds the tree.

--- a/include/pmm/allocator_policy.h
+++ b/include/pmm/allocator_policy.h
@@ -54,12 +54,10 @@
 #include "pmm/validation.h"
 
 #include <cassert>
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <vector>
 
 namespace pmm
 {
@@ -512,25 +510,22 @@ class AllocatorPolicy
      * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result )
+                                  VerifyResult& result ) noexcept
     {
-        std::vector<index_type>   expected_free;
-        std::vector<index_type>   visited_free;
-        std::vector<std::int16_t> heights;
-
-        index_type idx = hdr->first_block_offset;
+        std::size_t expected_count = 0;
+        index_type  idx            = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                expected_free.push_back( idx );
+                ++expected_count;
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_free.empty() )
+        if ( expected_count == 0 )
         {
             if ( root_present )
             {
@@ -542,7 +537,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( expected_count ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -560,140 +555,135 @@ class AllocatorPolicy
                         static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
         }
 
-        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        std::size_t visited_count = 0;
+        verify_free_tree_node( base, hdr, hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false,
+                               expected_count, visited_count, result );
+
+        idx = hdr->first_block_offset;
+        while ( idx != AddressTraitsT::no_block )
         {
-            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
-            index_type  n_next = BlockState::get_next_offset( n );
-            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
-            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
-                                                          : static_cast<index_type>( total - block_idx );
-        };
-        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
-        {
-            index_type a_gran = block_gran( base, a );
-            index_type b_gran = block_gran( base, b_idx );
-            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
-        };
-
-        struct Frame
-        {
-            index_type node;
-            index_type parent;
-            index_type lower;
-            bool       has_lower;
-            index_type upper;
-            bool       has_upper;
-            bool       expanded;
-        };
-        std::vector<Frame> stack;
-        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
-
-        while ( !stack.empty() )
-        {
-            Frame frame = stack.back();
-            stack.pop_back();
-            if ( frame.node == AddressTraitsT::no_block )
-                continue;
-            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
+                break;
+            const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
+            if ( BlockState::get_weight( blk_ptr ) == 0 &&
+                 !free_tree_contains( base, hdr, hdr->free_tree_root, idx, expected_count ) )
             {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
-                continue;
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( idx ),
+                            1, 0 );
             }
-
-            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
-            if ( BlockState::get_weight( node ) != 0 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 0,
-                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
-                continue;
-            }
-            if ( BlockState::get_parent_offset( node ) != frame.parent )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
-                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
-            }
-            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
-                            static_cast<std::uint64_t>( frame.node ) );
-            }
-            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
-                            static_cast<std::uint64_t>( frame.upper ) );
-            }
-
-            const bool already_seen =
-                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
-            if ( !frame.expanded && already_seen )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
-                continue;
-            }
-
-            if ( !frame.expanded )
-            {
-                visited_free.push_back( frame.node );
-                heights.push_back( 0 );
-                stack.push_back(
-                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
-                index_type right = BlockState::get_right_offset( node );
-                index_type left  = BlockState::get_left_offset( node );
-                if ( right != AddressTraitsT::no_block )
-                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
-                if ( left != AddressTraitsT::no_block )
-                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
-                continue;
-            }
-
-            std::int16_t left_h = 0, right_h = 0;
-            index_type   left  = BlockState::get_left_offset( node );
-            index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == left )
-                    left_h = heights[i];
-                if ( visited_free[i] == right )
-                    right_h = heights[i];
-            }
-            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
-            std::int16_t stored_h   = BlockState::get_avl_height( node );
-            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
-                            static_cast<std::uint64_t>( stored_h ) );
-            }
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == frame.node )
-                {
-                    heights[i] = expected_h;
-                    break;
-                }
-            }
+            idx = BlockState::get_next_offset( blk_ptr );
         }
-
-        for ( index_type expected : expected_free )
-        {
-            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( expected ), 1, 0 );
-            }
-        }
-        if ( visited_free.size() != expected_free.size() )
+        if ( visited_count != expected_count )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
-                        static_cast<std::uint64_t>( visited_free.size() ) );
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
+    }
+
+  private:
+    static index_type free_tree_block_granules( const std::uint8_t*                          base,
+                                                const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                                index_type                                   block_idx ) noexcept
+    {
+        const void* n      = detail::block_at<AddressTraitsT>( base, block_idx );
+        index_type  n_next = BlockState::get_next_offset( n );
+        index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+        return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                      : static_cast<index_type>( total - block_idx );
+    }
+
+    static bool free_tree_less_key( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type a, index_type b ) noexcept
+    {
+        index_type a_gran = free_tree_block_granules( base, hdr, a );
+        index_type b_gran = free_tree_block_granules( base, hdr, b );
+        return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b );
+    }
+
+    static bool free_tree_contains( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type node_idx, index_type target, std::size_t step_limit ) noexcept
+    {
+        while ( node_idx != AddressTraitsT::no_block && step_limit-- > 0 )
+        {
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+                return false;
+            const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+            if ( BlockState::get_weight( node ) != 0 )
+                return false;
+            if ( node_idx == target )
+                return true;
+            node_idx = free_tree_less_key( base, hdr, target, node_idx ) ? BlockState::get_left_offset( node )
+                                                                         : BlockState::get_right_offset( node );
+        }
+        return false;
+    }
+
+    static std::int16_t verify_free_tree_node( const std::uint8_t*                          base,
+                                               const detail::ManagerHeader<AddressTraitsT>* hdr, index_type node_idx,
+                                               index_type parent, index_type lower, bool has_lower, index_type upper,
+                                               bool has_upper, std::size_t expected_count, std::size_t& visited_count,
+                                               VerifyResult& result ) noexcept
+    {
+        if ( node_idx == AddressTraitsT::no_block )
+            return 0;
+        if ( visited_count >= expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 1, 2 );
+            return 0;
+        }
+        ++visited_count;
+
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( parent ),
+                        0, static_cast<std::uint64_t>( node_idx ) );
+            return 0;
+        }
+
+        const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+        if ( BlockState::get_weight( node ) != 0 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+            return 0;
+        }
+        if ( BlockState::get_parent_offset( node ) != parent )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( parent ),
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+        }
+        if ( has_lower && !free_tree_less_key( base, hdr, lower, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( lower ),
+                        static_cast<std::uint64_t>( node_idx ) );
+        }
+        if ( has_upper && !free_tree_less_key( base, hdr, node_idx, upper ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( node_idx ),
+                        static_cast<std::uint64_t>( upper ) );
+        }
+
+        index_type left  = BlockState::get_left_offset( node );
+        index_type right = BlockState::get_right_offset( node );
+
+        std::int16_t left_h     = verify_free_tree_node( base, hdr, left, node_idx, lower, has_lower, node_idx, true,
+                                                         expected_count, visited_count, result );
+        std::int16_t right_h    = verify_free_tree_node( base, hdr, right, node_idx, node_idx, true, upper, has_upper,
+                                                         expected_count, visited_count, result );
+        std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+        std::int16_t stored_h   = BlockState::get_avl_height( node );
+        if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( expected_h ),
+                        static_cast<std::uint64_t>( stored_h ) );
+        }
+        return expected_h;
     }
 
     // ─── reallocate_typed helpers ─────────────────────────────────

--- a/include/pmm/allocator_policy.h
+++ b/include/pmm/allocator_policy.h
@@ -51,8 +51,11 @@
 #include "pmm/diagnostics.h"
 #include "pmm/free_block_tree.h"
 #include "pmm/types.h"
+#include "pmm/validation.h"
 
 #include <cassert>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -503,38 +506,214 @@ class AllocatorPolicy
     }
 
     /**
-     * @brief Verify free tree root consistency without modifying the image.
+     * @brief Verify free tree structure without modifying the image.
      *
-     * Checks that the free_tree_root is consistent with the presence of free blocks.
-     * After file round-trip, AVL fields are not persisted, so the free tree root
-     * typically points to stale or zeroed AVL data. This check detects that condition.
-     *
-     * @param base    Base pointer of the managed area.
-     * @param hdr     Manager header (read-only).
-     * @param result  Diagnostic result to append violations to.
+     * Checks root validity, AVL parent/child links, strict ordering, height/balance,
+     * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
                                   VerifyResult& result ) noexcept
     {
-        // Count free blocks by walking the linked list.
-        index_type free_count = 0;
-        index_type idx        = hdr->first_block_offset;
+        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
+        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
+        std::size_t                                   expected_count    = 0;
+        std::size_t                                   visited_count     = 0;
+        bool                                          expected_overflow = false;
+
+        index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                free_count++;
+            {
+                if ( expected_count < expected_free.size() )
+                    expected_free[expected_count] = idx;
+                else
+                    expected_overflow = true;
+                expected_count++;
+            }
             idx = BlockState::get_next_offset( blk_ptr );
         }
-        // If free blocks exist but the tree root is no_block (or vice versa),
-        // the free tree is stale and needs rebuild.
-        bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( ( free_count > 0 && !root_present ) || ( free_count == 0 && root_present ) )
+
+        const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
+        if ( expected_count == 0 )
+        {
+            if ( root_present )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0, 0,
+                            static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            }
+            return;
+        }
+        if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( free_count ), static_cast<std::uint64_t>( hdr->free_tree_root ) );
+                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            return;
+        }
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, hdr->free_tree_root ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 1, 0 );
+            return;
+        }
+        const void* root = detail::block_at<AddressTraitsT>( base, hdr->free_tree_root );
+        if ( BlockState::get_weight( root ) != 0 || BlockState::get_parent_offset( root ) != AddressTraitsT::no_block )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
+        }
+
+        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        {
+            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
+            index_type  n_next = BlockState::get_next_offset( n );
+            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                          : static_cast<index_type>( total - block_idx );
+        };
+        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
+        {
+            index_type a_gran = block_gran( base, a );
+            index_type b_gran = block_gran( base, b_idx );
+            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
+        };
+
+        struct Frame
+        {
+            index_type node;
+            index_type parent;
+            index_type lower;
+            bool       has_lower;
+            index_type upper;
+            bool       has_upper;
+            bool       expanded;
+        };
+        std::array<Frame, kMaxDiagnosticEntries>        stack{};
+        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
+        std::size_t                                     stack_size = 0;
+        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+
+        while ( stack_size > 0 )
+        {
+            Frame frame = stack[--stack_size];
+            if ( frame.node == AddressTraitsT::no_block )
+                continue;
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
+                continue;
+            }
+
+            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
+            if ( BlockState::get_weight( node ) != 0 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 0,
+                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+                continue;
+            }
+            if ( BlockState::get_parent_offset( node ) != frame.parent )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
+                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+            }
+            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
+                            static_cast<std::uint64_t>( frame.node ) );
+            }
+            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
+                            static_cast<std::uint64_t>( frame.upper ) );
+            }
+
+            const auto visited_begin = visited_free.begin();
+            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
+            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            if ( !frame.expanded && already_seen )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
+                continue;
+            }
+
+            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
+                            static_cast<std::uint64_t>( visited_count ) );
+                break;
+            }
+
+            if ( !frame.expanded )
+            {
+                visited_free[visited_count++] = frame.node;
+                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
+                                                  frame.upper, frame.has_upper, true };
+                index_type right              = BlockState::get_right_offset( node );
+                index_type left               = BlockState::get_left_offset( node );
+                if ( right != AddressTraitsT::no_block )
+                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                if ( left != AddressTraitsT::no_block )
+                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                continue;
+            }
+
+            std::int16_t left_h = 0, right_h = 0;
+            index_type   left  = BlockState::get_left_offset( node );
+            index_type   right = BlockState::get_right_offset( node );
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == left )
+                    left_h = heights[i];
+                if ( visited_free[i] == right )
+                    right_h = heights[i];
+            }
+            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+            std::int16_t stored_h   = BlockState::get_avl_height( node );
+            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
+                            static_cast<std::uint64_t>( stored_h ) );
+            }
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == frame.node )
+                {
+                    heights[i] = expected_h;
+                    break;
+                }
+            }
+        }
+
+        if ( !expected_overflow )
+        {
+            for ( std::size_t i = 0; i < expected_count; ++i )
+            {
+                const auto begin = visited_free.begin();
+                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
+                if ( std::find( begin, end, expected_free[i] ) == end )
+                {
+                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
+                }
+            }
+        }
+        if ( visited_count != expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
     }
 

--- a/include/pmm/allocator_policy.h
+++ b/include/pmm/allocator_policy.h
@@ -580,7 +580,6 @@ class AllocatorPolicy
         }
     }
 
-  private:
     static index_type free_tree_block_granules( const std::uint8_t*                          base,
                                                 const detail::ManagerHeader<AddressTraitsT>* hdr,
                                                 index_type                                   block_idx ) noexcept

--- a/include/pmm/allocator_policy.h
+++ b/include/pmm/allocator_policy.h
@@ -55,11 +55,11 @@
 
 #include <cassert>
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <vector>
 
 namespace pmm
 {
@@ -512,13 +512,11 @@ class AllocatorPolicy
      * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result ) noexcept
+                                  VerifyResult& result )
     {
-        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
-        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
-        std::size_t                                   expected_count    = 0;
-        std::size_t                                   visited_count     = 0;
-        bool                                          expected_overflow = false;
+        std::vector<index_type>   expected_free;
+        std::vector<index_type>   visited_free;
+        std::vector<std::int16_t> heights;
 
         index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
@@ -527,18 +525,12 @@ class AllocatorPolicy
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-            {
-                if ( expected_count < expected_free.size() )
-                    expected_free[expected_count] = idx;
-                else
-                    expected_overflow = true;
-                expected_count++;
-            }
+                expected_free.push_back( idx );
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_count == 0 )
+        if ( expected_free.empty() )
         {
             if ( root_present )
             {
@@ -550,7 +542,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( expected_free.size() ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -593,14 +585,13 @@ class AllocatorPolicy
             bool       has_upper;
             bool       expanded;
         };
-        std::array<Frame, kMaxDiagnosticEntries>        stack{};
-        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
-        std::size_t                                     stack_size = 0;
-        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+        std::vector<Frame> stack;
+        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
 
-        while ( stack_size > 0 )
+        while ( !stack.empty() )
         {
-            Frame frame = stack[--stack_size];
+            Frame frame = stack.back();
+            stack.pop_back();
             if ( frame.node == AddressTraitsT::no_block )
                 continue;
             if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
@@ -637,9 +628,8 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.upper ) );
             }
 
-            const auto visited_begin = visited_free.begin();
-            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
-            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            const bool already_seen =
+                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
             if ( !frame.expanded && already_seen )
             {
                 result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
@@ -647,32 +637,25 @@ class AllocatorPolicy
                 continue;
             }
 
-            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
-                            static_cast<std::uint64_t>( visited_count ) );
-                break;
-            }
-
             if ( !frame.expanded )
             {
-                visited_free[visited_count++] = frame.node;
-                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
-                                                  frame.upper, frame.has_upper, true };
-                index_type right              = BlockState::get_right_offset( node );
-                index_type left               = BlockState::get_left_offset( node );
+                visited_free.push_back( frame.node );
+                heights.push_back( 0 );
+                stack.push_back(
+                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
+                index_type right = BlockState::get_right_offset( node );
+                index_type left  = BlockState::get_left_offset( node );
                 if ( right != AddressTraitsT::no_block )
-                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
                 if ( left != AddressTraitsT::no_block )
-                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
                 continue;
             }
 
             std::int16_t left_h = 0, right_h = 0;
             index_type   left  = BlockState::get_left_offset( node );
             index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == left )
                     left_h = heights[i];
@@ -687,7 +670,7 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
                             static_cast<std::uint64_t>( stored_h ) );
             }
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == frame.node )
                 {
@@ -697,23 +680,19 @@ class AllocatorPolicy
             }
         }
 
-        if ( !expected_overflow )
+        for ( index_type expected : expected_free )
         {
-            for ( std::size_t i = 0; i < expected_count; ++i )
+            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
             {
-                const auto begin = visited_free.begin();
-                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
-                if ( std::find( begin, end, expected_free[i] ) == end )
-                {
-                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
-                }
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( expected ), 1, 0 );
             }
         }
-        if ( visited_count != expected_count )
+        if ( visited_free.size() != expected_free.size() )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
+                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( visited_free.size() ) );
         }
     }
 

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -3850,6 +3850,8 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
  */
 
 #include <cassert>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -4300,38 +4302,214 @@ class AllocatorPolicy
     }
 
     /**
-     * @brief Verify free tree root consistency without modifying the image.
+     * @brief Verify free tree structure without modifying the image.
      *
-     * Checks that the free_tree_root is consistent with the presence of free blocks.
-     * After file round-trip, AVL fields are not persisted, so the free tree root
-     * typically points to stale or zeroed AVL data. This check detects that condition.
-     *
-     * @param base    Base pointer of the managed area.
-     * @param hdr     Manager header (read-only).
-     * @param result  Diagnostic result to append violations to.
+     * Checks root validity, AVL parent/child links, strict ordering, height/balance,
+     * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
                                   VerifyResult& result ) noexcept
     {
-        // Count free blocks by walking the linked list.
-        index_type free_count = 0;
-        index_type idx        = hdr->first_block_offset;
+        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
+        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
+        std::size_t                                   expected_count    = 0;
+        std::size_t                                   visited_count     = 0;
+        bool                                          expected_overflow = false;
+
+        index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                free_count++;
+            {
+                if ( expected_count < expected_free.size() )
+                    expected_free[expected_count] = idx;
+                else
+                    expected_overflow = true;
+                expected_count++;
+            }
             idx = BlockState::get_next_offset( blk_ptr );
         }
-        // If free blocks exist but the tree root is no_block (or vice versa),
-        // the free tree is stale and needs rebuild.
-        bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( ( free_count > 0 && !root_present ) || ( free_count == 0 && root_present ) )
+
+        const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
+        if ( expected_count == 0 )
+        {
+            if ( root_present )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0, 0,
+                            static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            }
+            return;
+        }
+        if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( free_count ), static_cast<std::uint64_t>( hdr->free_tree_root ) );
+                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            return;
+        }
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, hdr->free_tree_root ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 1, 0 );
+            return;
+        }
+        const void* root = detail::block_at<AddressTraitsT>( base, hdr->free_tree_root );
+        if ( BlockState::get_weight( root ) != 0 || BlockState::get_parent_offset( root ) != AddressTraitsT::no_block )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
+        }
+
+        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        {
+            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
+            index_type  n_next = BlockState::get_next_offset( n );
+            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                          : static_cast<index_type>( total - block_idx );
+        };
+        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
+        {
+            index_type a_gran = block_gran( base, a );
+            index_type b_gran = block_gran( base, b_idx );
+            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
+        };
+
+        struct Frame
+        {
+            index_type node;
+            index_type parent;
+            index_type lower;
+            bool       has_lower;
+            index_type upper;
+            bool       has_upper;
+            bool       expanded;
+        };
+        std::array<Frame, kMaxDiagnosticEntries>        stack{};
+        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
+        std::size_t                                     stack_size = 0;
+        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+
+        while ( stack_size > 0 )
+        {
+            Frame frame = stack[--stack_size];
+            if ( frame.node == AddressTraitsT::no_block )
+                continue;
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
+                continue;
+            }
+
+            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
+            if ( BlockState::get_weight( node ) != 0 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 0,
+                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+                continue;
+            }
+            if ( BlockState::get_parent_offset( node ) != frame.parent )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
+                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+            }
+            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
+                            static_cast<std::uint64_t>( frame.node ) );
+            }
+            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
+                            static_cast<std::uint64_t>( frame.upper ) );
+            }
+
+            const auto visited_begin = visited_free.begin();
+            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
+            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            if ( !frame.expanded && already_seen )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
+                continue;
+            }
+
+            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
+                            static_cast<std::uint64_t>( visited_count ) );
+                break;
+            }
+
+            if ( !frame.expanded )
+            {
+                visited_free[visited_count++] = frame.node;
+                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
+                                                  frame.upper, frame.has_upper, true };
+                index_type right              = BlockState::get_right_offset( node );
+                index_type left               = BlockState::get_left_offset( node );
+                if ( right != AddressTraitsT::no_block )
+                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                if ( left != AddressTraitsT::no_block )
+                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                continue;
+            }
+
+            std::int16_t left_h = 0, right_h = 0;
+            index_type   left  = BlockState::get_left_offset( node );
+            index_type   right = BlockState::get_right_offset( node );
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == left )
+                    left_h = heights[i];
+                if ( visited_free[i] == right )
+                    right_h = heights[i];
+            }
+            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+            std::int16_t stored_h   = BlockState::get_avl_height( node );
+            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
+                            static_cast<std::uint64_t>( stored_h ) );
+            }
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == frame.node )
+                {
+                    heights[i] = expected_h;
+                    break;
+                }
+            }
+        }
+
+        if ( !expected_overflow )
+        {
+            for ( std::size_t i = 0; i < expected_count; ++i )
+            {
+                const auto begin = visited_free.begin();
+                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
+                if ( std::find( begin, end, expected_free[i] ) == end )
+                {
+                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
+                }
+            }
+        }
+        if ( visited_count != expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
     }
 

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -3850,12 +3850,10 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
  */
 
 #include <cassert>
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <vector>
 
 namespace pmm
 {
@@ -4308,25 +4306,22 @@ class AllocatorPolicy
      * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result )
+                                  VerifyResult& result ) noexcept
     {
-        std::vector<index_type>   expected_free;
-        std::vector<index_type>   visited_free;
-        std::vector<std::int16_t> heights;
-
-        index_type idx = hdr->first_block_offset;
+        std::size_t expected_count = 0;
+        index_type  idx            = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                expected_free.push_back( idx );
+                ++expected_count;
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_free.empty() )
+        if ( expected_count == 0 )
         {
             if ( root_present )
             {
@@ -4338,7 +4333,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( expected_count ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -4356,140 +4351,135 @@ class AllocatorPolicy
                         static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
         }
 
-        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        std::size_t visited_count = 0;
+        verify_free_tree_node( base, hdr, hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false,
+                               expected_count, visited_count, result );
+
+        idx = hdr->first_block_offset;
+        while ( idx != AddressTraitsT::no_block )
         {
-            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
-            index_type  n_next = BlockState::get_next_offset( n );
-            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
-            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
-                                                          : static_cast<index_type>( total - block_idx );
-        };
-        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
-        {
-            index_type a_gran = block_gran( base, a );
-            index_type b_gran = block_gran( base, b_idx );
-            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
-        };
-
-        struct Frame
-        {
-            index_type node;
-            index_type parent;
-            index_type lower;
-            bool       has_lower;
-            index_type upper;
-            bool       has_upper;
-            bool       expanded;
-        };
-        std::vector<Frame> stack;
-        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
-
-        while ( !stack.empty() )
-        {
-            Frame frame = stack.back();
-            stack.pop_back();
-            if ( frame.node == AddressTraitsT::no_block )
-                continue;
-            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
+                break;
+            const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
+            if ( BlockState::get_weight( blk_ptr ) == 0 &&
+                 !free_tree_contains( base, hdr, hdr->free_tree_root, idx, expected_count ) )
             {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
-                continue;
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( idx ),
+                            1, 0 );
             }
-
-            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
-            if ( BlockState::get_weight( node ) != 0 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 0,
-                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
-                continue;
-            }
-            if ( BlockState::get_parent_offset( node ) != frame.parent )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
-                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
-            }
-            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
-                            static_cast<std::uint64_t>( frame.node ) );
-            }
-            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
-                            static_cast<std::uint64_t>( frame.upper ) );
-            }
-
-            const bool already_seen =
-                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
-            if ( !frame.expanded && already_seen )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
-                continue;
-            }
-
-            if ( !frame.expanded )
-            {
-                visited_free.push_back( frame.node );
-                heights.push_back( 0 );
-                stack.push_back(
-                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
-                index_type right = BlockState::get_right_offset( node );
-                index_type left  = BlockState::get_left_offset( node );
-                if ( right != AddressTraitsT::no_block )
-                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
-                if ( left != AddressTraitsT::no_block )
-                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
-                continue;
-            }
-
-            std::int16_t left_h = 0, right_h = 0;
-            index_type   left  = BlockState::get_left_offset( node );
-            index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == left )
-                    left_h = heights[i];
-                if ( visited_free[i] == right )
-                    right_h = heights[i];
-            }
-            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
-            std::int16_t stored_h   = BlockState::get_avl_height( node );
-            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
-                            static_cast<std::uint64_t>( stored_h ) );
-            }
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == frame.node )
-                {
-                    heights[i] = expected_h;
-                    break;
-                }
-            }
+            idx = BlockState::get_next_offset( blk_ptr );
         }
-
-        for ( index_type expected : expected_free )
-        {
-            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( expected ), 1, 0 );
-            }
-        }
-        if ( visited_free.size() != expected_free.size() )
+        if ( visited_count != expected_count )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
-                        static_cast<std::uint64_t>( visited_free.size() ) );
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
+    }
+
+  private:
+    static index_type free_tree_block_granules( const std::uint8_t*                          base,
+                                                const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                                index_type                                   block_idx ) noexcept
+    {
+        const void* n      = detail::block_at<AddressTraitsT>( base, block_idx );
+        index_type  n_next = BlockState::get_next_offset( n );
+        index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+        return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                      : static_cast<index_type>( total - block_idx );
+    }
+
+    static bool free_tree_less_key( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type a, index_type b ) noexcept
+    {
+        index_type a_gran = free_tree_block_granules( base, hdr, a );
+        index_type b_gran = free_tree_block_granules( base, hdr, b );
+        return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b );
+    }
+
+    static bool free_tree_contains( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type node_idx, index_type target, std::size_t step_limit ) noexcept
+    {
+        while ( node_idx != AddressTraitsT::no_block && step_limit-- > 0 )
+        {
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+                return false;
+            const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+            if ( BlockState::get_weight( node ) != 0 )
+                return false;
+            if ( node_idx == target )
+                return true;
+            node_idx = free_tree_less_key( base, hdr, target, node_idx ) ? BlockState::get_left_offset( node )
+                                                                         : BlockState::get_right_offset( node );
+        }
+        return false;
+    }
+
+    static std::int16_t verify_free_tree_node( const std::uint8_t*                          base,
+                                               const detail::ManagerHeader<AddressTraitsT>* hdr, index_type node_idx,
+                                               index_type parent, index_type lower, bool has_lower, index_type upper,
+                                               bool has_upper, std::size_t expected_count, std::size_t& visited_count,
+                                               VerifyResult& result ) noexcept
+    {
+        if ( node_idx == AddressTraitsT::no_block )
+            return 0;
+        if ( visited_count >= expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 1, 2 );
+            return 0;
+        }
+        ++visited_count;
+
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( parent ),
+                        0, static_cast<std::uint64_t>( node_idx ) );
+            return 0;
+        }
+
+        const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+        if ( BlockState::get_weight( node ) != 0 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+            return 0;
+        }
+        if ( BlockState::get_parent_offset( node ) != parent )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( parent ),
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+        }
+        if ( has_lower && !free_tree_less_key( base, hdr, lower, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( lower ),
+                        static_cast<std::uint64_t>( node_idx ) );
+        }
+        if ( has_upper && !free_tree_less_key( base, hdr, node_idx, upper ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( node_idx ),
+                        static_cast<std::uint64_t>( upper ) );
+        }
+
+        index_type left  = BlockState::get_left_offset( node );
+        index_type right = BlockState::get_right_offset( node );
+
+        std::int16_t left_h     = verify_free_tree_node( base, hdr, left, node_idx, lower, has_lower, node_idx, true,
+                                                         expected_count, visited_count, result );
+        std::int16_t right_h    = verify_free_tree_node( base, hdr, right, node_idx, node_idx, true, upper, has_upper,
+                                                         expected_count, visited_count, result );
+        std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+        std::int16_t stored_h   = BlockState::get_avl_height( node );
+        if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( expected_h ),
+                        static_cast<std::uint64_t>( stored_h ) );
+        }
+        return expected_h;
     }
 
     // ─── reallocate_typed helpers ─────────────────────────────────

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -4376,7 +4376,6 @@ class AllocatorPolicy
         }
     }
 
-  private:
     static index_type free_tree_block_granules( const std::uint8_t*                          base,
                                                 const detail::ManagerHeader<AddressTraitsT>* hdr,
                                                 index_type                                   block_idx ) noexcept

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -3851,11 +3851,11 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
 
 #include <cassert>
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <vector>
 
 namespace pmm
 {
@@ -4308,13 +4308,11 @@ class AllocatorPolicy
      * duplicate visits, and membership equality with the linked-list free blocks.
      */
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result ) noexcept
+                                  VerifyResult& result )
     {
-        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
-        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
-        std::size_t                                   expected_count    = 0;
-        std::size_t                                   visited_count     = 0;
-        bool                                          expected_overflow = false;
+        std::vector<index_type>   expected_free;
+        std::vector<index_type>   visited_free;
+        std::vector<std::int16_t> heights;
 
         index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
@@ -4323,18 +4321,12 @@ class AllocatorPolicy
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-            {
-                if ( expected_count < expected_free.size() )
-                    expected_free[expected_count] = idx;
-                else
-                    expected_overflow = true;
-                expected_count++;
-            }
+                expected_free.push_back( idx );
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_count == 0 )
+        if ( expected_free.empty() )
         {
             if ( root_present )
             {
@@ -4346,7 +4338,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( expected_free.size() ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -4389,14 +4381,13 @@ class AllocatorPolicy
             bool       has_upper;
             bool       expanded;
         };
-        std::array<Frame, kMaxDiagnosticEntries>        stack{};
-        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
-        std::size_t                                     stack_size = 0;
-        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+        std::vector<Frame> stack;
+        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
 
-        while ( stack_size > 0 )
+        while ( !stack.empty() )
         {
-            Frame frame = stack[--stack_size];
+            Frame frame = stack.back();
+            stack.pop_back();
             if ( frame.node == AddressTraitsT::no_block )
                 continue;
             if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
@@ -4433,9 +4424,8 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.upper ) );
             }
 
-            const auto visited_begin = visited_free.begin();
-            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
-            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            const bool already_seen =
+                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
             if ( !frame.expanded && already_seen )
             {
                 result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
@@ -4443,32 +4433,25 @@ class AllocatorPolicy
                 continue;
             }
 
-            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
-                            static_cast<std::uint64_t>( visited_count ) );
-                break;
-            }
-
             if ( !frame.expanded )
             {
-                visited_free[visited_count++] = frame.node;
-                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
-                                                  frame.upper, frame.has_upper, true };
-                index_type right              = BlockState::get_right_offset( node );
-                index_type left               = BlockState::get_left_offset( node );
+                visited_free.push_back( frame.node );
+                heights.push_back( 0 );
+                stack.push_back(
+                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
+                index_type right = BlockState::get_right_offset( node );
+                index_type left  = BlockState::get_left_offset( node );
                 if ( right != AddressTraitsT::no_block )
-                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
                 if ( left != AddressTraitsT::no_block )
-                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
                 continue;
             }
 
             std::int16_t left_h = 0, right_h = 0;
             index_type   left  = BlockState::get_left_offset( node );
             index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == left )
                     left_h = heights[i];
@@ -4483,7 +4466,7 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
                             static_cast<std::uint64_t>( stored_h ) );
             }
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == frame.node )
                 {
@@ -4493,23 +4476,19 @@ class AllocatorPolicy
             }
         }
 
-        if ( !expected_overflow )
+        for ( index_type expected : expected_free )
         {
-            for ( std::size_t i = 0; i < expected_count; ++i )
+            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
             {
-                const auto begin = visited_free.begin();
-                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
-                if ( std::find( begin, end, expected_free[i] ) == end )
-                {
-                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
-                }
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( expected ), 1, 0 );
             }
         }
-        if ( visited_count != expected_count )
+        if ( visited_free.size() != expected_free.size() )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
+                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( visited_free.size() ) );
         }
     }
 

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2180,12 +2180,10 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
 #endif
 
 #include <cassert>
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <vector>
 
 namespace pmm
 {
@@ -2500,25 +2498,22 @@ class AllocatorPolicy
     }
 
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result )
+                                  VerifyResult& result ) noexcept
     {
-        std::vector<index_type>   expected_free;
-        std::vector<index_type>   visited_free;
-        std::vector<std::int16_t> heights;
-
-        index_type idx = hdr->first_block_offset;
+        std::size_t expected_count = 0;
+        index_type  idx            = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                expected_free.push_back( idx );
+                ++expected_count;
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_free.empty() )
+        if ( expected_count == 0 )
         {
             if ( root_present )
             {
@@ -2530,7 +2525,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( expected_count ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -2548,140 +2543,135 @@ class AllocatorPolicy
                         static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
         }
 
-        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        std::size_t visited_count = 0;
+        verify_free_tree_node( base, hdr, hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false,
+                               expected_count, visited_count, result );
+
+        idx = hdr->first_block_offset;
+        while ( idx != AddressTraitsT::no_block )
         {
-            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
-            index_type  n_next = BlockState::get_next_offset( n );
-            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
-            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
-                                                          : static_cast<index_type>( total - block_idx );
-        };
-        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
-        {
-            index_type a_gran = block_gran( base, a );
-            index_type b_gran = block_gran( base, b_idx );
-            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
-        };
-
-        struct Frame
-        {
-            index_type node;
-            index_type parent;
-            index_type lower;
-            bool       has_lower;
-            index_type upper;
-            bool       has_upper;
-            bool       expanded;
-        };
-        std::vector<Frame> stack;
-        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
-
-        while ( !stack.empty() )
-        {
-            Frame frame = stack.back();
-            stack.pop_back();
-            if ( frame.node == AddressTraitsT::no_block )
-                continue;
-            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
+                break;
+            const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
+            if ( BlockState::get_weight( blk_ptr ) == 0 &&
+                 !free_tree_contains( base, hdr, hdr->free_tree_root, idx, expected_count ) )
             {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
-                continue;
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( idx ),
+                            1, 0 );
             }
-
-            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
-            if ( BlockState::get_weight( node ) != 0 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 0,
-                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
-                continue;
-            }
-            if ( BlockState::get_parent_offset( node ) != frame.parent )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
-                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
-            }
-            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
-                            static_cast<std::uint64_t>( frame.node ) );
-            }
-            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
-                            static_cast<std::uint64_t>( frame.upper ) );
-            }
-
-            const bool already_seen =
-                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
-            if ( !frame.expanded && already_seen )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
-                continue;
-            }
-
-            if ( !frame.expanded )
-            {
-                visited_free.push_back( frame.node );
-                heights.push_back( 0 );
-                stack.push_back(
-                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
-                index_type right = BlockState::get_right_offset( node );
-                index_type left  = BlockState::get_left_offset( node );
-                if ( right != AddressTraitsT::no_block )
-                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
-                if ( left != AddressTraitsT::no_block )
-                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
-                continue;
-            }
-
-            std::int16_t left_h = 0, right_h = 0;
-            index_type   left  = BlockState::get_left_offset( node );
-            index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == left )
-                    left_h = heights[i];
-                if ( visited_free[i] == right )
-                    right_h = heights[i];
-            }
-            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
-            std::int16_t stored_h   = BlockState::get_avl_height( node );
-            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
-                            static_cast<std::uint64_t>( stored_h ) );
-            }
-            for ( std::size_t i = 0; i < visited_free.size(); ++i )
-            {
-                if ( visited_free[i] == frame.node )
-                {
-                    heights[i] = expected_h;
-                    break;
-                }
-            }
+            idx = BlockState::get_next_offset( blk_ptr );
         }
-
-        for ( index_type expected : expected_free )
-        {
-            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( expected ), 1, 0 );
-            }
-        }
-        if ( visited_free.size() != expected_free.size() )
+        if ( visited_count != expected_count )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_free.size() ),
-                        static_cast<std::uint64_t>( visited_free.size() ) );
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
+    }
+
+  private:
+    static index_type free_tree_block_granules( const std::uint8_t*                          base,
+                                                const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                                index_type                                   block_idx ) noexcept
+    {
+        const void* n      = detail::block_at<AddressTraitsT>( base, block_idx );
+        index_type  n_next = BlockState::get_next_offset( n );
+        index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+        return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                      : static_cast<index_type>( total - block_idx );
+    }
+
+    static bool free_tree_less_key( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type a, index_type b ) noexcept
+    {
+        index_type a_gran = free_tree_block_granules( base, hdr, a );
+        index_type b_gran = free_tree_block_granules( base, hdr, b );
+        return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b );
+    }
+
+    static bool free_tree_contains( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
+                                    index_type node_idx, index_type target, std::size_t step_limit ) noexcept
+    {
+        while ( node_idx != AddressTraitsT::no_block && step_limit-- > 0 )
+        {
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+                return false;
+            const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+            if ( BlockState::get_weight( node ) != 0 )
+                return false;
+            if ( node_idx == target )
+                return true;
+            node_idx = free_tree_less_key( base, hdr, target, node_idx ) ? BlockState::get_left_offset( node )
+                                                                         : BlockState::get_right_offset( node );
+        }
+        return false;
+    }
+
+    static std::int16_t verify_free_tree_node( const std::uint8_t*                          base,
+                                               const detail::ManagerHeader<AddressTraitsT>* hdr, index_type node_idx,
+                                               index_type parent, index_type lower, bool has_lower, index_type upper,
+                                               bool has_upper, std::size_t expected_count, std::size_t& visited_count,
+                                               VerifyResult& result ) noexcept
+    {
+        if ( node_idx == AddressTraitsT::no_block )
+            return 0;
+        if ( visited_count >= expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 1, 2 );
+            return 0;
+        }
+        ++visited_count;
+
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, static_cast<std::uint64_t>( parent ),
+                        0, static_cast<std::uint64_t>( node_idx ) );
+            return 0;
+        }
+
+        const void* node = detail::block_at<AddressTraitsT>( base, node_idx );
+        if ( BlockState::get_weight( node ) != 0 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+            return 0;
+        }
+        if ( BlockState::get_parent_offset( node ) != parent )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( parent ),
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+        }
+        if ( has_lower && !free_tree_less_key( base, hdr, lower, node_idx ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( lower ),
+                        static_cast<std::uint64_t>( node_idx ) );
+        }
+        if ( has_upper && !free_tree_less_key( base, hdr, node_idx, upper ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( node_idx ),
+                        static_cast<std::uint64_t>( upper ) );
+        }
+
+        index_type left  = BlockState::get_left_offset( node );
+        index_type right = BlockState::get_right_offset( node );
+
+        std::int16_t left_h     = verify_free_tree_node( base, hdr, left, node_idx, lower, has_lower, node_idx, true,
+                                                         expected_count, visited_count, result );
+        std::int16_t right_h    = verify_free_tree_node( base, hdr, right, node_idx, node_idx, true, upper, has_upper,
+                                                         expected_count, visited_count, result );
+        std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+        std::int16_t stored_h   = BlockState::get_avl_height( node );
+        if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( node_idx ), static_cast<std::uint64_t>( expected_h ),
+                        static_cast<std::uint64_t>( stored_h ) );
+        }
+        return expected_h;
     }
 
     static void realloc_shrink( std::uint8_t* base, detail::ManagerHeader<AddressTraitsT>* hdr, index_type blk_idx,

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2568,7 +2568,6 @@ class AllocatorPolicy
         }
     }
 
-  private:
     static index_type free_tree_block_granules( const std::uint8_t*                          base,
                                                 const detail::ManagerHeader<AddressTraitsT>* hdr,
                                                 index_type                                   block_idx ) noexcept

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2181,11 +2181,11 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
 
 #include <cassert>
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <vector>
 
 namespace pmm
 {
@@ -2500,13 +2500,11 @@ class AllocatorPolicy
     }
 
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
-                                  VerifyResult& result ) noexcept
+                                  VerifyResult& result )
     {
-        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
-        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
-        std::size_t                                   expected_count    = 0;
-        std::size_t                                   visited_count     = 0;
-        bool                                          expected_overflow = false;
+        std::vector<index_type>   expected_free;
+        std::vector<index_type>   visited_free;
+        std::vector<std::int16_t> heights;
 
         index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
@@ -2515,18 +2513,12 @@ class AllocatorPolicy
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-            {
-                if ( expected_count < expected_free.size() )
-                    expected_free[expected_count] = idx;
-                else
-                    expected_overflow = true;
-                expected_count++;
-            }
+                expected_free.push_back( idx );
             idx = BlockState::get_next_offset( blk_ptr );
         }
 
         const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( expected_count == 0 )
+        if ( expected_free.empty() )
         {
             if ( root_present )
             {
@@ -2538,7 +2530,7 @@ class AllocatorPolicy
         if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( expected_free.size() ),
                         static_cast<std::uint64_t>( hdr->free_tree_root ) );
             return;
         }
@@ -2581,14 +2573,13 @@ class AllocatorPolicy
             bool       has_upper;
             bool       expanded;
         };
-        std::array<Frame, kMaxDiagnosticEntries>        stack{};
-        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
-        std::size_t                                     stack_size = 0;
-        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+        std::vector<Frame> stack;
+        stack.push_back( { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false } );
 
-        while ( stack_size > 0 )
+        while ( !stack.empty() )
         {
-            Frame frame = stack[--stack_size];
+            Frame frame = stack.back();
+            stack.pop_back();
             if ( frame.node == AddressTraitsT::no_block )
                 continue;
             if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
@@ -2625,9 +2616,8 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.upper ) );
             }
 
-            const auto visited_begin = visited_free.begin();
-            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
-            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            const bool already_seen =
+                std::find( visited_free.begin(), visited_free.end(), frame.node ) != visited_free.end();
             if ( !frame.expanded && already_seen )
             {
                 result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
@@ -2635,32 +2625,25 @@ class AllocatorPolicy
                 continue;
             }
 
-            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
-            {
-                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
-                            static_cast<std::uint64_t>( visited_count ) );
-                break;
-            }
-
             if ( !frame.expanded )
             {
-                visited_free[visited_count++] = frame.node;
-                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
-                                                  frame.upper, frame.has_upper, true };
-                index_type right              = BlockState::get_right_offset( node );
-                index_type left               = BlockState::get_left_offset( node );
+                visited_free.push_back( frame.node );
+                heights.push_back( 0 );
+                stack.push_back(
+                    { frame.node, frame.parent, frame.lower, frame.has_lower, frame.upper, frame.has_upper, true } );
+                index_type right = BlockState::get_right_offset( node );
+                index_type left  = BlockState::get_left_offset( node );
                 if ( right != AddressTraitsT::no_block )
-                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                    stack.push_back( { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false } );
                 if ( left != AddressTraitsT::no_block )
-                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                    stack.push_back( { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false } );
                 continue;
             }
 
             std::int16_t left_h = 0, right_h = 0;
             index_type   left  = BlockState::get_left_offset( node );
             index_type   right = BlockState::get_right_offset( node );
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == left )
                     left_h = heights[i];
@@ -2675,7 +2658,7 @@ class AllocatorPolicy
                             static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
                             static_cast<std::uint64_t>( stored_h ) );
             }
-            for ( std::size_t i = 0; i < visited_count; ++i )
+            for ( std::size_t i = 0; i < visited_free.size(); ++i )
             {
                 if ( visited_free[i] == frame.node )
                 {
@@ -2685,23 +2668,19 @@ class AllocatorPolicy
             }
         }
 
-        if ( !expected_overflow )
+        for ( index_type expected : expected_free )
         {
-            for ( std::size_t i = 0; i < expected_count; ++i )
+            if ( std::find( visited_free.begin(), visited_free.end(), expected ) == visited_free.end() )
             {
-                const auto begin = visited_free.begin();
-                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
-                if ( std::find( begin, end, expected_free[i] ) == end )
-                {
-                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
-                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
-                }
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( expected ), 1, 0 );
             }
         }
-        if ( visited_count != expected_count )
+        if ( visited_free.size() != expected_free.size() )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
+                        static_cast<std::uint64_t>( expected_free.size() ),
+                        static_cast<std::uint64_t>( visited_free.size() ) );
         }
     }
 

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2180,6 +2180,8 @@ using LargeDBConfig = BasicConfig<LargeAddressTraits, config::SharedMutexLock, 2
 #endif
 
 #include <cassert>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -2500,24 +2502,206 @@ class AllocatorPolicy
     static void verify_free_tree( const std::uint8_t* base, const detail::ManagerHeader<AddressTraitsT>* hdr,
                                   VerifyResult& result ) noexcept
     {
-        
-        index_type free_count = 0;
-        index_type idx        = hdr->first_block_offset;
+        std::array<index_type, kMaxDiagnosticEntries> expected_free{};
+        std::array<index_type, kMaxDiagnosticEntries> visited_free{};
+        std::size_t                                   expected_count    = 0;
+        std::size_t                                   visited_count     = 0;
+        bool                                          expected_overflow = false;
+
+        index_type idx = hdr->first_block_offset;
         while ( idx != AddressTraitsT::no_block )
         {
             if ( static_cast<std::size_t>( idx ) * AddressTraitsT::granule_size + sizeof( BlockT ) > hdr->total_size )
                 break;
             const void* blk_ptr = detail::block_at<AddressTraitsT>( base, idx );
             if ( BlockState::get_weight( blk_ptr ) == 0 )
-                free_count++;
+            {
+                if ( expected_count < expected_free.size() )
+                    expected_free[expected_count] = idx;
+                else
+                    expected_overflow = true;
+                expected_count++;
+            }
             idx = BlockState::get_next_offset( blk_ptr );
         }
-        
-        bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
-        if ( ( free_count > 0 && !root_present ) || ( free_count == 0 && root_present ) )
+
+        const bool root_present = ( hdr->free_tree_root != AddressTraitsT::no_block );
+        if ( expected_count == 0 )
+        {
+            if ( root_present )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0, 0,
+                            static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            }
+            return;
+        }
+        if ( !root_present )
         {
             result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
-                        static_cast<std::uint64_t>( free_count ), static_cast<std::uint64_t>( hdr->free_tree_root ) );
+                        static_cast<std::uint64_t>( expected_count ),
+                        static_cast<std::uint64_t>( hdr->free_tree_root ) );
+            return;
+        }
+        if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, hdr->free_tree_root ) )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 1, 0 );
+            return;
+        }
+        const void* root = detail::block_at<AddressTraitsT>( base, hdr->free_tree_root );
+        if ( BlockState::get_weight( root ) != 0 || BlockState::get_parent_offset( root ) != AddressTraitsT::no_block )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                        static_cast<std::uint64_t>( hdr->free_tree_root ), 0,
+                        static_cast<std::uint64_t>( BlockState::get_parent_offset( root ) ) );
+        }
+
+        auto block_gran = [hdr]( const std::uint8_t* b, index_type block_idx ) noexcept
+        {
+            const void* n      = detail::block_at<AddressTraitsT>( b, block_idx );
+            index_type  n_next = BlockState::get_next_offset( n );
+            index_type  total  = detail::byte_off_to_idx_t<AddressTraitsT>( hdr->total_size );
+            return ( n_next != AddressTraitsT::no_block ) ? static_cast<index_type>( n_next - block_idx )
+                                                          : static_cast<index_type>( total - block_idx );
+        };
+        auto less_key = [&]( index_type a, index_type b_idx ) noexcept
+        {
+            index_type a_gran = block_gran( base, a );
+            index_type b_gran = block_gran( base, b_idx );
+            return ( a_gran < b_gran ) || ( a_gran == b_gran && a < b_idx );
+        };
+
+        struct Frame
+        {
+            index_type node;
+            index_type parent;
+            index_type lower;
+            bool       has_lower;
+            index_type upper;
+            bool       has_upper;
+            bool       expanded;
+        };
+        std::array<Frame, kMaxDiagnosticEntries>        stack{};
+        std::array<std::int16_t, kMaxDiagnosticEntries> heights{};
+        std::size_t                                     stack_size = 0;
+        stack[stack_size++] = { hdr->free_tree_root, AddressTraitsT::no_block, {}, false, {}, false, false };
+
+        while ( stack_size > 0 )
+        {
+            Frame frame = stack[--stack_size];
+            if ( frame.node == AddressTraitsT::no_block )
+                continue;
+            if ( !detail::validate_block_index<AddressTraitsT>( hdr->total_size, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.parent ), 0, static_cast<std::uint64_t>( frame.node ) );
+                continue;
+            }
+
+            const void* node = detail::block_at<AddressTraitsT>( base, frame.node );
+            if ( BlockState::get_weight( node ) != 0 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 0,
+                            static_cast<std::uint64_t>( BlockState::get_weight( node ) ) );
+                continue;
+            }
+            if ( BlockState::get_parent_offset( node ) != frame.parent )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.parent ),
+                            static_cast<std::uint64_t>( BlockState::get_parent_offset( node ) ) );
+            }
+            if ( frame.has_lower && !less_key( frame.lower, frame.node ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.lower ),
+                            static_cast<std::uint64_t>( frame.node ) );
+            }
+            if ( frame.has_upper && !less_key( frame.node, frame.upper ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( frame.node ),
+                            static_cast<std::uint64_t>( frame.upper ) );
+            }
+
+            const auto visited_begin = visited_free.begin();
+            const auto visited_end   = visited_begin + static_cast<std::ptrdiff_t>( visited_count );
+            const bool already_seen  = std::find( visited_begin, visited_end, frame.node ) != visited_end;
+            if ( !frame.expanded && already_seen )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), 1, 2 );
+                continue;
+            }
+
+            if ( !frame.expanded && ( visited_count >= visited_free.size() || stack_size + 3 >= stack.size() ) )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_count ),
+                            static_cast<std::uint64_t>( visited_count ) );
+                break;
+            }
+
+            if ( !frame.expanded )
+            {
+                visited_free[visited_count++] = frame.node;
+                stack[stack_size++]           = { frame.node,  frame.parent,    frame.lower, frame.has_lower,
+                                                  frame.upper, frame.has_upper, true };
+                index_type right              = BlockState::get_right_offset( node );
+                index_type left               = BlockState::get_left_offset( node );
+                if ( right != AddressTraitsT::no_block )
+                    stack[stack_size++] = { right, frame.node, frame.node, true, frame.upper, frame.has_upper, false };
+                if ( left != AddressTraitsT::no_block )
+                    stack[stack_size++] = { left, frame.node, frame.lower, frame.has_lower, frame.node, true, false };
+                continue;
+            }
+
+            std::int16_t left_h = 0, right_h = 0;
+            index_type   left  = BlockState::get_left_offset( node );
+            index_type   right = BlockState::get_right_offset( node );
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == left )
+                    left_h = heights[i];
+                if ( visited_free[i] == right )
+                    right_h = heights[i];
+            }
+            std::int16_t expected_h = static_cast<std::int16_t>( 1 + ( left_h > right_h ? left_h : right_h ) );
+            std::int16_t stored_h   = BlockState::get_avl_height( node );
+            if ( stored_h != expected_h || left_h - right_h > 1 || right_h - left_h > 1 )
+            {
+                result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                            static_cast<std::uint64_t>( frame.node ), static_cast<std::uint64_t>( expected_h ),
+                            static_cast<std::uint64_t>( stored_h ) );
+            }
+            for ( std::size_t i = 0; i < visited_count; ++i )
+            {
+                if ( visited_free[i] == frame.node )
+                {
+                    heights[i] = expected_h;
+                    break;
+                }
+            }
+        }
+
+        if ( !expected_overflow )
+        {
+            for ( std::size_t i = 0; i < expected_count; ++i )
+            {
+                const auto begin = visited_free.begin();
+                const auto end   = begin + static_cast<std::ptrdiff_t>( visited_count );
+                if ( std::find( begin, end, expected_free[i] ) == end )
+                {
+                    result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction,
+                                static_cast<std::uint64_t>( expected_free[i] ), 1, 0 );
+                }
+            }
+        }
+        if ( visited_count != expected_count )
+        {
+            result.add( ViolationType::FreeTreeStale, DiagnosticAction::NoAction, 0,
+                        static_cast<std::uint64_t>( expected_count ), static_cast<std::uint64_t>( visited_count ) );
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,6 +285,9 @@ pmm_add_test(test_issue258_corruption     test_issue258_corruption.cpp)
 pmm_add_test(test_issue258_verify_behavior test_issue258_verify_behavior.cpp)
 pmm_add_test(test_issue258_property       test_issue258_property.cpp)
 
+# ─── Issue 303: full free-tree structural verifier ──────────────
+pmm_add_test(test_issue303_free_tree_verifier test_issue303_free_tree_verifier.cpp)
+
 # ─── Issue 295: layout include-shard repayment guard ────────────
 pmm_add_test(test_issue295_layout_compaction test_issue295_layout_compaction.cpp)
 target_compile_definitions(test_issue295_layout_compaction PRIVATE PMM_SOURCE_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/test_issue303_free_tree_verifier.cpp
+++ b/tests/test_issue303_free_tree_verifier.cpp
@@ -1,0 +1,125 @@
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstdint>
+
+using AT  = pmm::DefaultAddressTraits;
+using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 303>;
+
+static void setup_fragmented_free_tree()
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 128 * 1024 ) );
+
+    std::array<Mgr::pptr<std::uint8_t>, 4> gaps{};
+    std::array<Mgr::pptr<std::uint8_t>, 5> barriers{};
+    for ( std::size_t i = 0; i < gaps.size(); ++i )
+    {
+        gaps[i]     = Mgr::allocate_typed<std::uint8_t>( 256 + i * 64 );
+        barriers[i] = Mgr::allocate_typed<std::uint8_t>( 32 );
+        REQUIRE( !gaps[i].is_null() );
+        REQUIRE( !barriers[i].is_null() );
+    }
+    barriers.back() = Mgr::allocate_typed<std::uint8_t>( 32 );
+    REQUIRE( !barriers.back().is_null() );
+
+    for ( auto gap : gaps )
+        Mgr::deallocate_typed( gap );
+}
+
+static pmm::detail::ManagerHeader<AT>* header()
+{
+    constexpr std::size_t hdr_off =
+        ( ( sizeof( pmm::Block<AT> ) + AT::granule_size - 1 ) / AT::granule_size ) * AT::granule_size;
+    return reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( Mgr::backend().base_ptr() + hdr_off );
+}
+
+static void* block_at( AT::index_type idx )
+{
+    return pmm::detail::block_at<AT>( Mgr::backend().base_ptr(), idx );
+}
+
+static bool has_free_tree_violation( const pmm::VerifyResult& result )
+{
+    for ( std::size_t i = 0; i < result.entry_count; ++i )
+        if ( result.entries[i].type == pmm::ViolationType::FreeTreeStale )
+            return true;
+    return false;
+}
+
+TEST_CASE( "free-tree verifier detects invalid root", "[issue303][verify]" )
+{
+    setup_fragmented_free_tree();
+    auto* hdr           = header();
+    hdr->free_tree_root = AT::no_block;
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "free-tree verifier detects child link corruption", "[issue303][verify]" )
+{
+    setup_fragmented_free_tree();
+    auto* hdr  = header();
+    void* root = block_at( hdr->free_tree_root );
+    pmm::BlockStateBase<AT>::set_left_offset_of( root, static_cast<AT::index_type>( 1 ) );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "free-tree verifier detects parent link corruption", "[issue303][verify]" )
+{
+    setup_fragmented_free_tree();
+    auto* hdr  = header();
+    void* root = block_at( hdr->free_tree_root );
+    pmm::BlockStateBase<AT>::set_parent_offset_of( root, hdr->first_block_offset );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "free-tree verifier detects ordering corruption", "[issue303][verify]" )
+{
+    setup_fragmented_free_tree();
+    auto* hdr   = header();
+    void* root  = block_at( hdr->free_tree_root );
+    auto  right = pmm::BlockStateBase<AT>::get_right_offset( root );
+    REQUIRE( right != AT::no_block );
+
+    pmm::BlockStateBase<AT>::set_left_offset_of( root, right );
+    pmm::BlockStateBase<AT>::set_right_offset_of( root, AT::no_block );
+    pmm::BlockStateBase<AT>::set_parent_offset_of( block_at( right ), hdr->free_tree_root );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "free-tree verifier detects duplicate revisit", "[issue303][verify]" )
+{
+    setup_fragmented_free_tree();
+    auto* hdr  = header();
+    void* root = block_at( hdr->free_tree_root );
+    pmm::BlockStateBase<AT>::set_left_offset_of( root, hdr->free_tree_root );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE_FALSE( result.ok );
+    REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}

--- a/tests/test_issue303_free_tree_verifier.cpp
+++ b/tests/test_issue303_free_tree_verifier.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstdint>
+#include <vector>
 
 using AT  = pmm::DefaultAddressTraits;
 using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 303>;
@@ -120,6 +121,49 @@ TEST_CASE( "free-tree verifier detects duplicate revisit", "[issue303][verify]" 
     pmm::VerifyResult result = Mgr::verify();
     REQUIRE_FALSE( result.ok );
     REQUIRE( has_free_tree_violation( result ) );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "free-tree verifier does not cap traversal at diagnostic entry limit", "[issue303][verify]" )
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 1024 * 1024 ) );
+
+    constexpr std::size_t gap_count    = pmm::kMaxDiagnosticEntries + 16;
+    constexpr std::size_t gap_size     = 96;
+    constexpr std::size_t barrier_size = 32;
+
+    std::vector<Mgr::pptr<std::uint8_t>> gaps;
+    std::vector<Mgr::pptr<std::uint8_t>> barriers;
+    gaps.reserve( gap_count );
+    barriers.reserve( gap_count + 1 );
+
+    for ( std::size_t i = 0; i < gap_count; ++i )
+    {
+        auto gap     = Mgr::allocate_typed<std::uint8_t>( gap_size );
+        auto barrier = Mgr::allocate_typed<std::uint8_t>( barrier_size );
+        REQUIRE( !gap.is_null() );
+        REQUIRE( !barrier.is_null() );
+        gaps.push_back( gap );
+        barriers.push_back( barrier );
+    }
+
+    auto tail_barrier = Mgr::allocate_typed<std::uint8_t>( barrier_size );
+    REQUIRE( !tail_barrier.is_null() );
+    barriers.push_back( tail_barrier );
+
+    for ( auto gap : gaps )
+        Mgr::deallocate_typed( gap );
+
+    REQUIRE( Mgr::free_block_count() > pmm::kMaxDiagnosticEntries );
+
+    pmm::VerifyResult result = Mgr::verify();
+    REQUIRE( result.ok );
+    REQUIRE_FALSE( has_free_tree_violation( result ) );
+
+    for ( auto barrier : barriers )
+        Mgr::deallocate_typed( barrier );
 
     Mgr::destroy();
 }


### PR DESCRIPTION
## Summary
- Replaces the free-tree root-presence check with a read-only structural verifier for root validity, parent/child consistency, strict `(block_size, block_index)` ordering, AVL height/balance, duplicate visits, and linked-list/free-tree membership agreement.
- Keeps diagnostics on the existing `FreeTreeStale` violation path so `load()` can continue to report and rebuild the allocator free tree without changing allocator policy.
- Separates verifier traversal/membership state from the `kMaxDiagnosticEntries` diagnostic-output cap so valid images with more than 64 free blocks do not produce false `FreeTreeStale` violations.
- Preserves the public `verify()` noexcept contract by keeping `verify_free_tree()` noexcept and removing heap-allocating `std::vector` state from the verify path.
- Adds issue-specific corruption tests for invalid root, child links, parent links, ordering, duplicate/cycle-like revisit scenarios, and the >64-free-block false-positive regression.

Fixes netkeep80/PersistMemoryManager#303

## Reproduction
Before this change, `verify_free_tree()` only compared the number of free blocks with whether `free_tree_root` was present, so malformed AVL links under a non-null root could pass verify diagnostics.

An intermediate implementation also reused `kMaxDiagnosticEntries` as an internal traversal cap. The regression creates more than 64 valid free blocks and verifies that `verify()` stays clean.

The latest review blocker was that the verifier used `std::vector` under the public `PersistMemoryManager::verify() noexcept` path. The verifier now uses no heap allocation in `verify_free_tree()`.

## Tests
- `clang-format --dry-run --Werror include/pmm/allocator_policy.h tests/test_issue303_free_tree_verifier.cpp`
- `git diff --check`
- `cmake -S . -B build`
- `cmake --build build --target test_issue303_free_tree_verifier`
- `ctest --test-dir build --output-on-failure -R test_issue303_free_tree_verifier`
- `cmake --build build --target test_avl_allocator test_issue243_free_tree_policy test_issue258_corruption test_issue258_verify_behavior test_issue303_free_tree_verifier`
- `ctest --test-dir build --output-on-failure -R 'test_issue303_free_tree_verifier|test_issue258_corruption|test_issue258_verify_behavior|test_issue243_free_tree_policy|test_avl_allocator'`

## Notes
- Repository-wide clang-format still reports pre-existing generated single-header formatting issues in `single_include/pmm/pmm_no_comments.h`; touched source/test files pass the format check above.
