### PR TITLE
Make legacy root use canonical domain registry

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T20:05:28.748Z for PR creation at branch issue-313-5390ad98d41c for issue https://github.com/netkeep80/PersistMemoryManager/issues/313

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T20:05:28.748Z for PR creation at branch issue-313-5390ad98d41c for issue https://github.com/netkeep80/PersistMemoryManager/issues/313

--- a/changelog.d/20260419_201900_legacy_root_domain.md
+++ b/changelog.d/20260419_201900_legacy_root_domain.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Made the legacy root API use the canonical domain registry root record.

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -402,7 +402,6 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
-    // 7. Legacy root compatibility is represented as a direct-root domain.
     const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
     if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
         return false;

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -99,15 +99,15 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
 
 static index_type get_legacy_root_offset_unlocked() noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    return ( reg != nullptr ) ? reg->legacy_root_offset : static_cast<index_type>( 0 );
+    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
 }
 
 static void set_legacy_root_offset_unlocked( index_type off ) noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    if ( reg != nullptr )
-        reg->legacy_root_offset = off;
+    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
+        rec->root_offset = off;
 }
 
 // ─── Symbol domain helpers ────────────────────────────────────────────────────
@@ -296,11 +296,11 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic              = detail::kForestRegistryMagic;
-    reg->version            = detail::kForestRegistryVersion;
-    reg->domain_count       = 0;
-    reg->legacy_root_offset = legacy_root_offset;
-    reg->next_binding_id    = 1;
+    reg->magic                = detail::kForestRegistryMagic;
+    reg->version              = detail::kForestRegistryVersion;
+    reg->domain_count         = 0;
+    reg->reserved_root_offset = 0;
+    reg->next_binding_id      = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -325,6 +325,12 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
     if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                     detail::kForestBindingDirectRoot, get_header( _backend.base_ptr() )->root_offset ) )
+    {
+        _last_error = PmmError::BackendError;
+        return false;
+    }
+    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -368,11 +374,13 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
         return false;
     if ( reg->version != detail::kForestRegistryVersion )
         return false;
-    if ( reg->domain_count < 3 )
-        return false; // at least free_tree, symbols, registry
+    if ( reg->domain_count < 4 )
+        return false; // at least free_tree, symbols, registry, legacy_root
+    if ( reg->reserved_root_offset != 0 )
+        return false;
     // 3. System domains present with correct flags
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -394,6 +402,10 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
+    // 7. Legacy root compatibility is represented as a direct-root domain.
+    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+        return false;
     return true;
 }
 
@@ -404,6 +416,12 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
+        forest_registry* reg = forest_registry_root_unlocked();
+        index_type       migrated_legacy_root =
+            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
+                ? reg->reserved_root_offset
+                : static_cast<index_type>( 0 );
+
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -412,6 +430,9 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
+            return false;
+        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
             return false;
 
         if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
@@ -431,6 +452,13 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             registry_rec->binding_kind = detail::kForestBindingDirectRoot;
             registry_rec->root_offset  = hdr->root_offset;
         }
+        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
+        {
+            legacy_rec->flags |= detail::kForestDomainFlagSystem;
+            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
+        }
+        if ( reg != nullptr )
+            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 

--- a/include/pmm/forest_registry.h
+++ b/include/pmm/forest_registry.h
@@ -59,8 +59,8 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), reserved_root_offset( 0 ),
-          next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
+          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
     {
     }
 };

--- a/include/pmm/forest_registry.h
+++ b/include/pmm/forest_registry.h
@@ -54,12 +54,12 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         legacy_root_offset;
+    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), legacy_root_offset( 0 ),
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), reserved_root_offset( 0 ),
           next_binding_id( 1 ), domains{}
     {
     }

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -846,8 +846,8 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
 
     // ─── Root object API ──────────────────────────────
 
-    /// @brief Установить корневой объект в ManagerHeader.
-    /// @tparam T Тип объекта.  @param p Персистентный указатель; пустой pptr сбрасывает корень.
+    /// @brief Compatibility shim for the legacy root object API.
+    /// Stores the root in the canonical `service/legacy_root` domain record.
     template <typename T> static void set_root( pptr<T> p ) noexcept
     {
         typename thread_policy::unique_lock_type lock( _mutex );
@@ -857,7 +857,7 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     }
 
     /**
-     * @brief Получить корневой объект из ManagerHeader.
+     * @brief Compatibility shim for the legacy root object API.
      *
      * @tparam T Тип объекта (должен совпадать с типом, переданным в set_root).
      * @return pptr<T> — корневой указатель или пустой pptr, если корень не установлен.

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -209,7 +209,7 @@ template <typename AddressTraitsT = DefaultAddressTraits> struct ManagerHeader
     std::uint16_t granule_size;       ///< kGranuleSize at creation time; validated on load
     std::uint64_t prev_total_size;    ///< Previous buffer size in bytes (runtime-only)
     std::uint32_t crc32;              ///< CRC32 checksum of the persisted image
-    index_type    root_offset;        ///< Root object granule index (no_block = no root set)
+    index_type    root_offset;        ///< Forest registry root granule index (no_block before bootstrap)
 };
 
 static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) == 64,

--- a/include/pmm/verify_repair_mixin.inc
+++ b/include/pmm/verify_repair_mixin.inc
@@ -94,7 +94,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -1995,7 +1995,7 @@ template <typename AddressTraitsT = DefaultAddressTraits> struct ManagerHeader
     std::uint16_t granule_size;       ///< kGranuleSize at creation time; validated on load
     std::uint64_t prev_total_size;    ///< Previous buffer size in bytes (runtime-only)
     std::uint32_t crc32;              ///< CRC32 checksum of the persisted image
-    index_type    root_offset;        ///< Root object granule index (no_block = no root set)
+    index_type    root_offset;        ///< Forest registry root granule index (no_block before bootstrap)
 };
 
 static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) == 64,
@@ -4626,13 +4626,13 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         legacy_root_offset;
+    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), legacy_root_offset( 0 ),
-          next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
+          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
     {
     }
 };
@@ -7910,8 +7910,8 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
 
     // ─── Root object API ──────────────────────────────
 
-    /// @brief Установить корневой объект в ManagerHeader.
-    /// @tparam T Тип объекта.  @param p Персистентный указатель; пустой pptr сбрасывает корень.
+    /// @brief Compatibility shim for the legacy root object API.
+    /// Stores the root in the canonical `service/legacy_root` domain record.
     template <typename T> static void set_root( pptr<T> p ) noexcept
     {
         typename thread_policy::unique_lock_type lock( _mutex );
@@ -7921,7 +7921,7 @@ template <typename ConfigT = CacheManagerConfig, std::size_t InstanceId = 0> cla
     }
 
     /**
-     * @brief Получить корневой объект из ManagerHeader.
+     * @brief Compatibility shim for the legacy root object API.
      *
      * @tparam T Тип объекта (должен совпадать с типом, переданным в set_root).
      * @return pptr<T> — корневой указатель или пустой pptr, если корень не установлен.
@@ -8581,15 +8581,15 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
 
 static index_type get_legacy_root_offset_unlocked() noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    return ( reg != nullptr ) ? reg->legacy_root_offset : static_cast<index_type>( 0 );
+    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
 }
 
 static void set_legacy_root_offset_unlocked( index_type off ) noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    if ( reg != nullptr )
-        reg->legacy_root_offset = off;
+    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
+        rec->root_offset = off;
 }
 
 // ─── Symbol domain helpers ────────────────────────────────────────────────────
@@ -8778,11 +8778,11 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic              = detail::kForestRegistryMagic;
-    reg->version            = detail::kForestRegistryVersion;
-    reg->domain_count       = 0;
-    reg->legacy_root_offset = legacy_root_offset;
-    reg->next_binding_id    = 1;
+    reg->magic                = detail::kForestRegistryMagic;
+    reg->version              = detail::kForestRegistryVersion;
+    reg->domain_count         = 0;
+    reg->reserved_root_offset = 0;
+    reg->next_binding_id      = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -8807,6 +8807,12 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
     if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                     detail::kForestBindingDirectRoot, get_header( _backend.base_ptr() )->root_offset ) )
+    {
+        _last_error = PmmError::BackendError;
+        return false;
+    }
+    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -8850,11 +8856,13 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
         return false;
     if ( reg->version != detail::kForestRegistryVersion )
         return false;
-    if ( reg->domain_count < 3 )
-        return false; // at least free_tree, symbols, registry
+    if ( reg->domain_count < 4 )
+        return false; // at least free_tree, symbols, registry, legacy_root
+    if ( reg->reserved_root_offset != 0 )
+        return false;
     // 3. System domains present with correct flags
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -8876,6 +8884,9 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
+    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+        return false;
     return true;
 }
 
@@ -8886,6 +8897,12 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
+        forest_registry* reg = forest_registry_root_unlocked();
+        index_type       migrated_legacy_root =
+            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
+                ? reg->reserved_root_offset
+                : static_cast<index_type>( 0 );
+
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -8894,6 +8911,9 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
+            return false;
+        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
             return false;
 
         if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
@@ -8913,6 +8933,13 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             registry_rec->binding_kind = detail::kForestBindingDirectRoot;
             registry_rec->root_offset  = hdr->root_offset;
         }
+        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
+        {
+            legacy_rec->flags |= detail::kForestDomainFlagSystem;
+            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
+        }
+        if ( reg != nullptr )
+            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 
@@ -9234,7 +9261,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2813,13 +2813,13 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         legacy_root_offset;
+    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), legacy_root_offset( 0 ),
-          next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
+          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
     {
     }
 };
@@ -5213,15 +5213,15 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
 
 static index_type get_legacy_root_offset_unlocked() noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    return ( reg != nullptr ) ? reg->legacy_root_offset : static_cast<index_type>( 0 );
+    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
 }
 
 static void set_legacy_root_offset_unlocked( index_type off ) noexcept
 {
-    forest_registry* reg = forest_registry_root_unlocked();
-    if ( reg != nullptr )
-        reg->legacy_root_offset = off;
+    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
+        rec->root_offset = off;
 }
 
 static forest_domain* symbol_domain_record_unlocked() noexcept
@@ -5399,11 +5399,11 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic              = detail::kForestRegistryMagic;
-    reg->version            = detail::kForestRegistryVersion;
-    reg->domain_count       = 0;
-    reg->legacy_root_offset = legacy_root_offset;
-    reg->next_binding_id    = 1;
+    reg->magic                = detail::kForestRegistryMagic;
+    reg->version              = detail::kForestRegistryVersion;
+    reg->domain_count         = 0;
+    reg->reserved_root_offset = 0;
+    reg->next_binding_id      = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -5428,6 +5428,12 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
     if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                     detail::kForestBindingDirectRoot, get_header( _backend.base_ptr() )->root_offset ) )
+    {
+        _last_error = PmmError::BackendError;
+        return false;
+    }
+    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -5468,11 +5474,13 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
         return false;
     if ( reg->version != detail::kForestRegistryVersion )
         return false;
-    if ( reg->domain_count < 3 )
+    if ( reg->domain_count < 4 )
         return false; 
+    if ( reg->reserved_root_offset != 0 )
+        return false;
     
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -5494,6 +5502,9 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
+    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
+    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+        return false;
     return true;
 }
 
@@ -5502,6 +5513,12 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
+        forest_registry* reg = forest_registry_root_unlocked();
+        index_type       migrated_legacy_root =
+            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
+                ? reg->reserved_root_offset
+                : static_cast<index_type>( 0 );
+
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -5510,6 +5527,9 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
+            return false;
+        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
             return false;
 
         if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
@@ -5529,6 +5549,13 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
             registry_rec->binding_kind = detail::kForestBindingDirectRoot;
             registry_rec->root_offset  = hdr->root_offset;
         }
+        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
+        {
+            legacy_rec->flags |= detail::kForestDomainFlagSystem;
+            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
+        }
+        if ( reg != nullptr )
+            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 
@@ -5800,7 +5827,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/tests/test_forest_registry.cpp
+++ b/tests/test_forest_registry.cpp
@@ -154,11 +154,10 @@ TEST_CASE( "legacy root API is a compatibility shim over the domain registry", "
     REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameLegacyRoot ).is_null() );
     REQUIRE( CanonicalRootMgr::get_domain_root_offset( legacy_domain_id ) == 0 );
 
-    using AT = CanonicalRootMgr::address_traits;
+    using AT           = CanonicalRootMgr::address_traits;
     std::uint8_t* base = CanonicalRootMgr::backend().base_ptr();
-    auto*         hdr =
-        reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
-    auto* reg = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
+    auto*         hdr  = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
+    auto*         reg  = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
         base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
     REQUIRE( reg->reserved_root_offset == 0 );
 
@@ -168,8 +167,7 @@ TEST_CASE( "legacy root API is a compatibility shim over the domain registry", "
     REQUIRE( !domain_value.is_null() );
 
     CanonicalRootMgr::set_root( legacy_value );
-    REQUIRE( CanonicalRootMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) ==
-             legacy_value.offset() );
+    REQUIRE( CanonicalRootMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == legacy_value.offset() );
     REQUIRE( CanonicalRootMgr::get_domain_root<int>( legacy_domain_id ).offset() == legacy_value.offset() );
 
     REQUIRE( CanonicalRootMgr::set_domain_root( pmm::detail::kServiceNameLegacyRoot, domain_value ) );

--- a/tests/test_forest_registry.cpp
+++ b/tests/test_forest_registry.cpp
@@ -3,10 +3,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 
 using ForestMgr        = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 240>;
 using ForestPersistMgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 241>;
+using CanonicalRootMgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 313>;
 
 TEST_CASE( "forest registry bootstraps system domains", "[test_forest_registry]" )
 {
@@ -16,19 +19,23 @@ TEST_CASE( "forest registry bootstraps system domains", "[test_forest_registry]"
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainFreeTree ) );
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainSymbols ) );
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainRegistry ) );
+    REQUIRE( ForestMgr::has_domain( pmm::detail::kServiceNameLegacyRoot ) );
 
     auto free_id     = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainFreeTree );
     auto symbols_id  = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainSymbols );
     auto registry_id = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainRegistry );
+    auto legacy_id   = ForestMgr::find_domain_by_name( pmm::detail::kServiceNameLegacyRoot );
 
     REQUIRE( free_id != 0 );
     REQUIRE( symbols_id != 0 );
     REQUIRE( registry_id != 0 );
+    REQUIRE( legacy_id != 0 );
 
     REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) != 0 );
     REQUIRE( ForestMgr::get_domain_root_offset( free_id ) ==
              ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) );
     REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainSymbols ) != 0 );
+    REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == 0 );
 
     ForestMgr::pptr<ForestMgr::pstringview> symbols_domain_symbol =
         ForestMgr::pstringview( pmm::detail::kSystemDomainSymbols );
@@ -117,6 +124,7 @@ TEST_CASE( "forest registry persists user domains and legacy root", "[test_fores
     REQUIRE( !legacy_root.is_null() );
     REQUIRE( legacy_root.offset() == alpha_offset );
     REQUIRE( *legacy_root == 11 );
+    REQUIRE( ForestPersistMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == alpha_offset );
 
     REQUIRE( ForestPersistMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) != 0 );
     REQUIRE( ForestPersistMgr::pstringview::root_index() != 0 );
@@ -131,4 +139,51 @@ TEST_CASE( "forest registry persists user domains and legacy root", "[test_fores
 
     ForestPersistMgr::destroy();
     std::remove( filename );
+}
+
+TEST_CASE( "legacy root API is a compatibility shim over the domain registry", "[test_forest_registry][issue313]" )
+{
+    CanonicalRootMgr::destroy();
+    REQUIRE( CanonicalRootMgr::create( 128 * 1024 ) );
+
+    REQUIRE( CanonicalRootMgr::has_domain( pmm::detail::kServiceNameLegacyRoot ) );
+    auto legacy_domain_id = CanonicalRootMgr::find_domain_by_name( pmm::detail::kServiceNameLegacyRoot );
+    REQUIRE( legacy_domain_id != 0 );
+
+    REQUIRE( CanonicalRootMgr::get_root<int>().is_null() );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameLegacyRoot ).is_null() );
+    REQUIRE( CanonicalRootMgr::get_domain_root_offset( legacy_domain_id ) == 0 );
+
+    using AT = CanonicalRootMgr::address_traits;
+    std::uint8_t* base = CanonicalRootMgr::backend().base_ptr();
+    auto*         hdr =
+        reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
+    auto* reg = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
+        base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
+    REQUIRE( reg->reserved_root_offset == 0 );
+
+    auto legacy_value = CanonicalRootMgr::create_typed<int>( 31 );
+    auto domain_value = CanonicalRootMgr::create_typed<int>( 313 );
+    REQUIRE( !legacy_value.is_null() );
+    REQUIRE( !domain_value.is_null() );
+
+    CanonicalRootMgr::set_root( legacy_value );
+    REQUIRE( CanonicalRootMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) ==
+             legacy_value.offset() );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( legacy_domain_id ).offset() == legacy_value.offset() );
+
+    REQUIRE( CanonicalRootMgr::set_domain_root( pmm::detail::kServiceNameLegacyRoot, domain_value ) );
+    REQUIRE( CanonicalRootMgr::get_root<int>().offset() == domain_value.offset() );
+    REQUIRE( *CanonicalRootMgr::get_root<int>() == 313 );
+
+    reg->reserved_root_offset = legacy_value.offset();
+    REQUIRE( CanonicalRootMgr::get_root<int>().offset() == domain_value.offset() );
+    reg->reserved_root_offset = 0;
+    REQUIRE( CanonicalRootMgr::validate_bootstrap_invariants() );
+
+    CanonicalRootMgr::set_root( CanonicalRootMgr::pptr<int>() );
+    REQUIRE( CanonicalRootMgr::get_root<int>().is_null() );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameLegacyRoot ).is_null() );
+
+    CanonicalRootMgr::destroy();
 }


### PR DESCRIPTION
## Summary
- Register `service/legacy_root` as a system direct-root domain during forest registry bootstrap.
- Make legacy `get_root()/set_root()` read and write that canonical domain record instead of standalone registry state.
- Keep the old registry slot as a zeroed reserved migration field and migrate old standalone values into the domain path on load.
- Refresh generated single-header files and add the required changelog fragment for CI.

## Reproduction
- Added `[issue313]` coverage in `tests/test_forest_registry.cpp`.
- Before the fix, `./build/tests/test_forest_registry "[issue313]"` failed because `service/legacy_root` was not registered as a domain.

## Verification
- `cmake -S . -B build -DPMM_BUILD_EXAMPLES=OFF -DPMM_BUILD_DEMO=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (87/87 passed)
- `git diff --check`
- `bash scripts/check-changelog-fragment.sh`
- Regenerated single headers with `bash scripts/generate-single-headers.sh --strip-comments` and compared against a fresh `--output-dir` generation.

Fixes netkeep80/PersistMemoryManager#313