### PR TITLE
Add pstringview forest-domain descriptor policy

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T20:43:41.144Z for PR creation at branch issue-316-16b1196b9f33 for issue https://github.com/netkeep80/PersistMemoryManager/issues/316

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T20:43:41.144Z for PR creation at branch issue-316-16b1196b9f33 for issue https://github.com/netkeep80/PersistMemoryManager/issues/316

--- a/changelog.d/20260419_211500_forest_domain_descriptor.md
+++ b/changelog.d/20260419_211500_forest_domain_descriptor.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+---
+
+### Added
+- Added a minimal AVL forest-domain descriptor/policy seam and migrated the pstringview symbol dictionary to it.

--- a/include/pmm/avl_tree_mixin.h
+++ b/include/pmm/avl_tree_mixin.h
@@ -37,6 +37,7 @@
 #include "pmm/block_state.h"
 #include "pmm/types.h"
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 
@@ -510,6 +511,78 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 
     avl_rebalance_up( parent, root_idx, update_node );
 }
+
+// ─── Forest-domain descriptor/policy seam ────────────────────────────────────
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+    typename Domain::index_type;
+    typename Domain::node_type;
+    typename Domain::node_pptr;
+    { Domain::name() } -> std::convertible_to<const char*>;
+    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
+    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+};
+
+template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+{
+    if constexpr ( requires {
+                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                   } )
+        return Domain::validate_node( p );
+    else
+        return true;
+}
+
+/**
+ * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
+ *
+ * The descriptor owns domain identity, root binding, node resolution, ordering,
+ * and optional node validation. This wrapper keeps the AVL substrate reusable
+ * without forcing allocator and non-allocator domains into the same runtime type.
+ */
+template <typename Domain> struct ForestDomainOps
+{
+    using index_type = typename Domain::index_type;
+    using node_pptr  = typename Domain::node_pptr;
+
+    static constexpr const char* name() noexcept { return Domain::name(); }
+    static index_type            root_index() noexcept { return Domain::root_index(); }
+    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+
+    static bool reset_root() noexcept
+    {
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    template <typename Key>
+        requires ForestDomainDescriptorForKey<Domain, Key>
+    static node_pptr find( const Key& key ) noexcept
+    {
+        return avl_find<node_pptr>(
+            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+
+    static void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = Domain::root_index_ptr();
+        if ( root == nullptr || new_node.is_null() )
+            return;
+        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+            return;
+        avl_insert(
+            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+};
 
 // ─── BlockPPtr: adapter for free_block_tree to reuse shared AVL operations ───
 

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -123,13 +123,6 @@ static index_type symbol_domain_root_offset_unlocked() noexcept
     return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
-static void reset_symbol_domain_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    if ( rec != nullptr )
-        rec->root_offset = 0;
-}
-
 // ─── Domain registration ─────────────────────────────────────────────────────
 
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
@@ -186,18 +179,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    forest_domain* symbol_domain = symbol_domain_record_unlocked();
-    if ( symbol_domain == nullptr )
+    using symbol_policy = typename pstringview::forest_domain_policy;
+    if ( symbol_policy::root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = detail::avl_find<pptr<pstringview>>(
-        symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> int
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) ? std::strcmp( s, cur_str ) : 0;
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    pptr<pstringview> found = symbol_policy::find( s );
     if ( !found.is_null() )
         return found;
 
@@ -223,16 +209,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    // Re-derive c_str() pointer for comparisons using offset-based access.
-    const char* new_str = static_cast<const char*>( public_raw ) + offsetof( pstringview, str );
-    detail::avl_insert(
-        new_node, symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> bool
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) && ( std::strcmp( new_str, cur_str ) < 0 );
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    symbol_policy::insert( new_node );
 
     return new_node;
 }

--- a/include/pmm/pstringview.h
+++ b/include/pmm/pstringview.h
@@ -51,6 +51,7 @@
 #pragma once
 
 #include "pmm/avl_tree_mixin.h"
+#include "pmm/forest_registry.h"
 #include "pmm/types.h"
 
 #include <cstddef>
@@ -99,6 +100,49 @@ template <typename ManagerT> struct pstringview
     using manager_type = ManagerT;
     using index_type   = typename ManagerT::index_type;
     using psview_pptr  = typename ManagerT::template pptr<pstringview>;
+
+    struct forest_domain_descriptor
+    {
+        using manager_type = ManagerT;
+        using index_type   = typename ManagerT::index_type;
+        using node_type    = pstringview;
+        using node_pptr    = psview_pptr;
+
+        static constexpr const char* name() noexcept { return detail::kSystemDomainSymbols; }
+
+        static index_type root_index() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+        }
+
+        static index_type* root_index_ptr() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+        }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const char* key, node_pptr cur ) noexcept
+        {
+            if ( key == nullptr )
+                key = "";
+            node_type* obj = resolve_node( cur );
+            return ( obj != nullptr ) ? std::strcmp( key, obj->c_str() ) : 0;
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && std::strcmp( lhs_obj->c_str(), rhs_obj->c_str() ) < 0;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
 
     std::uint32_t length; ///< Длина строки (без нулевого терминатора)
     char          str[1]; ///< Строковые данные (flexible array member pattern)
@@ -196,7 +240,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        ManagerT::reset_symbol_domain_unlocked();
+        forest_domain_policy::reset_root();
     }
 
     /// @brief Текущий persistent root словаря интернирования; 0 = пустое дерево.
@@ -205,7 +249,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return ManagerT::symbol_domain_root_offset_unlocked();
+        return forest_domain_policy::root_index();
     }
 
     // Public destructor required for stack-temporary construction via pstringview<Mgr>("hello").
@@ -288,38 +332,10 @@ template <typename ManagerT> struct pstringview
     // ─── AVL-дерево (использует встроенные TreeNode-поля каждого pstringview-блока) ─
 
     /// @brief Найти узел AVL-дерева с заданной строкой. Возвращает null если не найден.
-    static psview_pptr _avl_find( const char* s ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return psview_pptr();
-        return detail::avl_find<psview_pptr>(
-            domain->root_offset,
-            [&]( psview_pptr cur ) -> int
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) ? std::strcmp( s, obj->c_str() ) : 0;
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
 
     /// @brief Вставить новый узел в AVL-дерево. Предполагается, что строка ещё не в дереве.
-    static void _avl_insert( psview_pptr new_node ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return;
-        pstringview* new_obj = ManagerT::template resolve<pstringview>( new_node );
-        const char*  new_str = ( new_obj != nullptr ) ? new_obj->c_str() : "";
-        detail::avl_insert(
-            new_node, domain->root_offset,
-            [&]( psview_pptr cur ) -> bool
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) && ( std::strcmp( new_str, obj->c_str() ) < 0 );
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 } // namespace pmm

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2296,6 +2296,7 @@ inline typename AddressTraitsT::index_type required_block_granules_t( std::size_
 
 } // namespace pmm
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 
@@ -2769,6 +2770,78 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 
     avl_rebalance_up( parent, root_idx, update_node );
 }
+
+// ─── Forest-domain descriptor/policy seam ────────────────────────────────────
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+    typename Domain::index_type;
+    typename Domain::node_type;
+    typename Domain::node_pptr;
+    { Domain::name() } -> std::convertible_to<const char*>;
+    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
+    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+};
+
+template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+{
+    if constexpr ( requires {
+                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                   } )
+        return Domain::validate_node( p );
+    else
+        return true;
+}
+
+/**
+ * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
+ *
+ * The descriptor owns domain identity, root binding, node resolution, ordering,
+ * and optional node validation. This wrapper keeps the AVL substrate reusable
+ * without forcing allocator and non-allocator domains into the same runtime type.
+ */
+template <typename Domain> struct ForestDomainOps
+{
+    using index_type = typename Domain::index_type;
+    using node_pptr  = typename Domain::node_pptr;
+
+    static constexpr const char* name() noexcept { return Domain::name(); }
+    static index_type            root_index() noexcept { return Domain::root_index(); }
+    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+
+    static bool reset_root() noexcept
+    {
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    template <typename Key>
+        requires ForestDomainDescriptorForKey<Domain, Key>
+    static node_pptr find( const Key& key ) noexcept
+    {
+        return avl_find<node_pptr>(
+            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+
+    static void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = Domain::root_index_ptr();
+        if ( root == nullptr || new_node.is_null() )
+            return;
+        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+            return;
+        avl_insert(
+            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+};
 
 // ─── BlockPPtr: adapter for free_block_tree to reuse shared AVL operations ───
 
@@ -6742,6 +6815,49 @@ template <typename ManagerT> struct pstringview
     using index_type   = typename ManagerT::index_type;
     using psview_pptr  = typename ManagerT::template pptr<pstringview>;
 
+    struct forest_domain_descriptor
+    {
+        using manager_type = ManagerT;
+        using index_type   = typename ManagerT::index_type;
+        using node_type    = pstringview;
+        using node_pptr    = psview_pptr;
+
+        static constexpr const char* name() noexcept { return detail::kSystemDomainSymbols; }
+
+        static index_type root_index() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+        }
+
+        static index_type* root_index_ptr() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+        }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const char* key, node_pptr cur ) noexcept
+        {
+            if ( key == nullptr )
+                key = "";
+            node_type* obj = resolve_node( cur );
+            return ( obj != nullptr ) ? std::strcmp( key, obj->c_str() ) : 0;
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && std::strcmp( lhs_obj->c_str(), rhs_obj->c_str() ) < 0;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
     std::uint32_t length; ///< Длина строки (без нулевого терминатора)
     char          str[1]; ///< Строковые данные (flexible array member pattern)
 
@@ -6838,7 +6954,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        ManagerT::reset_symbol_domain_unlocked();
+        forest_domain_policy::reset_root();
     }
 
     /// @brief Текущий persistent root словаря интернирования; 0 = пустое дерево.
@@ -6847,7 +6963,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return ManagerT::symbol_domain_root_offset_unlocked();
+        return forest_domain_policy::root_index();
     }
 
     // Public destructor required for stack-temporary construction via pstringview<Mgr>("hello").
@@ -6930,38 +7046,10 @@ template <typename ManagerT> struct pstringview
     // ─── AVL-дерево (использует встроенные TreeNode-поля каждого pstringview-блока) ─
 
     /// @brief Найти узел AVL-дерева с заданной строкой. Возвращает null если не найден.
-    static psview_pptr _avl_find( const char* s ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return psview_pptr();
-        return detail::avl_find<psview_pptr>(
-            domain->root_offset,
-            [&]( psview_pptr cur ) -> int
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) ? std::strcmp( s, obj->c_str() ) : 0;
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
 
     /// @brief Вставить новый узел в AVL-дерево. Предполагается, что строка ещё не в дереве.
-    static void _avl_insert( psview_pptr new_node ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return;
-        pstringview* new_obj = ManagerT::template resolve<pstringview>( new_node );
-        const char*  new_str = ( new_obj != nullptr ) ? new_obj->c_str() : "";
-        detail::avl_insert(
-            new_node, domain->root_offset,
-            [&]( psview_pptr cur ) -> bool
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) && ( std::strcmp( new_str, obj->c_str() ) < 0 );
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 } // namespace pmm
@@ -8605,13 +8693,6 @@ static index_type symbol_domain_root_offset_unlocked() noexcept
     return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
-static void reset_symbol_domain_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    if ( rec != nullptr )
-        rec->root_offset = 0;
-}
-
 // ─── Domain registration ─────────────────────────────────────────────────────
 
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
@@ -8668,18 +8749,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    forest_domain* symbol_domain = symbol_domain_record_unlocked();
-    if ( symbol_domain == nullptr )
+    using symbol_policy = typename pstringview::forest_domain_policy;
+    if ( symbol_policy::root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = detail::avl_find<pptr<pstringview>>(
-        symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> int
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) ? std::strcmp( s, cur_str ) : 0;
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    pptr<pstringview> found = symbol_policy::find( s );
     if ( !found.is_null() )
         return found;
 
@@ -8705,16 +8779,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    // Re-derive c_str() pointer for comparisons using offset-based access.
-    const char* new_str = static_cast<const char*>( public_raw ) + offsetof( pstringview, str );
-    detail::avl_insert(
-        new_node, symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> bool
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) && ( std::strcmp( new_str, cur_str ) < 0 );
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    symbol_policy::insert( new_node );
 
     return new_node;
 }

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2296,7 +2296,6 @@ inline typename AddressTraitsT::index_type required_block_granules_t( std::size_
 
 } // namespace pmm
 
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 
@@ -2770,78 +2769,6 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 
     avl_rebalance_up( parent, root_idx, update_node );
 }
-
-// ─── Forest-domain descriptor/policy seam ────────────────────────────────────
-
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
-    typename Domain::index_type;
-    typename Domain::node_type;
-    typename Domain::node_pptr;
-    { Domain::name() } -> std::convertible_to<const char*>;
-    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
-    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
-    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
-};
-
-template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
-{
-    if constexpr ( requires {
-                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
-                   } )
-        return Domain::validate_node( p );
-    else
-        return true;
-}
-
-/**
- * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
- *
- * The descriptor owns domain identity, root binding, node resolution, ordering,
- * and optional node validation. This wrapper keeps the AVL substrate reusable
- * without forcing allocator and non-allocator domains into the same runtime type.
- */
-template <typename Domain> struct ForestDomainOps
-{
-    using index_type = typename Domain::index_type;
-    using node_pptr  = typename Domain::node_pptr;
-
-    static constexpr const char* name() noexcept { return Domain::name(); }
-    static index_type            root_index() noexcept { return Domain::root_index(); }
-    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
-
-    static bool reset_root() noexcept
-    {
-        index_type* root = root_index_ptr();
-        if ( root == nullptr )
-            return false;
-        *root = static_cast<index_type>( 0 );
-        return true;
-    }
-
-    template <typename Key>
-        requires ForestDomainDescriptorForKey<Domain, Key>
-    static node_pptr find( const Key& key ) noexcept
-    {
-        return avl_find<node_pptr>(
-            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
-    }
-
-    static void insert( node_pptr new_node ) noexcept
-    {
-        index_type* root = Domain::root_index_ptr();
-        if ( root == nullptr || new_node.is_null() )
-            return;
-        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
-            return;
-        avl_insert(
-            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
-    }
-};
 
 // ─── BlockPPtr: adapter for free_block_tree to reuse shared AVL operations ───
 
@@ -6815,49 +6742,6 @@ template <typename ManagerT> struct pstringview
     using index_type   = typename ManagerT::index_type;
     using psview_pptr  = typename ManagerT::template pptr<pstringview>;
 
-    struct forest_domain_descriptor
-    {
-        using manager_type = ManagerT;
-        using index_type   = typename ManagerT::index_type;
-        using node_type    = pstringview;
-        using node_pptr    = psview_pptr;
-
-        static constexpr const char* name() noexcept { return detail::kSystemDomainSymbols; }
-
-        static index_type root_index() noexcept
-        {
-            auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
-        }
-
-        static index_type* root_index_ptr() noexcept
-        {
-            auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
-        }
-
-        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
-
-        static int compare_key( const char* key, node_pptr cur ) noexcept
-        {
-            if ( key == nullptr )
-                key = "";
-            node_type* obj = resolve_node( cur );
-            return ( obj != nullptr ) ? std::strcmp( key, obj->c_str() ) : 0;
-        }
-
-        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
-        {
-            node_type* lhs_obj = resolve_node( lhs );
-            node_type* rhs_obj = resolve_node( rhs );
-            return lhs_obj != nullptr && rhs_obj != nullptr && std::strcmp( lhs_obj->c_str(), rhs_obj->c_str() ) < 0;
-        }
-
-        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
-    };
-
-    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
-
     std::uint32_t length; ///< Длина строки (без нулевого терминатора)
     char          str[1]; ///< Строковые данные (flexible array member pattern)
 
@@ -6954,7 +6838,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        forest_domain_policy::reset_root();
+        ManagerT::reset_symbol_domain_unlocked();
     }
 
     /// @brief Текущий persistent root словаря интернирования; 0 = пустое дерево.
@@ -6963,7 +6847,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return forest_domain_policy::root_index();
+        return ManagerT::symbol_domain_root_offset_unlocked();
     }
 
     // Public destructor required for stack-temporary construction via pstringview<Mgr>("hello").
@@ -7046,10 +6930,38 @@ template <typename ManagerT> struct pstringview
     // ─── AVL-дерево (использует встроенные TreeNode-поля каждого pstringview-блока) ─
 
     /// @brief Найти узел AVL-дерева с заданной строкой. Возвращает null если не найден.
-    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
+    static psview_pptr _avl_find( const char* s ) noexcept
+    {
+        auto* domain = ManagerT::symbol_domain_record_unlocked();
+        if ( domain == nullptr )
+            return psview_pptr();
+        return detail::avl_find<psview_pptr>(
+            domain->root_offset,
+            [&]( psview_pptr cur ) -> int
+            {
+                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
+                return ( obj != nullptr ) ? std::strcmp( s, obj->c_str() ) : 0;
+            },
+            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
+    }
 
     /// @brief Вставить новый узел в AVL-дерево. Предполагается, что строка ещё не в дереве.
-    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
+    static void _avl_insert( psview_pptr new_node ) noexcept
+    {
+        auto* domain = ManagerT::symbol_domain_record_unlocked();
+        if ( domain == nullptr )
+            return;
+        pstringview* new_obj = ManagerT::template resolve<pstringview>( new_node );
+        const char*  new_str = ( new_obj != nullptr ) ? new_obj->c_str() : "";
+        detail::avl_insert(
+            new_node, domain->root_offset,
+            [&]( psview_pptr cur ) -> bool
+            {
+                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
+                return ( obj != nullptr ) && ( std::strcmp( new_str, obj->c_str() ) < 0 );
+            },
+            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
+    }
 };
 
 } // namespace pmm
@@ -8693,6 +8605,13 @@ static index_type symbol_domain_root_offset_unlocked() noexcept
     return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
+static void reset_symbol_domain_unlocked() noexcept
+{
+    forest_domain* rec = symbol_domain_record_unlocked();
+    if ( rec != nullptr )
+        rec->root_offset = 0;
+}
+
 // ─── Domain registration ─────────────────────────────────────────────────────
 
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
@@ -8749,11 +8668,18 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    using symbol_policy = typename pstringview::forest_domain_policy;
-    if ( symbol_policy::root_index_ptr() == nullptr )
+    forest_domain* symbol_domain = symbol_domain_record_unlocked();
+    if ( symbol_domain == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = symbol_policy::find( s );
+    pptr<pstringview> found = detail::avl_find<pptr<pstringview>>(
+        symbol_domain->root_offset,
+        [&]( pptr<pstringview> cur ) -> int
+        {
+            const char* cur_str = pstringview_c_str_unlocked( cur );
+            return ( cur_str != nullptr ) ? std::strcmp( s, cur_str ) : 0;
+        },
+        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
     if ( !found.is_null() )
         return found;
 
@@ -8779,7 +8705,16 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    symbol_policy::insert( new_node );
+    // Re-derive c_str() pointer for comparisons using offset-based access.
+    const char* new_str = static_cast<const char*>( public_raw ) + offsetof( pstringview, str );
+    detail::avl_insert(
+        new_node, symbol_domain->root_offset,
+        [&]( pptr<pstringview> cur ) -> bool
+        {
+            const char* cur_str = pstringview_c_str_unlocked( cur );
+            return ( cur_str != nullptr ) && ( std::strcmp( new_str, cur_str ) < 0 );
+        },
+        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
 
     return new_node;
 }

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1220,7 +1220,6 @@ inline typename AddressTraitsT::index_type required_block_granules_t( std::size_
 
 } 
 
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 
@@ -1605,69 +1604,6 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 
     avl_rebalance_up( parent, root_idx, update_node );
 }
-
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
-    typename Domain::index_type;
-    typename Domain::node_type;
-    typename Domain::node_pptr;
-    { Domain::name() } -> std::convertible_to<const char*>;
-    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
-    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
-    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
-};
-
-template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
-{
-    if constexpr ( requires {
-                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
-                   } )
-        return Domain::validate_node( p );
-    else
-        return true;
-}
-
-template <typename Domain> struct ForestDomainOps
-{
-    using index_type = typename Domain::index_type;
-    using node_pptr  = typename Domain::node_pptr;
-
-    static constexpr const char* name() noexcept { return Domain::name(); }
-    static index_type            root_index() noexcept { return Domain::root_index(); }
-    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
-
-    static bool reset_root() noexcept
-    {
-        index_type* root = root_index_ptr();
-        if ( root == nullptr )
-            return false;
-        *root = static_cast<index_type>( 0 );
-        return true;
-    }
-
-    template <typename Key>
-        requires ForestDomainDescriptorForKey<Domain, Key>
-    static node_pptr find( const Key& key ) noexcept
-    {
-        return avl_find<node_pptr>(
-            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
-    }
-
-    static void insert( node_pptr new_node ) noexcept
-    {
-        index_type* root = Domain::root_index_ptr();
-        if ( root == nullptr || new_node.is_null() )
-            return;
-        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
-            return;
-        avl_insert(
-            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
-    }
-};
 
 template <typename AddressTraitsT> struct BlockPPtrManagerTag
 {
@@ -3949,49 +3885,6 @@ template <typename ManagerT> struct pstringview
     using index_type   = typename ManagerT::index_type;
     using psview_pptr  = typename ManagerT::template pptr<pstringview>;
 
-    struct forest_domain_descriptor
-    {
-        using manager_type = ManagerT;
-        using index_type   = typename ManagerT::index_type;
-        using node_type    = pstringview;
-        using node_pptr    = psview_pptr;
-
-        static constexpr const char* name() noexcept { return detail::kSystemDomainSymbols; }
-
-        static index_type root_index() noexcept
-        {
-            auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
-        }
-
-        static index_type* root_index_ptr() noexcept
-        {
-            auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
-        }
-
-        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
-
-        static int compare_key( const char* key, node_pptr cur ) noexcept
-        {
-            if ( key == nullptr )
-                key = "";
-            node_type* obj = resolve_node( cur );
-            return ( obj != nullptr ) ? std::strcmp( key, obj->c_str() ) : 0;
-        }
-
-        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
-        {
-            node_type* lhs_obj = resolve_node( lhs );
-            node_type* rhs_obj = resolve_node( rhs );
-            return lhs_obj != nullptr && rhs_obj != nullptr && std::strcmp( lhs_obj->c_str(), rhs_obj->c_str() ) < 0;
-        }
-
-        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
-    };
-
-    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
-
     std::uint32_t length; 
     char          str[1]; 
 
@@ -4036,7 +3929,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        forest_domain_policy::reset_root();
+        ManagerT::reset_symbol_domain_unlocked();
     }
 
     static index_type root_index() noexcept
@@ -4044,7 +3937,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return forest_domain_policy::root_index();
+        return ManagerT::symbol_domain_root_offset_unlocked();
     }
 
     ~pstringview() = default;
@@ -4111,9 +4004,37 @@ template <typename ManagerT> struct pstringview
         return new_node;
     }
 
-    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
+    static psview_pptr _avl_find( const char* s ) noexcept
+    {
+        auto* domain = ManagerT::symbol_domain_record_unlocked();
+        if ( domain == nullptr )
+            return psview_pptr();
+        return detail::avl_find<psview_pptr>(
+            domain->root_offset,
+            [&]( psview_pptr cur ) -> int
+            {
+                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
+                return ( obj != nullptr ) ? std::strcmp( s, obj->c_str() ) : 0;
+            },
+            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
+    }
 
-    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
+    static void _avl_insert( psview_pptr new_node ) noexcept
+    {
+        auto* domain = ManagerT::symbol_domain_record_unlocked();
+        if ( domain == nullptr )
+            return;
+        pstringview* new_obj = ManagerT::template resolve<pstringview>( new_node );
+        const char*  new_str = ( new_obj != nullptr ) ? new_obj->c_str() : "";
+        detail::avl_insert(
+            new_node, domain->root_offset,
+            [&]( psview_pptr cur ) -> bool
+            {
+                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
+                return ( obj != nullptr ) && ( std::strcmp( new_str, obj->c_str() ) < 0 );
+            },
+            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
+    }
 };
 
 } 
@@ -5314,6 +5235,13 @@ static index_type symbol_domain_root_offset_unlocked() noexcept
     return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
+static void reset_symbol_domain_unlocked() noexcept
+{
+    forest_domain* rec = symbol_domain_record_unlocked();
+    if ( rec != nullptr )
+        rec->root_offset = 0;
+}
+
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
                                       index_type initial_root ) noexcept
 {
@@ -5366,11 +5294,18 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    using symbol_policy = typename pstringview::forest_domain_policy;
-    if ( symbol_policy::root_index_ptr() == nullptr )
+    forest_domain* symbol_domain = symbol_domain_record_unlocked();
+    if ( symbol_domain == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = symbol_policy::find( s );
+    pptr<pstringview> found = detail::avl_find<pptr<pstringview>>(
+        symbol_domain->root_offset,
+        [&]( pptr<pstringview> cur ) -> int
+        {
+            const char* cur_str = pstringview_c_str_unlocked( cur );
+            return ( cur_str != nullptr ) ? std::strcmp( s, cur_str ) : 0;
+        },
+        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
     if ( !found.is_null() )
         return found;
 
@@ -5396,7 +5331,15 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    symbol_policy::insert( new_node );
+    const char* new_str = static_cast<const char*>( public_raw ) + offsetof( pstringview, str );
+    detail::avl_insert(
+        new_node, symbol_domain->root_offset,
+        [&]( pptr<pstringview> cur ) -> bool
+        {
+            const char* cur_str = pstringview_c_str_unlocked( cur );
+            return ( cur_str != nullptr ) && ( std::strcmp( new_str, cur_str ) < 0 );
+        },
+        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
 
     return new_node;
 }

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1220,6 +1220,7 @@ inline typename AddressTraitsT::index_type required_block_granules_t( std::size_
 
 } 
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 
@@ -1604,6 +1605,69 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 
     avl_rebalance_up( parent, root_idx, update_node );
 }
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+    typename Domain::index_type;
+    typename Domain::node_type;
+    typename Domain::node_pptr;
+    { Domain::name() } -> std::convertible_to<const char*>;
+    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
+    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+};
+
+template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+{
+    if constexpr ( requires {
+                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                   } )
+        return Domain::validate_node( p );
+    else
+        return true;
+}
+
+template <typename Domain> struct ForestDomainOps
+{
+    using index_type = typename Domain::index_type;
+    using node_pptr  = typename Domain::node_pptr;
+
+    static constexpr const char* name() noexcept { return Domain::name(); }
+    static index_type            root_index() noexcept { return Domain::root_index(); }
+    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+
+    static bool reset_root() noexcept
+    {
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    template <typename Key>
+        requires ForestDomainDescriptorForKey<Domain, Key>
+    static node_pptr find( const Key& key ) noexcept
+    {
+        return avl_find<node_pptr>(
+            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+
+    static void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = Domain::root_index_ptr();
+        if ( root == nullptr || new_node.is_null() )
+            return;
+        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+            return;
+        avl_insert(
+            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
+            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+    }
+};
 
 template <typename AddressTraitsT> struct BlockPPtrManagerTag
 {
@@ -3885,6 +3949,49 @@ template <typename ManagerT> struct pstringview
     using index_type   = typename ManagerT::index_type;
     using psview_pptr  = typename ManagerT::template pptr<pstringview>;
 
+    struct forest_domain_descriptor
+    {
+        using manager_type = ManagerT;
+        using index_type   = typename ManagerT::index_type;
+        using node_type    = pstringview;
+        using node_pptr    = psview_pptr;
+
+        static constexpr const char* name() noexcept { return detail::kSystemDomainSymbols; }
+
+        static index_type root_index() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+        }
+
+        static index_type* root_index_ptr() noexcept
+        {
+            auto* domain = ManagerT::symbol_domain_record_unlocked();
+            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+        }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const char* key, node_pptr cur ) noexcept
+        {
+            if ( key == nullptr )
+                key = "";
+            node_type* obj = resolve_node( cur );
+            return ( obj != nullptr ) ? std::strcmp( key, obj->c_str() ) : 0;
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && std::strcmp( lhs_obj->c_str(), rhs_obj->c_str() ) < 0;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
     std::uint32_t length; 
     char          str[1]; 
 
@@ -3929,7 +4036,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        ManagerT::reset_symbol_domain_unlocked();
+        forest_domain_policy::reset_root();
     }
 
     static index_type root_index() noexcept
@@ -3937,7 +4044,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return ManagerT::symbol_domain_root_offset_unlocked();
+        return forest_domain_policy::root_index();
     }
 
     ~pstringview() = default;
@@ -4004,37 +4111,9 @@ template <typename ManagerT> struct pstringview
         return new_node;
     }
 
-    static psview_pptr _avl_find( const char* s ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return psview_pptr();
-        return detail::avl_find<psview_pptr>(
-            domain->root_offset,
-            [&]( psview_pptr cur ) -> int
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) ? std::strcmp( s, obj->c_str() ) : 0;
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
 
-    static void _avl_insert( psview_pptr new_node ) noexcept
-    {
-        auto* domain = ManagerT::symbol_domain_record_unlocked();
-        if ( domain == nullptr )
-            return;
-        pstringview* new_obj = ManagerT::template resolve<pstringview>( new_node );
-        const char*  new_str = ( new_obj != nullptr ) ? new_obj->c_str() : "";
-        detail::avl_insert(
-            new_node, domain->root_offset,
-            [&]( psview_pptr cur ) -> bool
-            {
-                pstringview* obj = ManagerT::template resolve<pstringview>( cur );
-                return ( obj != nullptr ) && ( std::strcmp( new_str, obj->c_str() ) < 0 );
-            },
-            []( psview_pptr p ) -> pstringview* { return ManagerT::template resolve<pstringview>( p ); } );
-    }
+    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 } 
@@ -5235,13 +5314,6 @@ static index_type symbol_domain_root_offset_unlocked() noexcept
     return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
-static void reset_symbol_domain_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    if ( rec != nullptr )
-        rec->root_offset = 0;
-}
-
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
                                       index_type initial_root ) noexcept
 {
@@ -5294,18 +5366,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    forest_domain* symbol_domain = symbol_domain_record_unlocked();
-    if ( symbol_domain == nullptr )
+    using symbol_policy = typename pstringview::forest_domain_policy;
+    if ( symbol_policy::root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = detail::avl_find<pptr<pstringview>>(
-        symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> int
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) ? std::strcmp( s, cur_str ) : 0;
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    pptr<pstringview> found = symbol_policy::find( s );
     if ( !found.is_null() )
         return found;
 
@@ -5331,15 +5396,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    const char* new_str = static_cast<const char*>( public_raw ) + offsetof( pstringview, str );
-    detail::avl_insert(
-        new_node, symbol_domain->root_offset,
-        [&]( pptr<pstringview> cur ) -> bool
-        {
-            const char* cur_str = pstringview_c_str_unlocked( cur );
-            return ( cur_str != nullptr ) && ( std::strcmp( new_str, cur_str ) < 0 );
-        },
-        []( pptr<pstringview> p ) -> const char* { return pstringview_c_str_unlocked( p ); } );
+    symbol_policy::insert( new_node );
 
     return new_node;
 }

--- a/tests/test_issue151_pstringview.cpp
+++ b/tests/test_issue151_pstringview.cpp
@@ -305,6 +305,35 @@ TEST_CASE( "    AVL root tracked by persistent symbol domain", "[test_issue151_p
     TestPsv::reset();
 }
 
+/// @brief pstringview exposes an explicit forest-domain descriptor/policy contract.
+TEST_CASE( "    forest-domain descriptor drives symbol dictionary", "[test_issue151_pstringview]" )
+{
+    using Domain = TestPsv::forest_domain_descriptor;
+    static_assert( pmm::detail::ForestDomainDescriptorForKey<Domain, const char*> );
+
+    TestMgr::destroy();
+    TestPsv::reset();
+    REQUIRE( TestMgr::create( 128 * 1024 ) );
+
+    REQUIRE( std::strcmp( Domain::name(), pmm::detail::kSystemDomainSymbols ) == 0 );
+    REQUIRE( Domain::root_index_ptr() != nullptr );
+    REQUIRE( Domain::root_index() == TestPsv::root_index() );
+    REQUIRE( TestMgr::get_domain_root_offset( Domain::name() ) == TestPsv::root_index() );
+
+    TestMgr_pptr_psv alpha = TestMgr::pstringview( "descriptor_alpha" );
+    TestMgr_pptr_psv beta  = TestMgr::pstringview( "descriptor_beta" );
+    REQUIRE( ( !alpha.is_null() && !beta.is_null() ) );
+
+    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_alpha" ) == alpha );
+    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_beta" ) == beta );
+    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_missing" ).is_null() );
+    REQUIRE( Domain::validate_node( alpha ) );
+    REQUIRE( *Domain::root_index_ptr() == TestPsv::root_index() );
+
+    TestMgr::destroy();
+    TestPsv::reset();
+}
+
 // =============================================================================
 // I151-E: Dictionary grows during manager lifetime (key requirement #5)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds a minimal AVL forest-domain descriptor/policy seam: `ForestDomainDescriptorForKey` and `ForestDomainOps`.
- Migrates exactly one non-allocator domain, `pstringview` / `system/symbols`, onto that seam for domain identity, root binding, node access, ordering, and optional validation.
- Routes manager symbol interning through the same `pstringview` domain policy so bootstrap and public interning do not keep separate AVL code paths.
- Adds descriptor contract coverage to the existing pstringview test.
- Regenerates the required full single-header outputs, `single_include/pmm/pmm.h` and `single_include/pmm/pmm_no_comments.h`, so the required freshness workflow passes.

## Reproduction
- Added `forest-domain descriptor drives symbol dictionary` in `tests/test_issue151_pstringview.cpp`.
- Before the implementation, `cmake --build build --target test_issue151_pstringview` failed because `forest_domain_descriptor`, `forest_domain_policy`, and `ForestDomainDescriptorForKey` did not exist.
- The CI failure was reproduced locally by regenerating single headers to a temp directory and comparing them with the committed files; before the generated refresh, `single_include/pmm/pmm.h` and `single_include/pmm/pmm_no_comments.h` differed.

## Verification
- `bash scripts/generate-single-headers.sh --strip-comments --output-dir /tmp/generated-pmm-issue316-after` plus `diff -q` against all committed single-header preset outputs.
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (87/87 passed)
- `./build/tests/test_issue151_pstringview` (439 assertions passed)
- tracked-source `clang-format --dry-run --Werror`
- `bash scripts/check-file-size.sh`
- `bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `git diff --check upstream/main...HEAD`
- `git diff --check`

## Scope note
- The source-side extraction still migrates exactly one non-allocator client: `pstringview` / `system/symbols`.
- The `single_include/**` diff is mechanical generator output only. It is included because the current required CI workflow `Single-header presets up-to-date` compares generated headers against committed files for every PR; without these two generated files, this PR cannot be CI-green.
- No docs, governance files, workflow files, or generator scripts are changed.

Fixes netkeep80/PersistMemoryManager#316
