### PR TITLE
fix(#325): use aligned ManagerHeader offset for CRC

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T23:16:18.183Z for PR creation at branch issue-325-391b22c29545 for issue https://github.com/netkeep80/PersistMemoryManager/issues/325

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T23:16:18.183Z for PR creation at branch issue-325-391b22c29545 for issue https://github.com/netkeep80/PersistMemoryManager/issues/325

--- a/changelog.d/20260419_232000_issue325_manager_header_offset.md
+++ b/changelog.d/20260419_232000_issue325_manager_header_offset.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Use the canonical granule-aligned `ManagerHeader` offset in CRC, save, and load paths.

--- a/include/pmm/io.h
+++ b/include/pmm/io.h
@@ -82,12 +82,10 @@ template <typename MgrT> inline bool save_manager( const char* filename )
     if ( data == nullptr || total == 0 )
         return false;
 
-    // Compute and store CRC32 in the manager header.
-    // The header is located after Block_0 (sizeof(Block<AT>) bytes from base).
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
-    auto*                 hdr        = reinterpret_cast<detail::ManagerHeader<address_traits>*>( data + kHdrOffset );
-    hdr->crc32                       = 0; // zero the field before computing CRC
-    hdr->crc32                       = detail::compute_image_crc32<address_traits>( data, total );
+    // Compute and store CRC32 in the canonical manager header.
+    auto* hdr  = detail::manager_header_at<address_traits>( data );
+    hdr->crc32 = 0;
+    hdr->crc32 = detail::compute_image_crc32<address_traits>( data, total );
 
     // Atomic save — write to temp file, then rename.
     std::string tmp_path = std::string( filename ) + ".tmp";
@@ -182,10 +180,10 @@ template <typename MgrT> inline bool load_manager_from_file( const char* filenam
         return false;
 
     // Verify CRC32 before calling load().
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
+    constexpr std::size_t kHdrOffset = detail::manager_header_offset_bytes_v<address_traits>;
     if ( file_size >= kHdrOffset + sizeof( detail::ManagerHeader<address_traits> ) )
     {
-        auto*         hdr          = reinterpret_cast<detail::ManagerHeader<address_traits>*>( buf + kHdrOffset );
+        auto*         hdr          = detail::manager_header_at<address_traits>( buf );
         std::uint32_t stored_crc   = hdr->crc32;
         std::uint32_t computed_crc = detail::compute_image_crc32<address_traits>( buf, file_size );
         if ( stored_crc != computed_crc )

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -1057,9 +1057,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
 
     /// @brief Byte offset of ManagerHeader from base: rounds sizeof(Block<A>) up to granule boundary.
     /// For DefaultAddressTraits: 32 bytes. For SmallAddressTraits: roundup(18,16) = 32. For Large: 64.
-    static constexpr std::size_t kBlockHdrByteSize =
-        ( ( sizeof( Block<address_traits> ) + address_traits::granule_size - 1 ) / address_traits::granule_size ) *
-        address_traits::granule_size;
+    static constexpr std::size_t kBlockHdrByteSize = detail::manager_header_offset_bytes_v<address_traits>;
 
     static constexpr index_type kBlockHdrGranules =
         static_cast<index_type>( kBlockHdrByteSize / address_traits::granule_size );
@@ -1072,12 +1070,12 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
     static detail::ManagerHeader<address_traits>* get_header( std::uint8_t* base ) noexcept
     {
         // Place ManagerHeader at a granule-aligned offset after Block_0.
-        return reinterpret_cast<detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     static const detail::ManagerHeader<address_traits>* get_header_c( const std::uint8_t* base ) noexcept
     {
-        return reinterpret_cast<const detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     struct layout_access

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -217,6 +217,34 @@ static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) == 64,
 static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) % kGranuleSize == 0,
                "ManagerHeader<DefaultAddressTraits> must be granule-aligned " );
 
+/// @brief Block header size in granules for AddressTraitsT.
+/// Computes ceil(sizeof(Block<AT>) / AT::granule_size).
+/// For DefaultAddressTraits: 32/16 = 2. For SmallAddressTraits: ceil(18/16) = 2. For Large: 64/64 = 1.
+template <typename AddressTraitsT>
+inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
+    static_cast<typename AddressTraitsT::index_type>(
+        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
+
+/// @brief Canonical byte offset of ManagerHeader from the base pointer.
+template <typename AddressTraitsT>
+inline constexpr std::size_t manager_header_offset_bytes_v =
+    static_cast<std::size_t>( kBlockHeaderGranules_t<AddressTraitsT> ) * AddressTraitsT::granule_size;
+
+/// @brief Canonical mutable ManagerHeader pointer from the base pointer.
+template <typename AddressTraitsT>
+inline ManagerHeader<AddressTraitsT>* manager_header_at( std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<ManagerHeader<AddressTraitsT>*>( base + manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
+/// @brief Canonical const ManagerHeader pointer from the base pointer.
+template <typename AddressTraitsT>
+inline const ManagerHeader<AddressTraitsT>* manager_header_at( const std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<const ManagerHeader<AddressTraitsT>*>( base +
+                                                                   manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
 /// @brief Compute CRC32 of the full persisted image, treating the crc32 field as zero.
 /// @tparam AddressTraitsT Address traits type (determines ManagerHeader layout).
 /// @param data   Pointer to the start of the managed region.
@@ -226,8 +254,8 @@ template <typename AddressTraitsT>
 inline std::uint32_t compute_image_crc32( const std::uint8_t* data, std::size_t length ) noexcept
 {
     // Offset of the crc32 field within ManagerHeader, which itself is located
-    // after Block_0 (sizeof(Block<AT>) bytes from base).
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<AddressTraitsT> );
+    // at the canonical granule-aligned offset after Block_0.
+    constexpr std::size_t kHdrOffset = manager_header_offset_bytes_v<AddressTraitsT>;
     constexpr std::size_t kCrcOffset = kHdrOffset + offsetof( ManagerHeader<AddressTraitsT>, crc32 );
     constexpr std::size_t kCrcSize   = sizeof( std::uint32_t );
     constexpr std::size_t kAfterCrc  = kCrcOffset + kCrcSize;
@@ -369,14 +397,6 @@ inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*     
     assert( byte_off % AddressTraitsT::granule_size == 0 );
     return static_cast<typename AddressTraitsT::index_type>( byte_off / AddressTraitsT::granule_size );
 }
-
-/// @brief Block header size in granules for AddressTraitsT.
-/// Computes ceil(sizeof(Block<AT>) / AT::granule_size).
-/// For DefaultAddressTraits: 32/16 = 2. For SmallAddressTraits: ceil(18/16) = 2. For Large: 64/64 = 1.
-template <typename AddressTraitsT>
-inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
-    static_cast<typename AddressTraitsT::index_type>(
-        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
 
 /// @brief Manager header size in granules for AddressTraitsT.
 /// Uses ceiling division: ceil(sizeof(ManagerHeader<AT>) / AT::granule_size).

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2250,6 +2250,34 @@ static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) == 64,
 static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) % kGranuleSize == 0,
                "ManagerHeader<DefaultAddressTraits> must be granule-aligned " );
 
+/// @brief Block header size in granules for AddressTraitsT.
+/// Computes ceil(sizeof(Block<AT>) / AT::granule_size).
+/// For DefaultAddressTraits: 32/16 = 2. For SmallAddressTraits: ceil(18/16) = 2. For Large: 64/64 = 1.
+template <typename AddressTraitsT>
+inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
+    static_cast<typename AddressTraitsT::index_type>(
+        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
+
+/// @brief Canonical byte offset of ManagerHeader from the base pointer.
+template <typename AddressTraitsT>
+inline constexpr std::size_t manager_header_offset_bytes_v =
+    static_cast<std::size_t>( kBlockHeaderGranules_t<AddressTraitsT> ) * AddressTraitsT::granule_size;
+
+/// @brief Canonical mutable ManagerHeader pointer from the base pointer.
+template <typename AddressTraitsT>
+inline ManagerHeader<AddressTraitsT>* manager_header_at( std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<ManagerHeader<AddressTraitsT>*>( base + manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
+/// @brief Canonical const ManagerHeader pointer from the base pointer.
+template <typename AddressTraitsT>
+inline const ManagerHeader<AddressTraitsT>* manager_header_at( const std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<const ManagerHeader<AddressTraitsT>*>( base +
+                                                                   manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
 /// @brief Compute CRC32 of the full persisted image, treating the crc32 field as zero.
 /// @tparam AddressTraitsT Address traits type (determines ManagerHeader layout).
 /// @param data   Pointer to the start of the managed region.
@@ -2259,8 +2287,8 @@ template <typename AddressTraitsT>
 inline std::uint32_t compute_image_crc32( const std::uint8_t* data, std::size_t length ) noexcept
 {
     // Offset of the crc32 field within ManagerHeader, which itself is located
-    // after Block_0 (sizeof(Block<AT>) bytes from base).
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<AddressTraitsT> );
+    // at the canonical granule-aligned offset after Block_0.
+    constexpr std::size_t kHdrOffset = manager_header_offset_bytes_v<AddressTraitsT>;
     constexpr std::size_t kCrcOffset = kHdrOffset + offsetof( ManagerHeader<AddressTraitsT>, crc32 );
     constexpr std::size_t kCrcSize   = sizeof( std::uint32_t );
     constexpr std::size_t kAfterCrc  = kCrcOffset + kCrcSize;
@@ -2402,14 +2430,6 @@ inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*     
     assert( byte_off % AddressTraitsT::granule_size == 0 );
     return static_cast<typename AddressTraitsT::index_type>( byte_off / AddressTraitsT::granule_size );
 }
-
-/// @brief Block header size in granules for AddressTraitsT.
-/// Computes ceil(sizeof(Block<AT>) / AT::granule_size).
-/// For DefaultAddressTraits: 32/16 = 2. For SmallAddressTraits: ceil(18/16) = 2. For Large: 64/64 = 1.
-template <typename AddressTraitsT>
-inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
-    static_cast<typename AddressTraitsT::index_type>(
-        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
 
 /// @brief Manager header size in granules for AddressTraitsT.
 /// Uses ceiling division: ceil(sizeof(ManagerHeader<AT>) / AT::granule_size).
@@ -9518,9 +9538,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
 
     /// @brief Byte offset of ManagerHeader from base: rounds sizeof(Block<A>) up to granule boundary.
     /// For DefaultAddressTraits: 32 bytes. For SmallAddressTraits: roundup(18,16) = 32. For Large: 64.
-    static constexpr std::size_t kBlockHdrByteSize =
-        ( ( sizeof( Block<address_traits> ) + address_traits::granule_size - 1 ) / address_traits::granule_size ) *
-        address_traits::granule_size;
+    static constexpr std::size_t kBlockHdrByteSize = detail::manager_header_offset_bytes_v<address_traits>;
 
     static constexpr index_type kBlockHdrGranules =
         static_cast<index_type>( kBlockHdrByteSize / address_traits::granule_size );
@@ -9533,12 +9551,12 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     static detail::ManagerHeader<address_traits>* get_header( std::uint8_t* base ) noexcept
     {
         // Place ManagerHeader at a granule-aligned offset after Block_0.
-        return reinterpret_cast<detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     static const detail::ManagerHeader<address_traits>* get_header_c( const std::uint8_t* base ) noexcept
     {
-        return reinterpret_cast<const detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     struct layout_access
@@ -9652,12 +9670,10 @@ template <typename MgrT> inline bool save_manager( const char* filename )
     if ( data == nullptr || total == 0 )
         return false;
 
-    // Compute and store CRC32 in the manager header.
-    // The header is located after Block_0 (sizeof(Block<AT>) bytes from base).
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
-    auto*                 hdr        = reinterpret_cast<detail::ManagerHeader<address_traits>*>( data + kHdrOffset );
-    hdr->crc32                       = 0; // zero the field before computing CRC
-    hdr->crc32                       = detail::compute_image_crc32<address_traits>( data, total );
+    // Compute and store CRC32 in the canonical manager header.
+    auto* hdr  = detail::manager_header_at<address_traits>( data );
+    hdr->crc32 = 0;
+    hdr->crc32 = detail::compute_image_crc32<address_traits>( data, total );
 
     // Atomic save — write to temp file, then rename.
     std::string tmp_path = std::string( filename ) + ".tmp";
@@ -9752,10 +9768,10 @@ template <typename MgrT> inline bool load_manager_from_file( const char* filenam
         return false;
 
     // Verify CRC32 before calling load().
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
+    constexpr std::size_t kHdrOffset = detail::manager_header_offset_bytes_v<address_traits>;
     if ( file_size >= kHdrOffset + sizeof( detail::ManagerHeader<address_traits> ) )
     {
-        auto*         hdr          = reinterpret_cast<detail::ManagerHeader<address_traits>*>( buf + kHdrOffset );
+        auto*         hdr          = detail::manager_header_at<address_traits>( buf );
         std::uint32_t stored_crc   = hdr->crc32;
         std::uint32_t computed_crc = detail::compute_image_crc32<address_traits>( buf, file_size );
         if ( stored_crc != computed_crc )

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1234,10 +1234,32 @@ static_assert( sizeof( ManagerHeader<DefaultAddressTraits> ) % kGranuleSize == 0
                "ManagerHeader<DefaultAddressTraits> must be granule-aligned " );
 
 template <typename AddressTraitsT>
+inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
+    static_cast<typename AddressTraitsT::index_type>(
+        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
+
+template <typename AddressTraitsT>
+inline constexpr std::size_t manager_header_offset_bytes_v =
+    static_cast<std::size_t>( kBlockHeaderGranules_t<AddressTraitsT> ) * AddressTraitsT::granule_size;
+
+template <typename AddressTraitsT>
+inline ManagerHeader<AddressTraitsT>* manager_header_at( std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<ManagerHeader<AddressTraitsT>*>( base + manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
+template <typename AddressTraitsT>
+inline const ManagerHeader<AddressTraitsT>* manager_header_at( const std::uint8_t* base ) noexcept
+{
+    return reinterpret_cast<const ManagerHeader<AddressTraitsT>*>( base +
+                                                                   manager_header_offset_bytes_v<AddressTraitsT> );
+}
+
+template <typename AddressTraitsT>
 inline std::uint32_t compute_image_crc32( const std::uint8_t* data, std::size_t length ) noexcept
 {
     
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<AddressTraitsT> );
+    constexpr std::size_t kHdrOffset = manager_header_offset_bytes_v<AddressTraitsT>;
     constexpr std::size_t kCrcOffset = kHdrOffset + offsetof( ManagerHeader<AddressTraitsT>, crc32 );
     constexpr std::size_t kCrcSize   = sizeof( std::uint32_t );
     constexpr std::size_t kAfterCrc  = kCrcOffset + kCrcSize;
@@ -1350,11 +1372,6 @@ inline typename AddressTraitsT::index_type block_idx_t( const std::uint8_t*     
     assert( byte_off % AddressTraitsT::granule_size == 0 );
     return static_cast<typename AddressTraitsT::index_type>( byte_off / AddressTraitsT::granule_size );
 }
-
-template <typename AddressTraitsT>
-inline constexpr typename AddressTraitsT::index_type kBlockHeaderGranules_t =
-    static_cast<typename AddressTraitsT::index_type>(
-        ( sizeof( pmm::Block<AddressTraitsT> ) + AddressTraitsT::granule_size - 1 ) / AddressTraitsT::granule_size );
 
 template <typename AddressTraitsT>
 inline constexpr typename AddressTraitsT::index_type kManagerHeaderGranules_t =
@@ -6173,9 +6190,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 }
 
-    static constexpr std::size_t kBlockHdrByteSize =
-        ( ( sizeof( Block<address_traits> ) + address_traits::granule_size - 1 ) / address_traits::granule_size ) *
-        address_traits::granule_size;
+    static constexpr std::size_t kBlockHdrByteSize = detail::manager_header_offset_bytes_v<address_traits>;
 
     static constexpr index_type kBlockHdrGranules =
         static_cast<index_type>( kBlockHdrByteSize / address_traits::granule_size );
@@ -6187,12 +6202,12 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     static detail::ManagerHeader<address_traits>* get_header( std::uint8_t* base ) noexcept
     {
         
-        return reinterpret_cast<detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     static const detail::ManagerHeader<address_traits>* get_header_c( const std::uint8_t* base ) noexcept
     {
-        return reinterpret_cast<const detail::ManagerHeader<address_traits>*>( base + kBlockHdrByteSize );
+        return detail::manager_header_at<address_traits>( base );
     }
 
     struct layout_access
@@ -6272,10 +6287,9 @@ template <typename MgrT> inline bool save_manager( const char* filename )
     if ( data == nullptr || total == 0 )
         return false;
 
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
-    auto*                 hdr        = reinterpret_cast<detail::ManagerHeader<address_traits>*>( data + kHdrOffset );
-    hdr->crc32                       = 0; 
-    hdr->crc32                       = detail::compute_image_crc32<address_traits>( data, total );
+    auto* hdr  = detail::manager_header_at<address_traits>( data );
+    hdr->crc32 = 0;
+    hdr->crc32 = detail::compute_image_crc32<address_traits>( data, total );
 
     std::string tmp_path = std::string( filename ) + ".tmp";
 
@@ -6347,10 +6361,10 @@ template <typename MgrT> inline bool load_manager_from_file( const char* filenam
     if ( read_bytes != file_size )
         return false;
 
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<address_traits> );
+    constexpr std::size_t kHdrOffset = detail::manager_header_offset_bytes_v<address_traits>;
     if ( file_size >= kHdrOffset + sizeof( detail::ManagerHeader<address_traits> ) )
     {
-        auto*         hdr          = reinterpret_cast<detail::ManagerHeader<address_traits>*>( buf + kHdrOffset );
+        auto*         hdr          = detail::manager_header_at<address_traits>( buf );
         std::uint32_t stored_crc   = hdr->crc32;
         std::uint32_t computed_crc = detail::compute_image_crc32<address_traits>( buf, file_size );
         if ( stored_crc != computed_crc )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -303,6 +303,9 @@ pmm_add_test(test_issue312_access_modes test_issue312_access_modes.cpp)
 pmm_add_test(test_issue318_manager_header_compaction test_issue318_manager_header_compaction.cpp)
 target_compile_definitions(test_issue318_manager_header_compaction PRIVATE PMM_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
+# ─── Issue 325: manager-header offset consistency for CRC/save/load ─
+pmm_add_test(test_issue325_manager_header_offset test_issue325_manager_header_offset.cpp)
+
 # ─── Issue 314: build graph compaction contract ─────────────────
 add_test(
     NAME test_issue314_build_graph_contract

--- a/tests/test_forest_registry.cpp
+++ b/tests/test_forest_registry.cpp
@@ -156,7 +156,7 @@ TEST_CASE( "legacy root API is a compatibility shim over the domain registry", "
 
     using AT           = CanonicalRootMgr::address_traits;
     std::uint8_t* base = CanonicalRootMgr::backend().base_ptr();
-    auto*         hdr  = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
+    auto*         hdr  = pmm::detail::manager_header_at<AT>( base );
     auto*         reg  = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
         base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
     REQUIRE( reg->reserved_root_offset == 0 );

--- a/tests/test_issue201_error_codes.cpp
+++ b/tests/test_issue201_error_codes.cpp
@@ -144,9 +144,8 @@ TEST_CASE( "load_invalid_magic", "[test_issue201_error_codes]" )
     MgrLoad::create( 64 * 1024 );
     MgrLoad::destroy();
     // After destroy, magic is zeroed. Set a deliberately wrong magic.
-    auto& be  = MgrLoad::backend();
-    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>(
-        be.base_ptr() + sizeof( pmm::Block<pmm::DefaultAddressTraits> ) );
+    auto& be   = MgrLoad::backend();
+    auto* hdr  = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( be.base_ptr() );
     hdr->magic = 0xDEADBEEF;
     MgrLoad::clear_error();
     pmm::VerifyResult result;
@@ -162,9 +161,8 @@ TEST_CASE( "load_size_mismatch", "[test_issue201_error_codes]" )
     MgrSz::create( 64 * 1024 );
     MgrSz::destroy();
     // After destroy, magic is zeroed. Restore magic but set wrong total_size.
-    auto& be  = MgrSz::backend();
-    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>(
-        be.base_ptr() + sizeof( pmm::Block<pmm::DefaultAddressTraits> ) );
+    auto& be        = MgrSz::backend();
+    auto* hdr       = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( be.base_ptr() );
     hdr->magic      = pmm::kMagic;
     hdr->total_size = 12345; // wrong — doesn't match backend
     MgrSz::clear_error();
@@ -181,9 +179,8 @@ TEST_CASE( "load_granule_mismatch", "[test_issue201_error_codes]" )
     MgrGr::create( 64 * 1024 );
     MgrGr::destroy();
     // After destroy, magic is zeroed. Restore magic and total_size, but set wrong granule_size.
-    auto& be  = MgrGr::backend();
-    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>(
-        be.base_ptr() + sizeof( pmm::Block<pmm::DefaultAddressTraits> ) );
+    auto& be          = MgrGr::backend();
+    auto* hdr         = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( be.base_ptr() );
     hdr->magic        = pmm::kMagic;
     hdr->total_size   = be.total_size(); // correct
     hdr->granule_size = 99;              // wrong

--- a/tests/test_issue202_logging_hooks.cpp
+++ b/tests/test_issue202_logging_hooks.cpp
@@ -244,8 +244,7 @@ TEST_CASE( "on_corruption (bad magic)", "[test_issue202_logging_hooks]" )
     std::fclose( f );
 
     // Corrupt the magic number, keep total_size correct.
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<pmm::DefaultAddressTraits> );
-    auto* hdr  = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kHdrOffset );
+    auto* hdr  = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
     hdr->magic = 0xDEADBEEFULL;
 
     TestHookCounters::reset();
@@ -279,8 +278,7 @@ TEST_CASE( "on_corruption (size mismatch)", "[test_issue202_logging_hooks]" )
     std::fclose( f );
 
     // Corrupt total_size in header. Magic is correct from the saved image.
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<pmm::DefaultAddressTraits> );
-    auto* hdr       = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kHdrOffset );
+    auto* hdr       = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
     hdr->total_size = buf_size + 999;
 
     TestHookCounters::reset();
@@ -314,8 +312,7 @@ TEST_CASE( "on_corruption (granule mismatch)", "[test_issue202_logging_hooks]" )
     std::fclose( f );
 
     // Corrupt granule_size in header. Magic and total_size are correct from saved image.
-    constexpr std::size_t kHdrOffset = sizeof( pmm::Block<pmm::DefaultAddressTraits> );
-    auto* hdr         = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kHdrOffset );
+    auto* hdr         = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
     hdr->granule_size = 99;
 
     TestHookCounters::reset();

--- a/tests/test_issue245_verify_repair.cpp
+++ b/tests/test_issue245_verify_repair.cpp
@@ -30,16 +30,10 @@ using Mgr = pmm::presets::SingleThreadedHeap;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/// @brief Byte offset of ManagerHeader from base (mirrors the private constant in PersistMemoryManager).
-static constexpr std::size_t kBlockHdrByteSize =
-    ( ( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) + pmm::DefaultAddressTraits::granule_size - 1 ) /
-      pmm::DefaultAddressTraits::granule_size ) *
-    pmm::DefaultAddressTraits::granule_size;
-
-/// @brief Get ManagerHeader from base pointer (mirrors PersistMemoryManager::get_header).
+/// @brief Get ManagerHeader from base pointer.
 static pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>* test_get_header( std::uint8_t* base ) noexcept
 {
-    return reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kBlockHdrByteSize );
+    return pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
 }
 
 /// @brief Create a manager, do some allocations, save to buffer, reload.

--- a/tests/test_issue256_verify_repair_contract.cpp
+++ b/tests/test_issue256_verify_repair_contract.cpp
@@ -31,14 +31,9 @@ using Mgr = pmm::presets::SingleThreadedHeap;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-static constexpr std::size_t kBlockHdrByteSize =
-    ( ( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) + pmm::DefaultAddressTraits::granule_size - 1 ) /
-      pmm::DefaultAddressTraits::granule_size ) *
-    pmm::DefaultAddressTraits::granule_size;
-
 static pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>* test_get_header( std::uint8_t* base ) noexcept
 {
-    return reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kBlockHdrByteSize );
+    return pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
 }
 
 static void setup_clean_image( std::size_t arena_size = 64 * 1024 )

--- a/tests/test_issue258_corruption.cpp
+++ b/tests/test_issue258_corruption.cpp
@@ -24,12 +24,9 @@
 using AT  = pmm::DefaultAddressTraits;
 using Mgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 25830>;
 
-static constexpr std::size_t kBlockHdrByteSize =
-    ( ( sizeof( pmm::Block<AT> ) + AT::granule_size - 1 ) / AT::granule_size ) * AT::granule_size;
-
 static pmm::detail::ManagerHeader<AT>* get_header( std::uint8_t* base ) noexcept
 {
-    return reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + kBlockHdrByteSize );
+    return pmm::detail::manager_header_at<AT>( base );
 }
 
 static void setup_clean( std::size_t arena = 64 * 1024 )

--- a/tests/test_issue258_structural.cpp
+++ b/tests/test_issue258_structural.cpp
@@ -40,7 +40,7 @@ static std::vector<BlockInfo> walk_blocks( std::uint8_t* base, std::size_t total
     using BlockState              = pmm::BlockStateBase<AT>;
     constexpr std::size_t kGranSz = AT::granule_size;
 
-    auto* hdr = reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( base + sizeof( pmm::Block<AT> ) );
+    auto* hdr = pmm::detail::manager_header_at<AT>( base );
 
     std::vector<BlockInfo> blocks;
     AT::index_type         idx = hdr->first_block_offset;
@@ -349,8 +349,7 @@ TEST_CASE( "structural: total size equals sum of all block sizes", "[issue258][s
 
     // First block starts at first_block_offset, not at 0
     // The area before first_block_offset is Block_0 + ManagerHeader
-    auto* hdr =
-        reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( Mgr::backend().base_ptr() + sizeof( pmm::Block<AT> ) );
+    auto*          hdr            = pmm::detail::manager_header_at<AT>( Mgr::backend().base_ptr() );
     AT::index_type total_granules = static_cast<AT::index_type>( Mgr::total_size() / AT::granule_size );
     AT::index_type block_area     = total_granules - hdr->first_block_offset;
     REQUIRE( sum_granules == block_area );

--- a/tests/test_issue303_free_tree_verifier.cpp
+++ b/tests/test_issue303_free_tree_verifier.cpp
@@ -33,9 +33,7 @@ static void setup_fragmented_free_tree()
 
 static pmm::detail::ManagerHeader<AT>* header()
 {
-    constexpr std::size_t hdr_off =
-        ( ( sizeof( pmm::Block<AT> ) + AT::granule_size - 1 ) / AT::granule_size ) * AT::granule_size;
-    return reinterpret_cast<pmm::detail::ManagerHeader<AT>*>( Mgr::backend().base_ptr() + hdr_off );
+    return pmm::detail::manager_header_at<AT>( Mgr::backend().base_ptr() );
 }
 
 static void* block_at( AT::index_type idx )

--- a/tests/test_issue325_manager_header_offset.cpp
+++ b/tests/test_issue325_manager_header_offset.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file test_issue325_manager_header_offset.cpp
+ * @brief Regression tests for ManagerHeader offset consistency in CRC/save/load paths.
+ */
+
+#include "pmm/io.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+namespace
+{
+
+template <typename MgrSave, typename MgrLoad> void require_roundtrip( const char* filename, std::size_t arena_size )
+{
+    MgrSave::destroy();
+    MgrLoad::destroy();
+
+    struct Cleanup
+    {
+        const char* filename;
+        ~Cleanup()
+        {
+            MgrSave::destroy();
+            MgrLoad::destroy();
+            std::remove( filename );
+        }
+    } cleanup{ filename };
+
+    REQUIRE( MgrSave::create( arena_size ) );
+
+    typename MgrSave::template pptr<std::uint32_t> saved = MgrSave::template allocate_typed<std::uint32_t>( 4 );
+    REQUIRE( !saved.is_null() );
+
+    std::uint32_t* saved_data = MgrSave::template resolve<std::uint32_t>( saved );
+    REQUIRE( saved_data != nullptr );
+    for ( std::uint32_t i = 0; i < 4; ++i )
+        saved_data[i] = 0x32500000U + i;
+
+    auto saved_offset = saved.offset();
+    REQUIRE( pmm::save_manager<MgrSave>( filename ) );
+
+    using address_traits             = typename MgrSave::address_traits;
+    const std::uint8_t* data         = MgrSave::backend().base_ptr();
+    const auto*         hdr          = pmm::detail::manager_header_at<address_traits>( data );
+    std::uint32_t       computed_crc = pmm::detail::compute_image_crc32<address_traits>( data, MgrSave::total_size() );
+    INFO( "canonical_crc=" << hdr->crc32 );
+    INFO( "computed_crc=" << computed_crc );
+    REQUIRE( hdr->crc32 == computed_crc );
+
+    MgrSave::destroy();
+    REQUIRE( MgrLoad::create( arena_size ) );
+
+    pmm::VerifyResult result;
+    bool              load_ok = pmm::load_manager_from_file<MgrLoad>( filename, result );
+    INFO( "last_error=" << static_cast<int>( MgrLoad::last_error() ) );
+    REQUIRE( load_ok );
+
+    typename MgrLoad::template pptr<std::uint32_t> loaded_ptr( saved_offset );
+    const std::uint32_t*                           loaded_data = MgrLoad::template resolve<std::uint32_t>( loaded_ptr );
+    REQUIRE( loaded_data != nullptr );
+    for ( std::uint32_t i = 0; i < 4; ++i )
+        REQUIRE( loaded_data[i] == 0x32500000U + i );
+}
+
+} // namespace
+
+TEST_CASE( "I325: DefaultAddressTraits manager image round-trips with CRC", "[issue325]" )
+{
+    using Save = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 32501>;
+    using Load = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 32502>;
+
+    require_roundtrip<Save, Load>( "test_issue325_default.dat", 64 * 1024 );
+}
+
+TEST_CASE( "I325: SmallAddressTraits manager image round-trips with CRC", "[issue325]" )
+{
+    static_assert( sizeof( pmm::Block<pmm::SmallAddressTraits> ) % pmm::SmallAddressTraits::granule_size != 0,
+                   "SmallAddressTraits must exercise a non-granule-aligned Block header" );
+
+    using Save = pmm::PersistMemoryManager<pmm::SmallEmbeddedStaticConfig<4096>, 32503>;
+    using Load = pmm::PersistMemoryManager<pmm::SmallEmbeddedStaticConfig<4096>, 32504>;
+
+    require_roundtrip<Save, Load>( "test_issue325_small.dat", 4096 );
+}

--- a/tests/test_issue43_phase2_persistence.cpp
+++ b/tests/test_issue43_phase2_persistence.cpp
@@ -71,8 +71,7 @@ TEST_CASE( "crc32_save_load_roundtrip", "[test_issue43_phase2_persistence]" )
     // Verify CRC32 was written to the header
     {
         std::uint8_t* base = M1::backend().base_ptr();
-        auto*         hdr  = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>(
-            base + sizeof( pmm::Block<pmm::DefaultAddressTraits> ) );
+        auto*         hdr  = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
         REQUIRE( hdr->crc32 != 0 );
     }
     M1::destroy();
@@ -145,7 +144,7 @@ TEST_CASE( "crc32_zero_rejected", "[test_issue43_phase2_persistence]" )
     {
         std::FILE* f = std::fopen( TEST_FILE, "r+b" );
         REQUIRE( f != nullptr );
-        constexpr std::size_t kHdrOffset = sizeof( pmm::Block<pmm::DefaultAddressTraits> );
+        constexpr std::size_t kHdrOffset = pmm::detail::manager_header_offset_bytes_v<pmm::DefaultAddressTraits>;
         constexpr std::size_t kCrcOffset =
             kHdrOffset + offsetof( pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>, crc32 );
         std::fseek( f, static_cast<long>( kCrcOffset ), SEEK_SET );
@@ -328,8 +327,7 @@ TEST_CASE( "image_crc32_ignores_crc_field", "[test_issue43_phase2_persistence]" 
     std::size_t   total = M::backend().total_size();
 
     // Compute CRC with crc32 field at 0
-    constexpr std::size_t kHdrOff = sizeof( pmm::Block<pmm::DefaultAddressTraits> );
-    auto* hdr           = reinterpret_cast<pmm::detail::ManagerHeader<pmm::DefaultAddressTraits>*>( base + kHdrOff );
+    auto* hdr           = pmm::detail::manager_header_at<pmm::DefaultAddressTraits>( base );
     hdr->crc32          = 0;
     std::uint32_t crc_a = pmm::detail::compute_image_crc32<pmm::DefaultAddressTraits>( base, total );
 


### PR DESCRIPTION
Fixes netkeep80/PersistMemoryManager#325

## Summary
- Added a single canonical `detail::manager_header_offset_bytes_v<AT>` and `detail::manager_header_at<AT>()` helper for locating `ManagerHeader`.
- Updated CRC, `save_manager()`, `load_manager_from_file()`, and manager layout accessors to use the same aligned offset.
- Replaced direct test-side `ManagerHeader` offset calculations with the shared helper.
- Regenerated `single_include/pmm/pmm.h` and `single_include/pmm/pmm_no_comments.h`.

## Reproduction
Before the fix, the new regression test failed for `SmallAddressTraits` because `save_manager()` wrote CRC through the raw `sizeof(Block<SmallAddressTraits>)` offset while the canonical aligned `ManagerHeader` still had `crc32 == 0`:

```text
I325: SmallAddressTraits manager image round-trips with CRC
REQUIRE( hdr->crc32 == computed_crc )
with expansion:
  0 == 996036030 (0x3b5e4dbe)
```

## Tests
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (89/89 passed)
- `ctest --test-dir build --output-on-failure -R 'test_issue325_manager_header_offset|test_issue146_sh_small_embedded_static|test_issue170_sh_no_comments'`
- `git diff --check`
- `clang-format --dry-run --Werror` on repo sources with `build/` and `single_include/` excluded, matching CI exclusions for generated headers
- file-size guard on repo sources with `build/` and `single_include/` excluded
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `GITHUB_BASE_REF=main bash scripts/check-changelog-fragment.sh`

Not run locally:
- `cppcheck` because it is not installed in this environment.
- `scripts/check-version-consistency.sh` is currently failing on existing release-owned drift (`README.md` badge 0.55.12 vs CMake/CHANGELOG 0.57.2); this PR does not touch release-owned version files, so that workflow path is skipped for this change.