### PR TITLE
Harden user pointer header reconstruction

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T09:06:34.742Z for PR creation at branch issue-326-8ccee339fb08 for issue https://github.com/netkeep80/PersistMemoryManager/issues/326

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T09:06:34.742Z for PR creation at branch issue-326-8ccee339fb08 for issue https://github.com/netkeep80/PersistMemoryManager/issues/326

--- a/changelog.d/20260420_093000_issue326_user_ptr_validation.md
+++ b/changelog.d/20260420_093000_issue326_user_ptr_validation.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- Hardened user-pointer to block-header reconstruction so forged aligned payload pointers are rejected before
+  mutation paths can treat them as allocated blocks.

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -575,12 +575,31 @@ template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
         return pptr<T>();
     std::uint8_t* base     = _backend.base_ptr();
     auto*         raw_byte = static_cast<std::uint8_t*>( raw );
-    if ( base == nullptr || raw_byte < base || raw_byte >= base + _backend.total_size() )
+    if ( base == nullptr )
         return pptr<T>();
-    pmm::Block<address_traits>* blk = find_block_from_user_ptr( raw );
-    if ( blk == nullptr )
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_byte );
+    if ( raw_addr < base_addr )
         return pptr<T>();
-    index_type blk_idx = detail::block_idx_t<address_traits>( base, blk );
+    const std::size_t raw_off = static_cast<std::size_t>( raw_addr - base_addr );
+    if ( raw_off < sizeof( Block<address_traits> ) || raw_off >= _backend.total_size() )
+        return pptr<T>();
+    const std::size_t blk_off = raw_off - sizeof( Block<address_traits> );
+    if ( blk_off % address_traits::granule_size != 0 )
+        return pptr<T>();
+    const std::size_t blk_idx_raw = blk_off / address_traits::granule_size;
+    if ( blk_idx_raw > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+        return pptr<T>();
+    index_type blk_idx = static_cast<index_type>( blk_idx_raw );
+    if ( !detail::validate_block_index<address_traits>( _backend.total_size(), blk_idx ) )
+        return pptr<T>();
+    const void* blk = detail::block_at<address_traits>( base, blk_idx );
+    if ( BlockStateBase<address_traits>::get_weight( blk ) == 0 ||
+         BlockStateBase<address_traits>::get_root_offset( blk ) != blk_idx )
+        return pptr<T>();
+    const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return pptr<T>();
     if ( blk_idx > std::numeric_limits<index_type>::max() - kBlockHdrGranules )
         return pptr<T>();
     return pptr<T>( static_cast<index_type>( blk_idx + kBlockHdrGranules ) );

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -507,6 +507,7 @@ static void for_each_free_block_inorder( const std::uint8_t* base, const detail:
 }
 
 /// @brief Find the mutable block header for a user-data pointer (or nullptr).
+/// @pre Caller holds the manager lock, or block links are otherwise stable for canonical raw-pointer validation.
 static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcept
 {
     std::uint8_t*                          base = _backend.base_ptr();
@@ -535,6 +536,7 @@ static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcep
 }
 
 /// @brief Find the const block header for a user-data pointer.
+/// @pre Caller holds the manager lock, or block links are otherwise stable for canonical raw-pointer validation.
 /// Returns nullptr if ptr is out of range or the block header is invalid.
 static const pmm::Block<address_traits>* find_block_from_user_ptr( const void* ptr ) noexcept
 {

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -515,15 +515,18 @@ static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcep
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             auto* raw = static_cast<std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<pmm::Block<address_traits>*>( cand );
             }
         }
@@ -541,15 +544,18 @@ static const pmm::Block<address_traits>* find_block_from_user_ptr( const void* p
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             const auto* raw = static_cast<const std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 const std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<const pmm::Block<address_traits>*>( cand );
             }
         }

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -436,6 +436,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      * @brief Освободить блок по указателю на пользовательские данные.
      *
      * @note Если блок заблокирован навечно (lock_block_permanent), освобождение не выполняется.
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds the manager lock so canonical
+     *       validation observes stable prev/next relationships.
      */
     static void deallocate( void* ptr ) noexcept
     {
@@ -451,6 +453,9 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      *
      * @param ptr Указатель на пользовательские данные (тот же, что возвращает allocate()).
      * @return true если блок успешно заблокирован, false если блок не найден или уже свободен.
+     *
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds the manager lock so canonical
+     *       validation observes stable prev/next relationships.
      */
     static bool lock_block_permanent( void* ptr ) noexcept
     {
@@ -463,6 +468,9 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      *
      * @param ptr Указатель на пользовательские данные.
      * @return true если блок заблокирован навечно (node_type == kNodeReadOnly).
+     *
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds a shared lock so no writer
+     *       mutates prev/next relationships during validation.
      */
     static bool is_permanently_locked( const void* ptr ) noexcept
     {
@@ -986,6 +994,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         return nullptr;
     }
 
+    /// @pre Caller must guarantee stable block links, normally by holding the manager lock.
     static void deallocate_unlocked( void* ptr ) noexcept
     {
         if ( !_initialized || ptr == nullptr )
@@ -1013,6 +1022,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         allocator::coalesce( base, hdr, blk_idx );
     }
 
+    /// @pre Caller must guarantee stable block links, normally by holding the manager lock.
     static bool lock_block_permanent_unlocked( void* ptr ) noexcept
     {
         if ( !_initialized || ptr == nullptr )

--- a/include/pmm/typed_manager_api.h
+++ b/include/pmm/typed_manager_api.h
@@ -238,23 +238,33 @@ template <typename ManagerT> class PersistMemoryTypedApi
     template <typename T> static T* resolve_checked( pmm::pptr<T, ManagerT> p ) noexcept
     {
         using address_traits = typename ManagerT::address_traits;
+        using index_type     = typename ManagerT::index_type;
 
-        T*          raw      = resolve_unchecked<T>( p );
-        const void* user_raw = raw;
-        if ( user_raw == nullptr )
+        if ( p.is_null() || !ManagerT::_initialized )
             return nullptr;
-        const void* blk_raw = ManagerT::find_block_from_user_ptr( user_raw );
+
+        const void* blk_raw = ManagerT::template block_raw_ptr_from_pptr<T>( p );
         if ( blk_raw == nullptr )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        index_type blk_idx = ManagerT::template block_idx_from_pptr<T>( p );
         if ( BlockStateBase<address_traits>::get_weight( blk_raw ) == 0 ||
-             BlockStateBase<address_traits>::get_root_offset( blk_raw ) == 0 )
+             BlockStateBase<address_traits>::get_root_offset( blk_raw ) != blk_idx )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk_raw );
+        if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        {
+            ManagerT::_last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
+        T* raw = resolve_unchecked<T>( p );
+        if ( raw == nullptr )
+            return nullptr;
         ManagerT::_last_error = PmmError::Ok;
         return raw;
     }

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -494,22 +494,116 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
+template <typename AddressTraitsT>
+inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
+                                                 const std::uint8_t* cand_addr ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || cand_addr == nullptr )
+        return false;
+
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t cand_raw  = reinterpret_cast<std::uintptr_t>( cand_addr );
+    if ( cand_raw < base_addr )
+        return false;
+
+    const std::size_t cand_off = static_cast<std::size_t>( cand_raw - base_addr );
+    if ( cand_off % AddressTraitsT::granule_size != 0 )
+        return false;
+    if ( cand_off / AddressTraitsT::granule_size > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return false;
+
+    const IndexT cand_idx = static_cast<IndexT>( cand_off / AddressTraitsT::granule_size );
+    if ( !validate_block_index<AddressTraitsT>( total_size, cand_idx ) )
+        return false;
+
+    const IndexT weight = BlockState::get_weight( cand_addr );
+    if ( weight == 0 || BlockState::get_root_offset( cand_addr ) != cand_idx )
+        return false;
+
+    const std::uint16_t node_type = BlockState::get_node_type( cand_addr );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return false;
+
+    const IndexT prev = BlockState::get_prev_offset( cand_addr );
+    const IndexT next = BlockState::get_next_offset( cand_addr );
+    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
+         !validate_link_index<AddressTraitsT>( total_size, next ) )
+        return false;
+
+    if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
+        return false;
+
+    const auto* hdr = manager_header_at<AddressTraitsT>( base );
+    if ( hdr->total_size != total_size )
+        return false;
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( hdr->first_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( hdr->last_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
+            return false;
+    }
+
+    constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
+    if ( cand_off > total_size - kBlockSize )
+        return false;
+    const std::size_t data_start = cand_off + kBlockSize;
+    if ( static_cast<std::size_t>( weight ) >
+         ( std::numeric_limits<std::size_t>::max )() / AddressTraitsT::granule_size )
+        return false;
+    const std::size_t data_bytes = static_cast<std::size_t>( weight ) * AddressTraitsT::granule_size;
+    if ( data_bytes > total_size - data_start )
+        return false;
+
+    return true;
+}
+
+template <typename AddressTraitsT>
+inline bool is_canonical_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr ) noexcept
+{
+    constexpr std::size_t kBlockSize      = sizeof( pmm::Block<AddressTraitsT> );
+    const std::size_t     min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+        return false;
+
+    const auto* raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const auto* cand_addr = raw_ptr - kBlockSize;
+    if ( cand_addr + kBlockSize != raw_ptr )
+        return false;
+
+    return is_canonical_allocated_block_header<AddressTraitsT>( base, total_size, cand_addr );
+}
+
 /// @brief O(1) get Block<AddressTraitsT> from user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
 /// Block<AddressTraitsT> is the sole block type.
 /// Unified templated helper replaces the former DefaultAddressTraits-specific overload.
 template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
-    using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+    if ( !is_canonical_user_ptr<AddressTraitsT>( base, total_size, ptr ) )
         return nullptr;
-
     std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
-    if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }
 

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -494,9 +494,61 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
-// This helper runs on public pointer conversion paths that may not hold the
-// manager write lock, so keep validation to stable manager state and the
-// candidate header itself.
+// Canonical public-pointer reconstruction is a manager-structure check, not a
+// payload-byte self-consistency check. Callers in multi-threaded managers must
+// ensure the block links are stable while this runs.
+template <typename AddressTraitsT>
+inline bool is_block_header_linked_in_canonical_chain( const std::uint8_t*                  base,
+                                                       const ManagerHeader<AddressTraitsT>* hdr, std::size_t total_size,
+                                                       typename AddressTraitsT::index_type cand_idx ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || hdr == nullptr )
+        return false;
+    if ( hdr->block_count == 0 || hdr->first_block_offset == AddressTraitsT::no_block )
+        return false;
+
+    if ( !validate_block_index<AddressTraitsT>( total_size, hdr->first_block_offset ) ||
+         !validate_block_index<AddressTraitsT>( total_size, hdr->last_block_offset ) )
+        return false;
+
+    const void*  cand = base + static_cast<std::size_t>( cand_idx ) * AddressTraitsT::granule_size;
+    const IndexT prev = BlockState::get_prev_offset( cand );
+    const IndexT next = BlockState::get_next_offset( cand );
+
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->first_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, prev ) || prev >= cand_idx )
+            return false;
+        const void* prev_block = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_block ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->last_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, next ) || next <= cand_idx )
+            return false;
+        const void* next_block = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_block ) != cand_idx )
+            return false;
+    }
+
+    return true;
+}
+
 template <typename AddressTraitsT>
 inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
                                                  const std::uint8_t* cand_addr ) noexcept
@@ -535,6 +587,8 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
+        return false;
+    if ( !is_block_header_linked_in_canonical_chain<AddressTraitsT>( base, hdr, total_size, cand_idx ) )
         return false;
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -494,6 +494,9 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
+// This helper runs on public pointer conversion paths that may not hold the
+// manager write lock, so keep validation to stable manager state and the
+// candidate header itself.
 template <typename AddressTraitsT>
 inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
                                                  const std::uint8_t* cand_addr ) noexcept
@@ -527,41 +530,12 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
     if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
         return false;
 
-    const IndexT prev = BlockState::get_prev_offset( cand_addr );
-    const IndexT next = BlockState::get_next_offset( cand_addr );
-    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
-         !validate_link_index<AddressTraitsT>( total_size, next ) )
-        return false;
-
     if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
         return false;
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
         return false;
-    if ( prev == AddressTraitsT::no_block )
-    {
-        if ( hdr->first_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
-            return false;
-    }
-
-    if ( next == AddressTraitsT::no_block )
-    {
-        if ( hdr->last_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
-            return false;
-    }
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
     if ( cand_off > total_size - kBlockSize )

--- a/include/pmm/types.h
+++ b/include/pmm/types.h
@@ -495,8 +495,9 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
 }
 
 // Canonical public-pointer reconstruction is a manager-structure check, not a
-// payload-byte self-consistency check. Callers in multi-threaded managers must
-// ensure the block links are stable while this runs.
+// payload-byte self-consistency check. This reads first/last anchors plus
+// prev/next neighbor back-links without internal locking; callers must hold the
+// manager lock or otherwise guarantee that block links are stable while this runs.
 template <typename AddressTraitsT>
 inline bool is_block_header_linked_in_canonical_chain( const std::uint8_t*                  base,
                                                        const ManagerHeader<AddressTraitsT>* hdr, std::size_t total_size,
@@ -621,7 +622,8 @@ inline bool is_canonical_user_ptr( const std::uint8_t* base, std::size_t total_s
     return is_canonical_allocated_block_header<AddressTraitsT>( base, total_size, cand_addr );
 }
 
-/// @brief O(1) get Block<AddressTraitsT> from user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
+/// @brief O(1) get Block<AddressTraitsT> from canonical user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
+/// @pre Caller holds the manager lock, or block links are otherwise stable for the canonical-chain proof.
 /// Block<AddressTraitsT> is the sole block type.
 /// Unified templated helper replaces the former DefaultAddressTraits-specific overload.
 template <typename AddressTraitsT>

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2527,22 +2527,116 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
+template <typename AddressTraitsT>
+inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
+                                                 const std::uint8_t* cand_addr ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || cand_addr == nullptr )
+        return false;
+
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t cand_raw  = reinterpret_cast<std::uintptr_t>( cand_addr );
+    if ( cand_raw < base_addr )
+        return false;
+
+    const std::size_t cand_off = static_cast<std::size_t>( cand_raw - base_addr );
+    if ( cand_off % AddressTraitsT::granule_size != 0 )
+        return false;
+    if ( cand_off / AddressTraitsT::granule_size > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return false;
+
+    const IndexT cand_idx = static_cast<IndexT>( cand_off / AddressTraitsT::granule_size );
+    if ( !validate_block_index<AddressTraitsT>( total_size, cand_idx ) )
+        return false;
+
+    const IndexT weight = BlockState::get_weight( cand_addr );
+    if ( weight == 0 || BlockState::get_root_offset( cand_addr ) != cand_idx )
+        return false;
+
+    const std::uint16_t node_type = BlockState::get_node_type( cand_addr );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return false;
+
+    const IndexT prev = BlockState::get_prev_offset( cand_addr );
+    const IndexT next = BlockState::get_next_offset( cand_addr );
+    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
+         !validate_link_index<AddressTraitsT>( total_size, next ) )
+        return false;
+
+    if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
+        return false;
+
+    const auto* hdr = manager_header_at<AddressTraitsT>( base );
+    if ( hdr->total_size != total_size )
+        return false;
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( hdr->first_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( hdr->last_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
+            return false;
+    }
+
+    constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
+    if ( cand_off > total_size - kBlockSize )
+        return false;
+    const std::size_t data_start = cand_off + kBlockSize;
+    if ( static_cast<std::size_t>( weight ) >
+         ( std::numeric_limits<std::size_t>::max )() / AddressTraitsT::granule_size )
+        return false;
+    const std::size_t data_bytes = static_cast<std::size_t>( weight ) * AddressTraitsT::granule_size;
+    if ( data_bytes > total_size - data_start )
+        return false;
+
+    return true;
+}
+
+template <typename AddressTraitsT>
+inline bool is_canonical_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr ) noexcept
+{
+    constexpr std::size_t kBlockSize      = sizeof( pmm::Block<AddressTraitsT> );
+    const std::size_t     min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+        return false;
+
+    const auto* raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const auto* cand_addr = raw_ptr - kBlockSize;
+    if ( cand_addr + kBlockSize != raw_ptr )
+        return false;
+
+    return is_canonical_allocated_block_header<AddressTraitsT>( base, total_size, cand_addr );
+}
+
 /// @brief O(1) get Block<AddressTraitsT> from user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
 /// Block<AddressTraitsT> is the sole block type.
 /// Unified templated helper replaces the former DefaultAddressTraits-specific overload.
 template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
-    using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+    if ( !is_canonical_user_ptr<AddressTraitsT>( base, total_size, ptr ) )
         return nullptr;
-
     std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
-    if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }
 
@@ -9275,15 +9369,18 @@ static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcep
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             auto* raw = static_cast<std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<pmm::Block<address_traits>*>( cand );
             }
         }
@@ -9301,15 +9398,18 @@ static const pmm::Block<address_traits>* find_block_from_user_ptr( const void* p
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             const auto* raw = static_cast<const std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 const std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<const pmm::Block<address_traits>*>( cand );
             }
         }

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2528,8 +2528,9 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
 }
 
 // Canonical public-pointer reconstruction is a manager-structure check, not a
-// payload-byte self-consistency check. Callers in multi-threaded managers must
-// ensure the block links are stable while this runs.
+// payload-byte self-consistency check. This reads first/last anchors plus
+// prev/next neighbor back-links without internal locking; callers must hold the
+// manager lock or otherwise guarantee that block links are stable while this runs.
 template <typename AddressTraitsT>
 inline bool is_block_header_linked_in_canonical_chain( const std::uint8_t*                  base,
                                                        const ManagerHeader<AddressTraitsT>* hdr, std::size_t total_size,
@@ -2654,7 +2655,8 @@ inline bool is_canonical_user_ptr( const std::uint8_t* base, std::size_t total_s
     return is_canonical_allocated_block_header<AddressTraitsT>( base, total_size, cand_addr );
 }
 
-/// @brief O(1) get Block<AddressTraitsT> from user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
+/// @brief O(1) get Block<AddressTraitsT> from canonical user_ptr (ptr - sizeof(Block<AddressTraitsT>)).
+/// @pre Caller holds the manager lock, or block links are otherwise stable for the canonical-chain proof.
 /// Block<AddressTraitsT> is the sole block type.
 /// Unified templated helper replaces the former DefaultAddressTraits-specific overload.
 template <typename AddressTraitsT>
@@ -8279,6 +8281,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      * @brief Освободить блок по указателю на пользовательские данные.
      *
      * @note Если блок заблокирован навечно (lock_block_permanent), освобождение не выполняется.
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds the manager lock so canonical
+     *       validation observes stable prev/next relationships.
      */
     static void deallocate( void* ptr ) noexcept
     {
@@ -8294,6 +8298,9 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      *
      * @param ptr Указатель на пользовательские данные (тот же, что возвращает allocate()).
      * @return true если блок успешно заблокирован, false если блок не найден или уже свободен.
+     *
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds the manager lock so canonical
+     *       validation observes stable prev/next relationships.
      */
     static bool lock_block_permanent( void* ptr ) noexcept
     {
@@ -8306,6 +8313,9 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
      *
      * @param ptr Указатель на пользовательские данные.
      * @return true если блок заблокирован навечно (node_type == kNodeReadOnly).
+     *
+     * @note Raw-pointer reconstruction checks block-chain links; this entry point holds a shared lock so no writer
+     *       mutates prev/next relationships during validation.
      */
     static bool is_permanently_locked( const void* ptr ) noexcept
     {
@@ -8829,6 +8839,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         return nullptr;
     }
 
+    /// @pre Caller must guarantee stable block links, normally by holding the manager lock.
     static void deallocate_unlocked( void* ptr ) noexcept
     {
         if ( !_initialized || ptr == nullptr )
@@ -8856,6 +8867,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         allocator::coalesce( base, hdr, blk_idx );
     }
 
+    /// @pre Caller must guarantee stable block links, normally by holding the manager lock.
     static bool lock_block_permanent_unlocked( void* ptr ) noexcept
     {
         if ( !_initialized || ptr == nullptr )
@@ -9399,6 +9411,7 @@ static void for_each_free_block_inorder( const std::uint8_t* base, const detail:
 }
 
 /// @brief Find the mutable block header for a user-data pointer (or nullptr).
+/// @pre Caller holds the manager lock, or block links are otherwise stable for canonical raw-pointer validation.
 static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcept
 {
     std::uint8_t*                          base = _backend.base_ptr();
@@ -9427,6 +9440,7 @@ static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcep
 }
 
 /// @brief Find the const block header for a user-data pointer.
+/// @pre Caller holds the manager lock, or block links are otherwise stable for canonical raw-pointer validation.
 /// Returns nullptr if ptr is out of range or the block header is invalid.
 static const pmm::Block<address_traits>* find_block_from_user_ptr( const void* ptr ) noexcept
 {

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2527,9 +2527,61 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
-// This helper runs on public pointer conversion paths that may not hold the
-// manager write lock, so keep validation to stable manager state and the
-// candidate header itself.
+// Canonical public-pointer reconstruction is a manager-structure check, not a
+// payload-byte self-consistency check. Callers in multi-threaded managers must
+// ensure the block links are stable while this runs.
+template <typename AddressTraitsT>
+inline bool is_block_header_linked_in_canonical_chain( const std::uint8_t*                  base,
+                                                       const ManagerHeader<AddressTraitsT>* hdr, std::size_t total_size,
+                                                       typename AddressTraitsT::index_type cand_idx ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || hdr == nullptr )
+        return false;
+    if ( hdr->block_count == 0 || hdr->first_block_offset == AddressTraitsT::no_block )
+        return false;
+
+    if ( !validate_block_index<AddressTraitsT>( total_size, hdr->first_block_offset ) ||
+         !validate_block_index<AddressTraitsT>( total_size, hdr->last_block_offset ) )
+        return false;
+
+    const void*  cand = base + static_cast<std::size_t>( cand_idx ) * AddressTraitsT::granule_size;
+    const IndexT prev = BlockState::get_prev_offset( cand );
+    const IndexT next = BlockState::get_next_offset( cand );
+
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->first_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, prev ) || prev >= cand_idx )
+            return false;
+        const void* prev_block = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_block ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->last_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, next ) || next <= cand_idx )
+            return false;
+        const void* next_block = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_block ) != cand_idx )
+            return false;
+    }
+
+    return true;
+}
+
 template <typename AddressTraitsT>
 inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
                                                  const std::uint8_t* cand_addr ) noexcept
@@ -2568,6 +2620,8 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
+        return false;
+    if ( !is_block_header_linked_in_canonical_chain<AddressTraitsT>( base, hdr, total_size, cand_idx ) )
         return false;
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
@@ -7757,23 +7811,33 @@ template <typename ManagerT> class PersistMemoryTypedApi
     template <typename T> static T* resolve_checked( pmm::pptr<T, ManagerT> p ) noexcept
     {
         using address_traits = typename ManagerT::address_traits;
+        using index_type     = typename ManagerT::index_type;
 
-        T*          raw      = resolve_unchecked<T>( p );
-        const void* user_raw = raw;
-        if ( user_raw == nullptr )
+        if ( p.is_null() || !ManagerT::_initialized )
             return nullptr;
-        const void* blk_raw = ManagerT::find_block_from_user_ptr( user_raw );
+
+        const void* blk_raw = ManagerT::template block_raw_ptr_from_pptr<T>( p );
         if ( blk_raw == nullptr )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        index_type blk_idx = ManagerT::template block_idx_from_pptr<T>( p );
         if ( BlockStateBase<address_traits>::get_weight( blk_raw ) == 0 ||
-             BlockStateBase<address_traits>::get_root_offset( blk_raw ) == 0 )
+             BlockStateBase<address_traits>::get_root_offset( blk_raw ) != blk_idx )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk_raw );
+        if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        {
+            ManagerT::_last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
+        T* raw = resolve_unchecked<T>( p );
+        if ( raw == nullptr )
+            return nullptr;
         ManagerT::_last_error = PmmError::Ok;
         return raw;
     }
@@ -9403,12 +9467,31 @@ template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
         return pptr<T>();
     std::uint8_t* base     = _backend.base_ptr();
     auto*         raw_byte = static_cast<std::uint8_t*>( raw );
-    if ( base == nullptr || raw_byte < base || raw_byte >= base + _backend.total_size() )
+    if ( base == nullptr )
         return pptr<T>();
-    pmm::Block<address_traits>* blk = find_block_from_user_ptr( raw );
-    if ( blk == nullptr )
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_byte );
+    if ( raw_addr < base_addr )
         return pptr<T>();
-    index_type blk_idx = detail::block_idx_t<address_traits>( base, blk );
+    const std::size_t raw_off = static_cast<std::size_t>( raw_addr - base_addr );
+    if ( raw_off < sizeof( Block<address_traits> ) || raw_off >= _backend.total_size() )
+        return pptr<T>();
+    const std::size_t blk_off = raw_off - sizeof( Block<address_traits> );
+    if ( blk_off % address_traits::granule_size != 0 )
+        return pptr<T>();
+    const std::size_t blk_idx_raw = blk_off / address_traits::granule_size;
+    if ( blk_idx_raw > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+        return pptr<T>();
+    index_type blk_idx = static_cast<index_type>( blk_idx_raw );
+    if ( !detail::validate_block_index<address_traits>( _backend.total_size(), blk_idx ) )
+        return pptr<T>();
+    const void* blk = detail::block_at<address_traits>( base, blk_idx );
+    if ( BlockStateBase<address_traits>::get_weight( blk ) == 0 ||
+         BlockStateBase<address_traits>::get_root_offset( blk ) != blk_idx )
+        return pptr<T>();
+    const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return pptr<T>();
     if ( blk_idx > std::numeric_limits<index_type>::max() - kBlockHdrGranules )
         return pptr<T>();
     return pptr<T>( static_cast<index_type>( blk_idx + kBlockHdrGranules ) );

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -2527,6 +2527,9 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
     return reinterpret_cast<std::uint8_t*>( block ) + sizeof( pmm::Block<AddressTraitsT> );
 }
 
+// This helper runs on public pointer conversion paths that may not hold the
+// manager write lock, so keep validation to stable manager state and the
+// candidate header itself.
 template <typename AddressTraitsT>
 inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
                                                  const std::uint8_t* cand_addr ) noexcept
@@ -2560,41 +2563,12 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
     if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
         return false;
 
-    const IndexT prev = BlockState::get_prev_offset( cand_addr );
-    const IndexT next = BlockState::get_next_offset( cand_addr );
-    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
-         !validate_link_index<AddressTraitsT>( total_size, next ) )
-        return false;
-
     if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
         return false;
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
         return false;
-    if ( prev == AddressTraitsT::no_block )
-    {
-        if ( hdr->first_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
-            return false;
-    }
-
-    if ( next == AddressTraitsT::no_block )
-    {
-        if ( hdr->last_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
-            return false;
-    }
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
     if ( cand_off > total_size - kBlockSize )

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1451,18 +1451,112 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
 }
 
 template <typename AddressTraitsT>
+inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
+                                                 const std::uint8_t* cand_addr ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || cand_addr == nullptr )
+        return false;
+
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t cand_raw  = reinterpret_cast<std::uintptr_t>( cand_addr );
+    if ( cand_raw < base_addr )
+        return false;
+
+    const std::size_t cand_off = static_cast<std::size_t>( cand_raw - base_addr );
+    if ( cand_off % AddressTraitsT::granule_size != 0 )
+        return false;
+    if ( cand_off / AddressTraitsT::granule_size > static_cast<std::size_t>( std::numeric_limits<IndexT>::max() ) )
+        return false;
+
+    const IndexT cand_idx = static_cast<IndexT>( cand_off / AddressTraitsT::granule_size );
+    if ( !validate_block_index<AddressTraitsT>( total_size, cand_idx ) )
+        return false;
+
+    const IndexT weight = BlockState::get_weight( cand_addr );
+    if ( weight == 0 || BlockState::get_root_offset( cand_addr ) != cand_idx )
+        return false;
+
+    const std::uint16_t node_type = BlockState::get_node_type( cand_addr );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return false;
+
+    const IndexT prev = BlockState::get_prev_offset( cand_addr );
+    const IndexT next = BlockState::get_next_offset( cand_addr );
+    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
+         !validate_link_index<AddressTraitsT>( total_size, next ) )
+        return false;
+
+    if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
+        return false;
+
+    const auto* hdr = manager_header_at<AddressTraitsT>( base );
+    if ( hdr->total_size != total_size )
+        return false;
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( hdr->first_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( hdr->last_block_offset != cand_idx )
+            return false;
+    }
+    else
+    {
+        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
+            return false;
+    }
+
+    constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
+    if ( cand_off > total_size - kBlockSize )
+        return false;
+    const std::size_t data_start = cand_off + kBlockSize;
+    if ( static_cast<std::size_t>( weight ) >
+         ( std::numeric_limits<std::size_t>::max )() / AddressTraitsT::granule_size )
+        return false;
+    const std::size_t data_bytes = static_cast<std::size_t>( weight ) * AddressTraitsT::granule_size;
+    if ( data_bytes > total_size - data_start )
+        return false;
+
+    return true;
+}
+
+template <typename AddressTraitsT>
+inline bool is_canonical_user_ptr( const std::uint8_t* base, std::size_t total_size, const void* ptr ) noexcept
+{
+    constexpr std::size_t kBlockSize      = sizeof( pmm::Block<AddressTraitsT> );
+    const std::size_t     min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
+    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+        return false;
+
+    const auto* raw_ptr   = static_cast<const std::uint8_t*>( ptr );
+    const auto* cand_addr = raw_ptr - kBlockSize;
+    if ( cand_addr + kBlockSize != raw_ptr )
+        return false;
+
+    return is_canonical_allocated_block_header<AddressTraitsT>( base, total_size, cand_addr );
+}
+
+template <typename AddressTraitsT>
 inline pmm::Block<AddressTraitsT>* header_from_ptr_t( std::uint8_t* base, void* ptr, std::size_t total_size )
 {
-    using BlockState                        = pmm::BlockStateBase<AddressTraitsT>;
     static constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
 
-    const std::size_t min_user_offset = kBlockSize + sizeof( ManagerHeader<AddressTraitsT> ) + kBlockSize;
-    if ( !validate_user_ptr<AddressTraitsT>( base, total_size, ptr, min_user_offset ) )
+    if ( !is_canonical_user_ptr<AddressTraitsT>( base, total_size, ptr ) )
         return nullptr;
-
     std::uint8_t* cand_addr = static_cast<std::uint8_t*>( ptr ) - kBlockSize;
-    if ( BlockState::get_weight( cand_addr ) == 0 )
-        return nullptr;
     return reinterpret_cast<pmm::Block<AddressTraitsT>*>( cand_addr );
 }
 
@@ -5976,15 +6070,18 @@ static pmm::Block<address_traits>* find_block_from_user_ptr( void* ptr ) noexcep
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             auto* raw = static_cast<std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<pmm::Block<address_traits>*>( cand );
             }
         }
@@ -6000,15 +6097,18 @@ static const pmm::Block<address_traits>* find_block_from_user_ptr( const void* p
     {
         constexpr std::size_t rounded_header_size =
             static_cast<std::size_t>( kBlockHdrGranules ) * address_traits::granule_size;
+        constexpr std::size_t min_public_user_offset =
+            static_cast<std::size_t>( kFreeBlkIdxLayout + kBlockHdrGranules ) * address_traits::granule_size;
         if ( ptr != nullptr && base != nullptr )
         {
             const auto* raw = static_cast<const std::uint8_t*>( ptr );
-            if ( raw >= base + rounded_header_size && raw < base + static_cast<std::size_t>( hdr->total_size ) )
+            if ( raw >= base + min_public_user_offset && raw < base + static_cast<std::size_t>( hdr->total_size ) )
             {
                 const std::uint8_t* cand = raw - rounded_header_size;
                 if ( ( static_cast<std::size_t>( cand - base ) % address_traits::granule_size ) == 0 &&
                      cand + sizeof( Block<address_traits> ) <= base + static_cast<std::size_t>( hdr->total_size ) &&
-                     BlockStateBase<address_traits>::get_weight( cand ) != 0 )
+                     detail::is_canonical_allocated_block_header<address_traits>(
+                         base, static_cast<std::size_t>( hdr->total_size ), cand ) )
                     return reinterpret_cast<const pmm::Block<address_traits>*>( cand );
             }
         }

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1483,41 +1483,12 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
     if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
         return false;
 
-    const IndexT prev = BlockState::get_prev_offset( cand_addr );
-    const IndexT next = BlockState::get_next_offset( cand_addr );
-    if ( !validate_link_index<AddressTraitsT>( total_size, prev ) ||
-         !validate_link_index<AddressTraitsT>( total_size, next ) )
-        return false;
-
     if ( total_size < manager_header_offset_bytes_v<AddressTraitsT> + sizeof( ManagerHeader<AddressTraitsT> ) )
         return false;
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
         return false;
-    if ( prev == AddressTraitsT::no_block )
-    {
-        if ( hdr->first_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* prev_addr = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_next_offset( prev_addr ) != cand_idx )
-            return false;
-    }
-
-    if ( next == AddressTraitsT::no_block )
-    {
-        if ( hdr->last_block_offset != cand_idx )
-            return false;
-    }
-    else
-    {
-        const auto* next_addr = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
-        if ( BlockState::get_prev_offset( next_addr ) != cand_idx )
-            return false;
-    }
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
     if ( cand_off > total_size - kBlockSize )

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -1451,6 +1451,58 @@ inline void* user_ptr( pmm::Block<AddressTraitsT>* block )
 }
 
 template <typename AddressTraitsT>
+inline bool is_block_header_linked_in_canonical_chain( const std::uint8_t*                  base,
+                                                       const ManagerHeader<AddressTraitsT>* hdr, std::size_t total_size,
+                                                       typename AddressTraitsT::index_type cand_idx ) noexcept
+{
+    using BlockState = pmm::BlockStateBase<AddressTraitsT>;
+    using IndexT     = typename AddressTraitsT::index_type;
+
+    if ( base == nullptr || hdr == nullptr )
+        return false;
+    if ( hdr->block_count == 0 || hdr->first_block_offset == AddressTraitsT::no_block )
+        return false;
+
+    if ( !validate_block_index<AddressTraitsT>( total_size, hdr->first_block_offset ) ||
+         !validate_block_index<AddressTraitsT>( total_size, hdr->last_block_offset ) )
+        return false;
+
+    const void*  cand = base + static_cast<std::size_t>( cand_idx ) * AddressTraitsT::granule_size;
+    const IndexT prev = BlockState::get_prev_offset( cand );
+    const IndexT next = BlockState::get_next_offset( cand );
+
+    if ( prev == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->first_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, prev ) || prev >= cand_idx )
+            return false;
+        const void* prev_block = base + static_cast<std::size_t>( prev ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_next_offset( prev_block ) != cand_idx )
+            return false;
+    }
+
+    if ( next == AddressTraitsT::no_block )
+    {
+        if ( cand_idx != hdr->last_block_offset )
+            return false;
+    }
+    else
+    {
+        if ( !validate_block_index<AddressTraitsT>( total_size, next ) || next <= cand_idx )
+            return false;
+        const void* next_block = base + static_cast<std::size_t>( next ) * AddressTraitsT::granule_size;
+        if ( BlockState::get_prev_offset( next_block ) != cand_idx )
+            return false;
+    }
+
+    return true;
+}
+
+template <typename AddressTraitsT>
 inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::size_t total_size,
                                                  const std::uint8_t* cand_addr ) noexcept
 {
@@ -1488,6 +1540,8 @@ inline bool is_canonical_allocated_block_header( const std::uint8_t* base, std::
 
     const auto* hdr = manager_header_at<AddressTraitsT>( base );
     if ( hdr->total_size != total_size )
+        return false;
+    if ( !is_block_header_linked_in_canonical_chain<AddressTraitsT>( base, hdr, total_size, cand_idx ) )
         return false;
 
     constexpr std::size_t kBlockSize = sizeof( pmm::Block<AddressTraitsT> );
@@ -4755,23 +4809,33 @@ template <typename ManagerT> class PersistMemoryTypedApi
     template <typename T> static T* resolve_checked( pmm::pptr<T, ManagerT> p ) noexcept
     {
         using address_traits = typename ManagerT::address_traits;
+        using index_type     = typename ManagerT::index_type;
 
-        T*          raw      = resolve_unchecked<T>( p );
-        const void* user_raw = raw;
-        if ( user_raw == nullptr )
+        if ( p.is_null() || !ManagerT::_initialized )
             return nullptr;
-        const void* blk_raw = ManagerT::find_block_from_user_ptr( user_raw );
+
+        const void* blk_raw = ManagerT::template block_raw_ptr_from_pptr<T>( p );
         if ( blk_raw == nullptr )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        index_type blk_idx = ManagerT::template block_idx_from_pptr<T>( p );
         if ( BlockStateBase<address_traits>::get_weight( blk_raw ) == 0 ||
-             BlockStateBase<address_traits>::get_root_offset( blk_raw ) == 0 )
+             BlockStateBase<address_traits>::get_root_offset( blk_raw ) != blk_idx )
         {
             ManagerT::_last_error = PmmError::InvalidPointer;
             return nullptr;
         }
+        const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk_raw );
+        if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        {
+            ManagerT::_last_error = PmmError::InvalidPointer;
+            return nullptr;
+        }
+        T* raw = resolve_unchecked<T>( p );
+        if ( raw == nullptr )
+            return nullptr;
         ManagerT::_last_error = PmmError::Ok;
         return raw;
     }
@@ -6094,12 +6158,31 @@ template <typename T> static pptr<T> make_pptr_from_raw( void* raw ) noexcept
         return pptr<T>();
     std::uint8_t* base     = _backend.base_ptr();
     auto*         raw_byte = static_cast<std::uint8_t*>( raw );
-    if ( base == nullptr || raw_byte < base || raw_byte >= base + _backend.total_size() )
+    if ( base == nullptr )
         return pptr<T>();
-    pmm::Block<address_traits>* blk = find_block_from_user_ptr( raw );
-    if ( blk == nullptr )
+    const std::uintptr_t base_addr = reinterpret_cast<std::uintptr_t>( base );
+    const std::uintptr_t raw_addr  = reinterpret_cast<std::uintptr_t>( raw_byte );
+    if ( raw_addr < base_addr )
         return pptr<T>();
-    index_type blk_idx = detail::block_idx_t<address_traits>( base, blk );
+    const std::size_t raw_off = static_cast<std::size_t>( raw_addr - base_addr );
+    if ( raw_off < sizeof( Block<address_traits> ) || raw_off >= _backend.total_size() )
+        return pptr<T>();
+    const std::size_t blk_off = raw_off - sizeof( Block<address_traits> );
+    if ( blk_off % address_traits::granule_size != 0 )
+        return pptr<T>();
+    const std::size_t blk_idx_raw = blk_off / address_traits::granule_size;
+    if ( blk_idx_raw > static_cast<std::size_t>( std::numeric_limits<index_type>::max() ) )
+        return pptr<T>();
+    index_type blk_idx = static_cast<index_type>( blk_idx_raw );
+    if ( !detail::validate_block_index<address_traits>( _backend.total_size(), blk_idx ) )
+        return pptr<T>();
+    const void* blk = detail::block_at<address_traits>( base, blk_idx );
+    if ( BlockStateBase<address_traits>::get_weight( blk ) == 0 ||
+         BlockStateBase<address_traits>::get_root_offset( blk ) != blk_idx )
+        return pptr<T>();
+    const std::uint16_t node_type = BlockStateBase<address_traits>::get_node_type( blk );
+    if ( node_type != pmm::kNodeReadWrite && node_type != pmm::kNodeReadOnly )
+        return pptr<T>();
     if ( blk_idx > std::numeric_limits<index_type>::max() - kBlockHdrGranules )
         return pptr<T>();
     return pptr<T>( static_cast<index_type>( blk_idx + kBlockHdrGranules ) );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -306,6 +306,9 @@ target_compile_definitions(test_issue318_manager_header_compaction PRIVATE PMM_S
 # ─── Issue 325: manager-header offset consistency for CRC/save/load ─
 pmm_add_test(test_issue325_manager_header_offset test_issue325_manager_header_offset.cpp)
 
+# ─── Issue 326: forged user-pointer reconstruction guard ───────────
+pmm_add_test(test_issue326_user_ptr_validation test_issue326_user_ptr_validation.cpp)
+
 # ─── Issue 314: build graph compaction contract ─────────────────
 add_test(
     NAME test_issue314_build_graph_contract

--- a/tests/test_issue326_user_ptr_validation.cpp
+++ b/tests/test_issue326_user_ptr_validation.cpp
@@ -33,6 +33,12 @@ void write_fake_allocated_header( void* raw )
     BlockState::set_next_offset_of( raw, AT::no_block );
     BlockState::set_node_type_of( raw, pmm::kNodeReadWrite );
 }
+
+void write_self_consistent_fake_allocated_header( std::uint8_t* base, void* raw )
+{
+    write_fake_allocated_header( raw );
+    BlockState::set_root_offset_of( raw, pmm::detail::ptr_to_granule_idx<AT>( base, raw ) );
+}
 } // namespace
 
 TEST_CASE( "I326: header_from_ptr_t rejects forged aligned payload pointer", "[issue326][validation]" )
@@ -59,6 +65,30 @@ TEST_CASE( "I326: header_from_ptr_t rejects forged aligned payload pointer", "[i
     Mgr::destroy();
 }
 
+TEST_CASE( "I326: header_from_ptr_t rejects self-consistent forged payload header", "[issue326][validation]" )
+{
+    reset_manager();
+
+    auto p = Mgr::allocate_typed<std::uint32_t>( 32 );
+    REQUIRE( !p.is_null() );
+
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+    auto*         payload    = reinterpret_cast<std::uint8_t*>( Mgr::resolve( p ) );
+    REQUIRE( payload != nullptr );
+
+    auto* real_block = pmm::detail::header_from_ptr_t<AT>( base, payload, total_size );
+    REQUIRE( real_block != nullptr );
+
+    write_self_consistent_fake_allocated_header( base, payload );
+    void* forged = payload + sizeof( pmm::Block<AT> );
+
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, forged, total_size ) == nullptr );
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, payload, total_size ) == real_block );
+
+    Mgr::destroy();
+}
+
 TEST_CASE( "I326: deallocate ignores forged aligned payload pointer", "[issue326][validation]" )
 {
     reset_manager();
@@ -76,6 +106,35 @@ TEST_CASE( "I326: deallocate ignores forged aligned payload pointer", "[issue326
     REQUIRE( original_weight > 0 );
 
     write_fake_allocated_header( payload );
+    void* forged = payload + sizeof( pmm::Block<AT> );
+
+    Mgr::deallocate( forged );
+
+    REQUIRE( BlockState::get_weight( real_block ) == original_weight );
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, payload, total_size ) == real_block );
+    REQUIRE( Mgr::verify().ok );
+
+    Mgr::deallocate_typed( p );
+    Mgr::destroy();
+}
+
+TEST_CASE( "I326: deallocate ignores self-consistent forged payload header", "[issue326][validation]" )
+{
+    reset_manager();
+
+    auto p = Mgr::allocate_typed<std::uint32_t>( 32 );
+    REQUIRE( !p.is_null() );
+
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+    auto*         payload    = reinterpret_cast<std::uint8_t*>( Mgr::resolve( p ) );
+    REQUIRE( payload != nullptr );
+
+    auto* real_block      = pmm::detail::header_from_ptr_t<AT>( base, payload, total_size );
+    auto  original_weight = BlockState::get_weight( real_block );
+    REQUIRE( original_weight > 0 );
+
+    write_self_consistent_fake_allocated_header( base, payload );
     void* forged = payload + sizeof( pmm::Block<AT> );
 
     Mgr::deallocate( forged );

--- a/tests/test_issue326_user_ptr_validation.cpp
+++ b/tests/test_issue326_user_ptr_validation.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file test_issue326_user_ptr_validation.cpp
+ * @brief Regression tests for forged user pointer rejection.
+ */
+
+#include "pmm/block_state.h"
+#include "pmm/persist_memory_manager.h"
+#include "pmm/pmm_presets.h"
+#include "pmm/types.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <cstring>
+
+namespace
+{
+using Mgr        = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 326>;
+using AT         = typename Mgr::address_traits;
+using BlockState = pmm::BlockStateBase<AT>;
+
+void reset_manager()
+{
+    Mgr::destroy();
+    REQUIRE( Mgr::create( 64 * 1024 ) );
+}
+
+void write_fake_allocated_header( void* raw )
+{
+    std::memset( raw, 0, sizeof( pmm::Block<AT> ) );
+    BlockState::set_weight_of( raw, 1 );
+    BlockState::set_prev_offset_of( raw, AT::no_block );
+    BlockState::set_next_offset_of( raw, AT::no_block );
+    BlockState::set_node_type_of( raw, pmm::kNodeReadWrite );
+}
+} // namespace
+
+TEST_CASE( "I326: header_from_ptr_t rejects forged aligned payload pointer", "[issue326][validation]" )
+{
+    reset_manager();
+
+    auto p = Mgr::allocate_typed<std::uint32_t>( 32 );
+    REQUIRE( !p.is_null() );
+
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+    auto*         payload    = reinterpret_cast<std::uint8_t*>( Mgr::resolve( p ) );
+    REQUIRE( payload != nullptr );
+
+    auto* real_block = pmm::detail::header_from_ptr_t<AT>( base, payload, total_size );
+    REQUIRE( real_block != nullptr );
+
+    write_fake_allocated_header( payload );
+    void* forged = payload + sizeof( pmm::Block<AT> );
+
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, forged, total_size ) == nullptr );
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, payload, total_size ) == real_block );
+
+    Mgr::destroy();
+}
+
+TEST_CASE( "I326: deallocate ignores forged aligned payload pointer", "[issue326][validation]" )
+{
+    reset_manager();
+
+    auto p = Mgr::allocate_typed<std::uint32_t>( 32 );
+    REQUIRE( !p.is_null() );
+
+    std::uint8_t* base       = Mgr::backend().base_ptr();
+    std::size_t   total_size = Mgr::backend().total_size();
+    auto*         payload    = reinterpret_cast<std::uint8_t*>( Mgr::resolve( p ) );
+    REQUIRE( payload != nullptr );
+
+    auto* real_block      = pmm::detail::header_from_ptr_t<AT>( base, payload, total_size );
+    auto  original_weight = BlockState::get_weight( real_block );
+    REQUIRE( original_weight > 0 );
+
+    write_fake_allocated_header( payload );
+    void* forged = payload + sizeof( pmm::Block<AT> );
+
+    Mgr::deallocate( forged );
+
+    REQUIRE( BlockState::get_weight( real_block ) == original_weight );
+    REQUIRE( pmm::detail::header_from_ptr_t<AT>( base, payload, total_size ) == real_block );
+    REQUIRE( Mgr::verify().ok );
+
+    Mgr::deallocate_typed( p );
+    Mgr::destroy();
+}


### PR DESCRIPTION
## Summary
- Adds canonical user-pointer validation before converting `user_ptr` back to `Block*`.
- Proves reconstructed raw user-pointer headers are real allocator blocks by checking manager first/last anchors plus `prev`/`next` neighbor back-links, not only local payload-byte self-consistency.
- Rejects crafted payload-resident fake headers with granule alignment, nonzero `weight`, `root_offset == cand_idx`, valid `node_type`, and in-bounds payload span.
- Keeps pptr-only conversion and checked resolve on bounded local header validation (`weight`, `root_offset`, `node_type`) so ordinary pptr access does not add unlocked chain/link reads.
- Applies the raw user-pointer validation to the SmallAddressTraits rounded public-pointer path.
- Documents the stable block-link contract at the canonical validation helpers, `find_block_from_user_ptr()`, and public raw-pointer entry points.
- Adds issue 326 regression tests and regenerates single-header outputs.

Fixes netkeep80/PersistMemoryManager#326

## Reproduction
Before the fix, an aligned pointer inside an allocated payload could be arranged so `ptr - sizeof(Block)` landed on payload bytes that looked like an allocated block header. A fully self-consistent fake payload header could satisfy local checks such as nonzero `weight`, `root_offset == cand_idx`, valid `node_type`, and in-bounds computed payload span. `header_from_ptr_t()` could then return that payload address as a block header, allowing `deallocate()` to mutate allocator state through a non-canonical header.

## Tests
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (passes 90/90)
- `ctest --test-dir build -R test_issue326_user_ptr_validation --output-on-failure`
- `~/.local/bin/clang-format --dry-run --Werror include/pmm/types.h include/pmm/forest_domain_mixin.inc include/pmm/persist_memory_manager.h`
- `scripts/generate-single-headers.sh --strip-comments --output-dir /tmp/generated-issue326` plus `diff -qr /tmp/generated-issue326 single_include/pmm`
- `scripts/check-file-size.sh`
- `scripts/check-docs-consistency.sh`
- `GITHUB_BASE_REF=main scripts/check-changelog-fragment.sh`
- `git diff --check`
- GitHub Actions passed on head SHA `d6e3d4556b64c27548000ee4cdbfacfb7e744e82`, including cppcheck, TSan, ASan/UBSan, and Windows/MSVC.

## Notes
- The raw user-pointer path now performs an O(1) canonical-link proof instead of walking the full block list, after a first chain-walk draft made `test_stress_realistic` hit its 120s timeout locally.
- The canonical-link proof reads manager `first/last` anchors and neighbor back-links, so raw-pointer callers must hold the manager lock or otherwise guarantee stable block links during validation.
- Local `cppcheck` is not installed in this container; the GitHub Actions workflow installs and runs it.
