### PR TITLE
Refactor forest domain protocol

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T17:17:40.916Z for PR creation at branch issue-335-e5e62876c0ee for issue https://github.com/netkeep80/PersistMemoryManager/issues/335

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T17:17:40.916Z for PR creation at branch issue-335-e5e62876c0ee for issue https://github.com/netkeep80/PersistMemoryManager/issues/335

--- a/changelog.d/20260420_184500_forest_domain_protocol.md
+++ b/changelog.d/20260420_184500_forest_domain_protocol.md
@@ -3,5 +3,6 @@ bump: patch
 ---
 
 ### Changed
-- Made `ForestDomainOps` the single value-based protocol wrapper for AVL-backed forest domains and moved `pmap` onto it.
+- Made `ForestDomainViewOps`/`ForestDomainOps` the canonical read-only/mutable protocol surfaces for
+  AVL-backed forest domains and moved `pmap` onto them.
 - Routed symbol and legacy root access through the canonical forest-domain root-index helpers.

--- a/changelog.d/20260420_184500_forest_domain_protocol.md
+++ b/changelog.d/20260420_184500_forest_domain_protocol.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Changed
+- Made `ForestDomainOps` the single value-based protocol wrapper for AVL-backed forest domains and moved `pmap` onto it.
+- Routed symbol and legacy root access through the canonical forest-domain root-index helpers.

--- a/include/pmm/avl_tree_mixin.h
+++ b/include/pmm/avl_tree_mixin.h
@@ -515,22 +515,27 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 // ─── Forest-domain protocol ──────────────────────────────────────────────────
 
 template <typename Domain>
-concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
+concept ForestDomainViewDescriptor = requires( const Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
     { domain.name() } -> std::convertible_to<const char*>;
     { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
     { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey =
-    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
-        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+template <typename Domain>
+concept ForestDomainDescriptor =
+    ForestDomainViewDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p ) {
+        { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+        { domain.less_node( p, p ) } -> std::convertible_to<bool>;
     };
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = ForestDomainViewDescriptor<Domain> &&
+                                       requires( const Domain domain, typename Domain::node_pptr p, const Key& key ) {
+                                           { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+                                       };
 
 template <typename Domain>
 static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
@@ -544,13 +549,12 @@ static bool forest_domain_validate_node( const Domain& domain, typename Domain::
 }
 
 /**
- * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
+ * @brief Generic read-only AVL-backed forest-domain operations for a concrete descriptor.
  *
- * The descriptor is the canonical forest-domain protocol: domain identity, root
- * binding, node resolution, node ordering, optional external-key comparison,
- * and optional node validation.
+ * The view descriptor supplies domain identity, read-only root binding, node
+ * resolution, and optional external-key comparison.
  */
-template <ForestDomainDescriptor Domain> struct ForestDomainOps
+template <ForestDomainViewDescriptor Domain> struct ForestDomainViewOps
 {
     using index_type = typename Domain::index_type;
     using node_type  = typename Domain::node_type;
@@ -558,20 +562,10 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
 
     Domain domain;
 
-    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+    constexpr explicit ForestDomainViewOps( Domain d = Domain{} ) noexcept : domain( d ) {}
 
     const char* name() const noexcept { return domain.name(); }
     index_type  root_index() const noexcept { return domain.root_index(); }
-    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
-
-    bool reset_root() const noexcept
-    {
-        index_type* root = root_index_ptr();
-        if ( root == nullptr )
-            return false;
-        *root = static_cast<index_type>( 0 );
-        return true;
-    }
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
@@ -581,17 +575,52 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
             domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
             [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
+};
 
-    void insert( node_pptr new_node ) const noexcept
+/**
+ * @brief Generic mutable AVL-backed forest-domain operations for a concrete descriptor.
+ *
+ * The mutable descriptor adds root-slot access and node ordering. Mutation is
+ * intentionally kept off the const surface: callers that only have a const
+ * handle can read identity/root state and perform keyed lookup, but cannot
+ * obtain or rewrite the root slot.
+ */
+template <ForestDomainDescriptor Domain> struct ForestDomainOps : ForestDomainViewOps<Domain>
+{
+    using view_base  = ForestDomainViewOps<Domain>;
+    using index_type = typename view_base::index_type;
+    using node_type  = typename view_base::node_type;
+    using node_pptr  = typename view_base::node_pptr;
+
+    using view_base::find;
+    using view_base::name;
+    using view_base::root_index;
+
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : view_base( d ) {}
+
+    index_type* root_index_ptr() noexcept { return this->domain.root_index_ptr(); }
+
+    bool reset_root() noexcept
     {
-        index_type* root = domain.root_index_ptr();
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = this->domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
+        if ( this->domain.resolve_node( new_node ) == nullptr ||
+             !forest_domain_validate_node( this->domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
-            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
+            new_node, *root,
+            [this, new_node]( node_pptr cur ) -> bool { return this->domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return this->domain.resolve_node( p ); } );
     }
 };
 

--- a/include/pmm/avl_tree_mixin.h
+++ b/include/pmm/avl_tree_mixin.h
@@ -512,27 +512,33 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
     avl_rebalance_up( parent, root_idx, update_node );
 }
 
-// ─── Forest-domain descriptor/policy seam ────────────────────────────────────
+// ─── Forest-domain protocol ──────────────────────────────────────────────────
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+template <typename Domain>
+concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
-    { Domain::name() } -> std::convertible_to<const char*>;
-    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
-    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
-    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+    { domain.name() } -> std::convertible_to<const char*>;
+    { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey =
+    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
+        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+    };
+
+template <typename Domain>
+static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
 {
     if constexpr ( requires {
-                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                       { domain.validate_node( p ) } -> std::convertible_to<bool>;
                    } )
-        return Domain::validate_node( p );
+        return domain.validate_node( p );
     else
         return true;
 }
@@ -540,20 +546,25 @@ template <typename Domain> static bool forest_domain_validate_node( typename Dom
 /**
  * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
  *
- * The descriptor owns domain identity, root binding, node resolution, ordering,
- * and optional node validation. This wrapper keeps the AVL substrate reusable
- * without forcing allocator and non-allocator domains into the same runtime type.
+ * The descriptor is the canonical forest-domain protocol: domain identity, root
+ * binding, node resolution, node ordering, optional external-key comparison,
+ * and optional node validation.
  */
-template <typename Domain> struct ForestDomainOps
+template <ForestDomainDescriptor Domain> struct ForestDomainOps
 {
     using index_type = typename Domain::index_type;
+    using node_type  = typename Domain::node_type;
     using node_pptr  = typename Domain::node_pptr;
 
-    static constexpr const char* name() noexcept { return Domain::name(); }
-    static index_type            root_index() noexcept { return Domain::root_index(); }
-    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+    Domain domain;
 
-    static bool reset_root() noexcept
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+
+    const char* name() const noexcept { return domain.name(); }
+    index_type  root_index() const noexcept { return domain.root_index(); }
+    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
+
+    bool reset_root() const noexcept
     {
         index_type* root = root_index_ptr();
         if ( root == nullptr )
@@ -564,23 +575,23 @@ template <typename Domain> struct ForestDomainOps
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
-    static node_pptr find( const Key& key ) noexcept
+    node_pptr find( const Key& key ) const noexcept
     {
         return avl_find<node_pptr>(
-            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 
-    static void insert( node_pptr new_node ) noexcept
+    void insert( node_pptr new_node ) const noexcept
     {
-        index_type* root = Domain::root_index_ptr();
+        index_type* root = domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 };
 

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -85,9 +85,10 @@ static forest_domain* find_domain_by_symbol_unlocked( pptr<pstringview> symbol )
     return nullptr;
 }
 
-static index_type domain_root_offset_unlocked( const forest_domain*                         rec,
-                                               const detail::ManagerHeader<address_traits>* hdr ) noexcept
+static index_type forest_domain_root_index_unlocked( const forest_domain* rec ) noexcept
 {
+    const detail::ManagerHeader<address_traits>* hdr =
+        ( _backend.base_ptr() != nullptr ) ? get_header_c( _backend.base_ptr() ) : nullptr;
     if ( rec == nullptr || hdr == nullptr )
         return 0;
     if ( rec->binding_kind == detail::kForestBindingFreeTree )
@@ -95,32 +96,27 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
     return rec->root_offset;
 }
 
-// ─── Legacy root helpers ──────────────────────────────────────────────────────
-
-static index_type get_legacy_root_offset_unlocked() noexcept
+static index_type* forest_domain_root_index_ptr_unlocked( forest_domain* rec ) noexcept
 {
-    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+    if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
+        return nullptr;
+    return &rec->root_offset;
 }
 
-static void set_legacy_root_offset_unlocked( index_type off ) noexcept
+static bool set_forest_domain_root_index_unlocked( forest_domain* rec, index_type root ) noexcept
 {
-    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
-        rec->root_offset = off;
+    index_type* root_ptr = forest_domain_root_index_ptr_unlocked( rec );
+    if ( root_ptr == nullptr )
+        return false;
+    *root_ptr = root;
+    return true;
 }
 
-// ─── Symbol domain helpers ────────────────────────────────────────────────────
+// ─── Canonical system domain records ─────────────────────────────────────────
 
 static forest_domain* symbol_domain_record_unlocked() noexcept
 {
     return find_domain_by_name_unlocked( detail::kSystemDomainSymbols );
-}
-
-static index_type symbol_domain_root_offset_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
 // ─── Domain registration ─────────────────────────────────────────────────────
@@ -179,11 +175,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    using symbol_policy = typename pstringview::forest_domain_policy;
-    if ( symbol_policy::root_index_ptr() == nullptr )
+    auto symbol_policy = pstringview::forest_domain_ops();
+    if ( symbol_policy.root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = symbol_policy::find( s );
+    pptr<pstringview> found = symbol_policy.find( s );
     if ( !found.is_null() )
         return found;
 
@@ -209,7 +205,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    symbol_policy::insert( new_node );
+    symbol_policy.insert( new_node );
 
     return new_node;
 }
@@ -375,7 +371,7 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     if ( free_rec->binding_kind != detail::kForestBindingFreeTree )
         return false;
     // 5. Symbol dictionary root is non-zero (at least bootstrap symbols exist)
-    if ( symbol_domain_root_offset_unlocked() == 0 )
+    if ( pstringview::forest_domain_ops().root_index() == 0 )
         return false;
     // 6. Registry domain root matches header root_offset
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
@@ -404,7 +400,8 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainSymbols, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, symbol_domain_root_offset_unlocked() ) )
+                                        detail::kForestBindingDirectRoot,
+                                        pstringview::forest_domain_ops().root_index() ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -517,7 +517,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_legacy_root_offset_unlocked( p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+                                               p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
     /**
@@ -531,7 +532,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root = get_legacy_root_offset_unlocked();
+        index_type legacy_root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
         if ( legacy_root == static_cast<index_type>( 0 ) )
             return pptr<T>();
         return pptr<T>( legacy_root );
@@ -587,7 +589,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_name_unlocked( name );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( index_type binding_id ) noexcept
@@ -596,7 +598,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_binding_unlocked( binding_id );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( pptr<pstringview> symbol ) noexcept
@@ -605,7 +607,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_symbol_unlocked( symbol );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     template <typename T> static pptr<T> get_domain_root( const char* name ) noexcept
@@ -632,10 +634,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return false;
         forest_domain* rec = find_domain_by_name_unlocked( name );
-        if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
-            return false;
-        rec->root_offset = root.is_null() ? static_cast<index_type>( 0 ) : root.offset();
-        return true;
+        return set_forest_domain_root_index_unlocked( rec,
+                                                      root.is_null() ? static_cast<index_type>( 0 ) : root.offset() );
     }
 
     // ─── Методы доступа к полям AVL-узла блока ─────────────

--- a/include/pmm/pmap.h
+++ b/include/pmm/pmap.h
@@ -138,6 +138,44 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     using node_type    = pmap_node<_K, _V>;
     using node_pptr    = typename ManagerT::template pptr<node_type>;
 
+    struct forest_domain_descriptor
+    {
+        using index_type = typename ManagerT::index_type;
+        using node_type  = pmap_node<_K, _V>;
+        using node_pptr  = typename ManagerT::template pptr<node_type>;
+
+        index_type* root_index_slot;
+
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+
+        static constexpr const char* name() noexcept { return "container/pmap"; }
+
+        index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
+
+        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const _K& key, node_pptr cur ) noexcept
+        {
+            node_type* obj = resolve_node( cur );
+            if ( obj == nullptr )
+                return 0;
+            return ( key == obj->key ) ? 0 : ( ( key < obj->key ) ? -1 : 1 );
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && lhs_obj->key < rhs_obj->key;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
     /// @brief Sentinel value for "no node" in TreeNode fields.
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
 
@@ -150,6 +188,16 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     pmap() noexcept : _root_idx( static_cast<index_type>( 0 ) ) {}
 
     // ─── Методы доступа ───────────────────────────────────────────────────────
+
+    forest_domain_policy forest_domain_ops() noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
+    }
+
+    forest_domain_policy forest_domain_ops() const noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+    }
 
     /// @brief Проверить, пуст ли словарь.
     bool empty() const noexcept { return _root_idx == static_cast<index_type>( 0 ); }
@@ -177,8 +225,10 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      */
     node_pptr insert( const _K& key, const _V& val ) noexcept
     {
+        auto ops = forest_domain_ops();
+
         // Ищем существующий узел.
-        node_pptr existing = _avl_find( key );
+        node_pptr existing = ops.find( key );
         if ( !existing.is_null() )
         {
             // Ключ найден — обновляем значение.
@@ -204,7 +254,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         detail::avl_init_node( new_node );
 
         // Вставляем в AVL-дерево.
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
@@ -215,7 +265,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для поиска.
      * @return pptr на найденный узел, или нулевой pptr если не найден.
      */
-    node_pptr find( const _K& key ) const noexcept { return _avl_find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
 
     /**
      * @brief Проверить, содержит ли словарь заданный ключ.
@@ -223,7 +273,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для проверки.
      * @return true если ключ найден.
      */
-    bool contains( const _K& key ) const noexcept { return !_avl_find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
 
     /**
      * @brief Удалить узел по ключу.
@@ -236,7 +286,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      */
     bool erase( const _K& key ) noexcept
     {
-        node_pptr target = _avl_find( key );
+        node_pptr target = forest_domain_ops().find( key );
         if ( target.is_null() )
             return false;
 
@@ -263,7 +313,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      *
      * Сбрасывает _root_idx, но не освобождает данные в ПАП.
      */
-    void reset() noexcept { _root_idx = static_cast<index_type>( 0 ); }
+    void reset() noexcept { forest_domain_ops().reset_root(); }
 
     // ─── Итератор ───────────────────────────────────────────────
 
@@ -282,43 +332,6 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
 
     /// @brief Конец итерации (sentinel = 0).
     iterator end() const noexcept { return iterator( static_cast<index_type>( 0 ) ); }
-
-    // ─── AVL-дерево (использует встроенные TreeNode-поля каждого узла) ────────
-
-  private:
-    /// @brief Найти узел AVL-дерева с заданным ключом. Возвращает null если не найден.
-    node_pptr _avl_find( const _K& key ) const noexcept
-    {
-        return detail::avl_find<node_pptr>(
-            _root_idx,
-            [&]( node_pptr cur ) -> int
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                if ( obj == nullptr )
-                    return 0;
-                if ( key == obj->key )
-                    return 0;
-                return ( key < obj->key ) ? -1 : 1;
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
-    /// @brief Вставить новый узел в AVL-дерево. Предполагается, что ключ ещё не в дереве.
-    void _avl_insert( node_pptr new_node ) noexcept
-    {
-        node_type* new_obj = ManagerT::template resolve<node_type>( new_node );
-        detail::avl_insert(
-            new_node, _root_idx,
-            [&]( node_pptr cur ) -> bool
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                return ( obj != nullptr ) && ( new_obj->key < obj->key );
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
-    // _subtree_count and _clear_subtree replaced by shared
-    // detail::avl_subtree_count and detail::avl_clear_subtree.
 };
 
 } // namespace pmm

--- a/include/pmm/pmap.h
+++ b/include/pmm/pmap.h
@@ -144,15 +144,24 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         using node_type  = pmap_node<_K, _V>;
         using node_pptr  = typename ManagerT::template pptr<node_type>;
 
-        index_type* root_index_slot;
+        const index_type* root_index_slot;
+        index_type*       mutable_root_index_slot;
 
-        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( root )
+        {
+        }
+
+        constexpr explicit forest_domain_descriptor( const index_type* root ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( nullptr )
+        {
+        }
 
         static constexpr const char* name() noexcept { return "container/pmap"; }
 
         index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
 
-        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+        index_type* root_index_ptr() noexcept { return mutable_root_index_slot; }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
 
@@ -174,7 +183,8 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
     };
 
-    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+    using forest_domain_view_policy = detail::ForestDomainViewOps<forest_domain_descriptor>;
+    using forest_domain_policy      = detail::ForestDomainOps<forest_domain_descriptor>;
 
     /// @brief Sentinel value for "no node" in TreeNode fields.
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
@@ -194,9 +204,9 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
-    forest_domain_policy forest_domain_ops() const noexcept
+    forest_domain_view_policy forest_domain_view_ops() const noexcept
     {
-        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+        return forest_domain_view_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
     /// @brief Проверить, пуст ли словарь.
@@ -265,7 +275,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для поиска.
      * @return pptr на найденный узел, или нулевой pptr если не найден.
      */
-    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_view_ops().find( key ); }
 
     /**
      * @brief Проверить, содержит ли словарь заданный ключ.
@@ -273,7 +283,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для проверки.
      * @return true если ключ найден.
      */
-    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_view_ops().find( key ).is_null(); }
 
     /**
      * @brief Удалить узел по ключу.

--- a/include/pmm/pstringview.h
+++ b/include/pmm/pstringview.h
@@ -113,13 +113,13 @@ template <typename ManagerT> struct pstringview
         static index_type root_index() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+            return ManagerT::forest_domain_root_index_unlocked( domain );
         }
 
         static index_type* root_index_ptr() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+            return ManagerT::forest_domain_root_index_ptr_unlocked( domain );
         }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
@@ -143,6 +143,8 @@ template <typename ManagerT> struct pstringview
     };
 
     using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
+    static forest_domain_policy forest_domain_ops() noexcept { return forest_domain_policy{}; }
 
     std::uint32_t length; ///< Длина строки (без нулевого терминатора)
     char          str[1]; ///< Строковые данные (flexible array member pattern)
@@ -240,7 +242,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        forest_domain_policy::reset_root();
+        forest_domain_ops().reset_root();
     }
 
     /// @brief Текущий persistent root словаря интернирования; 0 = пустое дерево.
@@ -249,7 +251,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return forest_domain_policy::root_index();
+        return forest_domain_ops().root_index();
     }
 
     // Public destructor required for stack-temporary construction via pstringview<Mgr>("hello").
@@ -265,8 +267,10 @@ template <typename ManagerT> struct pstringview
         if ( s == nullptr )
             s = "";
 
+        auto ops = forest_domain_ops();
+
         // Ищем в AVL-дереве.
-        psview_pptr found = _avl_find( s );
+        psview_pptr found = ops.find( s );
         if ( !found.is_null() )
             return found;
 
@@ -324,18 +328,10 @@ template <typename ManagerT> struct pstringview
         ManagerT::lock_block_permanent( obj );
 
         // Вставляем в AVL-дерево.
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
-
-    // ─── AVL-дерево (использует встроенные TreeNode-поля каждого pstringview-блока) ─
-
-    /// @brief Найти узел AVL-дерева с заданной строкой. Возвращает null если не найден.
-    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
-
-    /// @brief Вставить новый узел в AVL-дерево. Предполагается, что строка ещё не в дереве.
-    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 } // namespace pmm

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -3181,27 +3181,33 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
     avl_rebalance_up( parent, root_idx, update_node );
 }
 
-// ─── Forest-domain descriptor/policy seam ────────────────────────────────────
+// ─── Forest-domain protocol ──────────────────────────────────────────────────
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+template <typename Domain>
+concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
-    { Domain::name() } -> std::convertible_to<const char*>;
-    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
-    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
-    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+    { domain.name() } -> std::convertible_to<const char*>;
+    { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey =
+    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
+        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+    };
+
+template <typename Domain>
+static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
 {
     if constexpr ( requires {
-                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                       { domain.validate_node( p ) } -> std::convertible_to<bool>;
                    } )
-        return Domain::validate_node( p );
+        return domain.validate_node( p );
     else
         return true;
 }
@@ -3209,20 +3215,25 @@ template <typename Domain> static bool forest_domain_validate_node( typename Dom
 /**
  * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
  *
- * The descriptor owns domain identity, root binding, node resolution, ordering,
- * and optional node validation. This wrapper keeps the AVL substrate reusable
- * without forcing allocator and non-allocator domains into the same runtime type.
+ * The descriptor is the canonical forest-domain protocol: domain identity, root
+ * binding, node resolution, node ordering, optional external-key comparison,
+ * and optional node validation.
  */
-template <typename Domain> struct ForestDomainOps
+template <ForestDomainDescriptor Domain> struct ForestDomainOps
 {
     using index_type = typename Domain::index_type;
+    using node_type  = typename Domain::node_type;
     using node_pptr  = typename Domain::node_pptr;
 
-    static constexpr const char* name() noexcept { return Domain::name(); }
-    static index_type            root_index() noexcept { return Domain::root_index(); }
-    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+    Domain domain;
 
-    static bool reset_root() noexcept
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+
+    const char* name() const noexcept { return domain.name(); }
+    index_type  root_index() const noexcept { return domain.root_index(); }
+    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
+
+    bool reset_root() const noexcept
     {
         index_type* root = root_index_ptr();
         if ( root == nullptr )
@@ -3233,23 +3244,23 @@ template <typename Domain> struct ForestDomainOps
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
-    static node_pptr find( const Key& key ) noexcept
+    node_pptr find( const Key& key ) const noexcept
     {
         return avl_find<node_pptr>(
-            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 
-    static void insert( node_pptr new_node ) noexcept
+    void insert( node_pptr new_node ) const noexcept
     {
-        index_type* root = Domain::root_index_ptr();
+        index_type* root = domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 };
 
@@ -6050,6 +6061,44 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     using node_type    = pmap_node<_K, _V>;
     using node_pptr    = typename ManagerT::template pptr<node_type>;
 
+    struct forest_domain_descriptor
+    {
+        using index_type = typename ManagerT::index_type;
+        using node_type  = pmap_node<_K, _V>;
+        using node_pptr  = typename ManagerT::template pptr<node_type>;
+
+        index_type* root_index_slot;
+
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+
+        static constexpr const char* name() noexcept { return "container/pmap"; }
+
+        index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
+
+        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const _K& key, node_pptr cur ) noexcept
+        {
+            node_type* obj = resolve_node( cur );
+            if ( obj == nullptr )
+                return 0;
+            return ( key == obj->key ) ? 0 : ( ( key < obj->key ) ? -1 : 1 );
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && lhs_obj->key < rhs_obj->key;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
     /// @brief Sentinel value for "no node" in TreeNode fields.
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
 
@@ -6062,6 +6111,16 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     pmap() noexcept : _root_idx( static_cast<index_type>( 0 ) ) {}
 
     // ─── Методы доступа ───────────────────────────────────────────────────────
+
+    forest_domain_policy forest_domain_ops() noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
+    }
+
+    forest_domain_policy forest_domain_ops() const noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+    }
 
     /// @brief Проверить, пуст ли словарь.
     bool empty() const noexcept { return _root_idx == static_cast<index_type>( 0 ); }
@@ -6089,8 +6148,10 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      */
     node_pptr insert( const _K& key, const _V& val ) noexcept
     {
+        auto ops = forest_domain_ops();
+
         // Ищем существующий узел.
-        node_pptr existing = _avl_find( key );
+        node_pptr existing = ops.find( key );
         if ( !existing.is_null() )
         {
             // Ключ найден — обновляем значение.
@@ -6116,7 +6177,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         detail::avl_init_node( new_node );
 
         // Вставляем в AVL-дерево.
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
@@ -6127,7 +6188,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для поиска.
      * @return pptr на найденный узел, или нулевой pptr если не найден.
      */
-    node_pptr find( const _K& key ) const noexcept { return _avl_find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
 
     /**
      * @brief Проверить, содержит ли словарь заданный ключ.
@@ -6135,7 +6196,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для проверки.
      * @return true если ключ найден.
      */
-    bool contains( const _K& key ) const noexcept { return !_avl_find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
 
     /**
      * @brief Удалить узел по ключу.
@@ -6148,7 +6209,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      */
     bool erase( const _K& key ) noexcept
     {
-        node_pptr target = _avl_find( key );
+        node_pptr target = forest_domain_ops().find( key );
         if ( target.is_null() )
             return false;
 
@@ -6175,7 +6236,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      *
      * Сбрасывает _root_idx, но не освобождает данные в ПАП.
      */
-    void reset() noexcept { _root_idx = static_cast<index_type>( 0 ); }
+    void reset() noexcept { forest_domain_ops().reset_root(); }
 
     // ─── Итератор ───────────────────────────────────────────────
 
@@ -6194,43 +6255,6 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
 
     /// @brief Конец итерации (sentinel = 0).
     iterator end() const noexcept { return iterator( static_cast<index_type>( 0 ) ); }
-
-    // ─── AVL-дерево (использует встроенные TreeNode-поля каждого узла) ────────
-
-  private:
-    /// @brief Найти узел AVL-дерева с заданным ключом. Возвращает null если не найден.
-    node_pptr _avl_find( const _K& key ) const noexcept
-    {
-        return detail::avl_find<node_pptr>(
-            _root_idx,
-            [&]( node_pptr cur ) -> int
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                if ( obj == nullptr )
-                    return 0;
-                if ( key == obj->key )
-                    return 0;
-                return ( key < obj->key ) ? -1 : 1;
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
-    /// @brief Вставить новый узел в AVL-дерево. Предполагается, что ключ ещё не в дереве.
-    void _avl_insert( node_pptr new_node ) noexcept
-    {
-        node_type* new_obj = ManagerT::template resolve<node_type>( new_node );
-        detail::avl_insert(
-            new_node, _root_idx,
-            [&]( node_pptr cur ) -> bool
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                return ( obj != nullptr ) && ( new_obj->key < obj->key );
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
-    // _subtree_count and _clear_subtree replaced by shared
-    // detail::avl_subtree_count and detail::avl_clear_subtree.
 };
 
 } // namespace pmm
@@ -7237,13 +7261,13 @@ template <typename ManagerT> struct pstringview
         static index_type root_index() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+            return ManagerT::forest_domain_root_index_unlocked( domain );
         }
 
         static index_type* root_index_ptr() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+            return ManagerT::forest_domain_root_index_ptr_unlocked( domain );
         }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
@@ -7267,6 +7291,8 @@ template <typename ManagerT> struct pstringview
     };
 
     using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
+    static forest_domain_policy forest_domain_ops() noexcept { return forest_domain_policy{}; }
 
     std::uint32_t length; ///< Длина строки (без нулевого терминатора)
     char          str[1]; ///< Строковые данные (flexible array member pattern)
@@ -7364,7 +7390,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        forest_domain_policy::reset_root();
+        forest_domain_ops().reset_root();
     }
 
     /// @brief Текущий persistent root словаря интернирования; 0 = пустое дерево.
@@ -7373,7 +7399,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return forest_domain_policy::root_index();
+        return forest_domain_ops().root_index();
     }
 
     // Public destructor required for stack-temporary construction via pstringview<Mgr>("hello").
@@ -7389,8 +7415,10 @@ template <typename ManagerT> struct pstringview
         if ( s == nullptr )
             s = "";
 
+        auto ops = forest_domain_ops();
+
         // Ищем в AVL-дереве.
-        psview_pptr found = _avl_find( s );
+        psview_pptr found = ops.find( s );
         if ( !found.is_null() )
             return found;
 
@@ -7448,18 +7476,10 @@ template <typename ManagerT> struct pstringview
         ManagerT::lock_block_permanent( obj );
 
         // Вставляем в AVL-дерево.
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
-
-    // ─── AVL-дерево (использует встроенные TreeNode-поля каждого pstringview-блока) ─
-
-    /// @brief Найти узел AVL-дерева с заданной строкой. Возвращает null если не найден.
-    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
-
-    /// @brief Вставить новый узел в AVL-дерево. Предполагается, что строка ещё не в дереве.
-    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 } // namespace pmm
@@ -8382,7 +8402,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_legacy_root_offset_unlocked( p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+                                               p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
     /**
@@ -8396,7 +8417,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root = get_legacy_root_offset_unlocked();
+        index_type legacy_root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
         if ( legacy_root == static_cast<index_type>( 0 ) )
             return pptr<T>();
         return pptr<T>( legacy_root );
@@ -8452,7 +8474,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_name_unlocked( name );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( index_type binding_id ) noexcept
@@ -8461,7 +8483,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_binding_unlocked( binding_id );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( pptr<pstringview> symbol ) noexcept
@@ -8470,7 +8492,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_symbol_unlocked( symbol );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     template <typename T> static pptr<T> get_domain_root( const char* name ) noexcept
@@ -8497,10 +8519,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return false;
         forest_domain* rec = find_domain_by_name_unlocked( name );
-        if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
-            return false;
-        rec->root_offset = root.is_null() ? static_cast<index_type>( 0 ) : root.offset();
-        return true;
+        return set_forest_domain_root_index_unlocked( rec,
+                                                      root.is_null() ? static_cast<index_type>( 0 ) : root.offset() );
     }
 
     // ─── Методы доступа к полям AVL-узла блока ─────────────
@@ -9034,9 +9054,10 @@ static forest_domain* find_domain_by_symbol_unlocked( pptr<pstringview> symbol )
     return nullptr;
 }
 
-static index_type domain_root_offset_unlocked( const forest_domain*                         rec,
-                                               const detail::ManagerHeader<address_traits>* hdr ) noexcept
+static index_type forest_domain_root_index_unlocked( const forest_domain* rec ) noexcept
 {
+    const detail::ManagerHeader<address_traits>* hdr =
+        ( _backend.base_ptr() != nullptr ) ? get_header_c( _backend.base_ptr() ) : nullptr;
     if ( rec == nullptr || hdr == nullptr )
         return 0;
     if ( rec->binding_kind == detail::kForestBindingFreeTree )
@@ -9044,32 +9065,27 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
     return rec->root_offset;
 }
 
-// ─── Legacy root helpers ──────────────────────────────────────────────────────
-
-static index_type get_legacy_root_offset_unlocked() noexcept
+static index_type* forest_domain_root_index_ptr_unlocked( forest_domain* rec ) noexcept
 {
-    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+    if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
+        return nullptr;
+    return &rec->root_offset;
 }
 
-static void set_legacy_root_offset_unlocked( index_type off ) noexcept
+static bool set_forest_domain_root_index_unlocked( forest_domain* rec, index_type root ) noexcept
 {
-    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
-        rec->root_offset = off;
+    index_type* root_ptr = forest_domain_root_index_ptr_unlocked( rec );
+    if ( root_ptr == nullptr )
+        return false;
+    *root_ptr = root;
+    return true;
 }
 
-// ─── Symbol domain helpers ────────────────────────────────────────────────────
+// ─── Canonical system domain records ─────────────────────────────────────────
 
 static forest_domain* symbol_domain_record_unlocked() noexcept
 {
     return find_domain_by_name_unlocked( detail::kSystemDomainSymbols );
-}
-
-static index_type symbol_domain_root_offset_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
 // ─── Domain registration ─────────────────────────────────────────────────────
@@ -9128,11 +9144,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    using symbol_policy = typename pstringview::forest_domain_policy;
-    if ( symbol_policy::root_index_ptr() == nullptr )
+    auto symbol_policy = pstringview::forest_domain_ops();
+    if ( symbol_policy.root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = symbol_policy::find( s );
+    pptr<pstringview> found = symbol_policy.find( s );
     if ( !found.is_null() )
         return found;
 
@@ -9158,7 +9174,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    symbol_policy::insert( new_node );
+    symbol_policy.insert( new_node );
 
     return new_node;
 }
@@ -9324,7 +9340,7 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     if ( free_rec->binding_kind != detail::kForestBindingFreeTree )
         return false;
     // 5. Symbol dictionary root is non-zero (at least bootstrap symbols exist)
-    if ( symbol_domain_root_offset_unlocked() == 0 )
+    if ( pstringview::forest_domain_ops().root_index() == 0 )
         return false;
     // 6. Registry domain root matches header root_offset
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
@@ -9353,7 +9369,8 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainSymbols, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, symbol_domain_root_offset_unlocked() ) )
+                                        detail::kForestBindingDirectRoot,
+                                        pstringview::forest_domain_ops().root_index() ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -3184,22 +3184,27 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 // ─── Forest-domain protocol ──────────────────────────────────────────────────
 
 template <typename Domain>
-concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
+concept ForestDomainViewDescriptor = requires( const Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
     { domain.name() } -> std::convertible_to<const char*>;
     { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
     { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey =
-    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
-        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+template <typename Domain>
+concept ForestDomainDescriptor =
+    ForestDomainViewDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p ) {
+        { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+        { domain.less_node( p, p ) } -> std::convertible_to<bool>;
     };
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = ForestDomainViewDescriptor<Domain> &&
+                                       requires( const Domain domain, typename Domain::node_pptr p, const Key& key ) {
+                                           { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+                                       };
 
 template <typename Domain>
 static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
@@ -3213,13 +3218,12 @@ static bool forest_domain_validate_node( const Domain& domain, typename Domain::
 }
 
 /**
- * @brief Generic AVL-backed forest-domain operations for a concrete descriptor.
+ * @brief Generic read-only AVL-backed forest-domain operations for a concrete descriptor.
  *
- * The descriptor is the canonical forest-domain protocol: domain identity, root
- * binding, node resolution, node ordering, optional external-key comparison,
- * and optional node validation.
+ * The view descriptor supplies domain identity, read-only root binding, node
+ * resolution, and optional external-key comparison.
  */
-template <ForestDomainDescriptor Domain> struct ForestDomainOps
+template <ForestDomainViewDescriptor Domain> struct ForestDomainViewOps
 {
     using index_type = typename Domain::index_type;
     using node_type  = typename Domain::node_type;
@@ -3227,20 +3231,10 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
 
     Domain domain;
 
-    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+    constexpr explicit ForestDomainViewOps( Domain d = Domain{} ) noexcept : domain( d ) {}
 
     const char* name() const noexcept { return domain.name(); }
     index_type  root_index() const noexcept { return domain.root_index(); }
-    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
-
-    bool reset_root() const noexcept
-    {
-        index_type* root = root_index_ptr();
-        if ( root == nullptr )
-            return false;
-        *root = static_cast<index_type>( 0 );
-        return true;
-    }
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
@@ -3250,17 +3244,52 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
             domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
             [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
+};
 
-    void insert( node_pptr new_node ) const noexcept
+/**
+ * @brief Generic mutable AVL-backed forest-domain operations for a concrete descriptor.
+ *
+ * The mutable descriptor adds root-slot access and node ordering. Mutation is
+ * intentionally kept off the const surface: callers that only have a const
+ * handle can read identity/root state and perform keyed lookup, but cannot
+ * obtain or rewrite the root slot.
+ */
+template <ForestDomainDescriptor Domain> struct ForestDomainOps : ForestDomainViewOps<Domain>
+{
+    using view_base  = ForestDomainViewOps<Domain>;
+    using index_type = typename view_base::index_type;
+    using node_type  = typename view_base::node_type;
+    using node_pptr  = typename view_base::node_pptr;
+
+    using view_base::find;
+    using view_base::name;
+    using view_base::root_index;
+
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : view_base( d ) {}
+
+    index_type* root_index_ptr() noexcept { return this->domain.root_index_ptr(); }
+
+    bool reset_root() noexcept
     {
-        index_type* root = domain.root_index_ptr();
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = this->domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
+        if ( this->domain.resolve_node( new_node ) == nullptr ||
+             !forest_domain_validate_node( this->domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
-            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
+            new_node, *root,
+            [this, new_node]( node_pptr cur ) -> bool { return this->domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return this->domain.resolve_node( p ); } );
     }
 };
 
@@ -6067,15 +6096,24 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         using node_type  = pmap_node<_K, _V>;
         using node_pptr  = typename ManagerT::template pptr<node_type>;
 
-        index_type* root_index_slot;
+        const index_type* root_index_slot;
+        index_type*       mutable_root_index_slot;
 
-        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( root )
+        {
+        }
+
+        constexpr explicit forest_domain_descriptor( const index_type* root ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( nullptr )
+        {
+        }
 
         static constexpr const char* name() noexcept { return "container/pmap"; }
 
         index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
 
-        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+        index_type* root_index_ptr() noexcept { return mutable_root_index_slot; }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
 
@@ -6097,7 +6135,8 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
     };
 
-    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+    using forest_domain_view_policy = detail::ForestDomainViewOps<forest_domain_descriptor>;
+    using forest_domain_policy      = detail::ForestDomainOps<forest_domain_descriptor>;
 
     /// @brief Sentinel value for "no node" in TreeNode fields.
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
@@ -6117,9 +6156,9 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
-    forest_domain_policy forest_domain_ops() const noexcept
+    forest_domain_view_policy forest_domain_view_ops() const noexcept
     {
-        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+        return forest_domain_view_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
     /// @brief Проверить, пуст ли словарь.
@@ -6188,7 +6227,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для поиска.
      * @return pptr на найденный узел, или нулевой pptr если не найден.
      */
-    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_view_ops().find( key ); }
 
     /**
      * @brief Проверить, содержит ли словарь заданный ключ.
@@ -6196,7 +6235,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
      * @param key Ключ для проверки.
      * @return true если ключ найден.
      */
-    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_view_ops().find( key ).is_null(); }
 
     /**
      * @brief Удалить узел по ключу.

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2001,22 +2001,27 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
 }
 
 template <typename Domain>
-concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
+concept ForestDomainViewDescriptor = requires( const Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
     { domain.name() } -> std::convertible_to<const char*>;
     { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
     { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey =
-    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
-        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+template <typename Domain>
+concept ForestDomainDescriptor =
+    ForestDomainViewDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p ) {
+        { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+        { domain.less_node( p, p ) } -> std::convertible_to<bool>;
     };
+
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey = ForestDomainViewDescriptor<Domain> &&
+                                       requires( const Domain domain, typename Domain::node_pptr p, const Key& key ) {
+                                           { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+                                       };
 
 template <typename Domain>
 static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
@@ -2029,7 +2034,7 @@ static bool forest_domain_validate_node( const Domain& domain, typename Domain::
         return true;
 }
 
-template <ForestDomainDescriptor Domain> struct ForestDomainOps
+template <ForestDomainViewDescriptor Domain> struct ForestDomainViewOps
 {
     using index_type = typename Domain::index_type;
     using node_type  = typename Domain::node_type;
@@ -2037,20 +2042,10 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
 
     Domain domain;
 
-    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+    constexpr explicit ForestDomainViewOps( Domain d = Domain{} ) noexcept : domain( d ) {}
 
     const char* name() const noexcept { return domain.name(); }
     index_type  root_index() const noexcept { return domain.root_index(); }
-    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
-
-    bool reset_root() const noexcept
-    {
-        index_type* root = root_index_ptr();
-        if ( root == nullptr )
-            return false;
-        *root = static_cast<index_type>( 0 );
-        return true;
-    }
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
@@ -2060,17 +2055,44 @@ template <ForestDomainDescriptor Domain> struct ForestDomainOps
             domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
             [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
+};
 
-    void insert( node_pptr new_node ) const noexcept
+template <ForestDomainDescriptor Domain> struct ForestDomainOps : ForestDomainViewOps<Domain>
+{
+    using view_base  = ForestDomainViewOps<Domain>;
+    using index_type = typename view_base::index_type;
+    using node_type  = typename view_base::node_type;
+    using node_pptr  = typename view_base::node_pptr;
+
+    using view_base::find;
+    using view_base::name;
+    using view_base::root_index;
+
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : view_base( d ) {}
+
+    index_type* root_index_ptr() noexcept { return this->domain.root_index_ptr(); }
+
+    bool reset_root() noexcept
     {
-        index_type* root = domain.root_index_ptr();
+        index_type* root = root_index_ptr();
+        if ( root == nullptr )
+            return false;
+        *root = static_cast<index_type>( 0 );
+        return true;
+    }
+
+    void insert( node_pptr new_node ) noexcept
+    {
+        index_type* root = this->domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
+        if ( this->domain.resolve_node( new_node ) == nullptr ||
+             !forest_domain_validate_node( this->domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
-            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
+            new_node, *root,
+            [this, new_node]( node_pptr cur ) -> bool { return this->domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return this->domain.resolve_node( p ); } );
     }
 };
 
@@ -3788,15 +3810,24 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         using node_type  = pmap_node<_K, _V>;
         using node_pptr  = typename ManagerT::template pptr<node_type>;
 
-        index_type* root_index_slot;
+        const index_type* root_index_slot;
+        index_type*       mutable_root_index_slot;
 
-        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( root )
+        {
+        }
+
+        constexpr explicit forest_domain_descriptor( const index_type* root ) noexcept
+            : root_index_slot( root ), mutable_root_index_slot( nullptr )
+        {
+        }
 
         static constexpr const char* name() noexcept { return "container/pmap"; }
 
         index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
 
-        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+        index_type* root_index_ptr() noexcept { return mutable_root_index_slot; }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
 
@@ -3818,7 +3849,8 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
     };
 
-    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+    using forest_domain_view_policy = detail::ForestDomainViewOps<forest_domain_descriptor>;
+    using forest_domain_policy      = detail::ForestDomainOps<forest_domain_descriptor>;
 
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
 
@@ -3831,9 +3863,9 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
-    forest_domain_policy forest_domain_ops() const noexcept
+    forest_domain_view_policy forest_domain_view_ops() const noexcept
     {
-        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+        return forest_domain_view_policy( forest_domain_descriptor( &_root_idx ) );
     }
 
     bool empty() const noexcept { return _root_idx == static_cast<index_type>( 0 ); }
@@ -3877,9 +3909,9 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         return new_node;
     }
 
-    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_view_ops().find( key ); }
 
-    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_view_ops().find( key ).is_null(); }
 
     bool erase( const _K& key ) noexcept
     {

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -2000,39 +2000,50 @@ static void avl_insert( PPtr new_node, IndexType& root_idx, GoLeftFn&& go_left, 
     avl_rebalance_up( parent, root_idx, update_node );
 }
 
-template <typename Domain, typename Key>
-concept ForestDomainDescriptorForKey = requires( typename Domain::node_pptr p, const Key& key ) {
+template <typename Domain>
+concept ForestDomainDescriptor = requires( Domain domain, typename Domain::node_pptr p ) {
     typename Domain::index_type;
     typename Domain::node_type;
     typename Domain::node_pptr;
-    { Domain::name() } -> std::convertible_to<const char*>;
-    { Domain::root_index() } -> std::convertible_to<typename Domain::index_type>;
-    { Domain::root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
-    { Domain::resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
-    { Domain::compare_key( key, p ) } -> std::convertible_to<int>;
-    { Domain::less_node( p, p ) } -> std::convertible_to<bool>;
+    { domain.name() } -> std::convertible_to<const char*>;
+    { domain.root_index() } -> std::convertible_to<typename Domain::index_type>;
+    { domain.root_index_ptr() } -> std::same_as<typename Domain::index_type*>;
+    { domain.resolve_node( p ) } -> std::convertible_to<typename Domain::node_type*>;
+    { domain.less_node( p, p ) } -> std::convertible_to<bool>;
 };
 
-template <typename Domain> static bool forest_domain_validate_node( typename Domain::node_pptr p ) noexcept
+template <typename Domain, typename Key>
+concept ForestDomainDescriptorForKey =
+    ForestDomainDescriptor<Domain> && requires( Domain domain, typename Domain::node_pptr p, const Key& key ) {
+        { domain.compare_key( key, p ) } -> std::convertible_to<int>;
+    };
+
+template <typename Domain>
+static bool forest_domain_validate_node( const Domain& domain, typename Domain::node_pptr p ) noexcept
 {
     if constexpr ( requires {
-                       { Domain::validate_node( p ) } -> std::convertible_to<bool>;
+                       { domain.validate_node( p ) } -> std::convertible_to<bool>;
                    } )
-        return Domain::validate_node( p );
+        return domain.validate_node( p );
     else
         return true;
 }
 
-template <typename Domain> struct ForestDomainOps
+template <ForestDomainDescriptor Domain> struct ForestDomainOps
 {
     using index_type = typename Domain::index_type;
+    using node_type  = typename Domain::node_type;
     using node_pptr  = typename Domain::node_pptr;
 
-    static constexpr const char* name() noexcept { return Domain::name(); }
-    static index_type            root_index() noexcept { return Domain::root_index(); }
-    static index_type*           root_index_ptr() noexcept { return Domain::root_index_ptr(); }
+    Domain domain;
 
-    static bool reset_root() noexcept
+    constexpr explicit ForestDomainOps( Domain d = Domain{} ) noexcept : domain( d ) {}
+
+    const char* name() const noexcept { return domain.name(); }
+    index_type  root_index() const noexcept { return domain.root_index(); }
+    index_type* root_index_ptr() const noexcept { return domain.root_index_ptr(); }
+
+    bool reset_root() const noexcept
     {
         index_type* root = root_index_ptr();
         if ( root == nullptr )
@@ -2043,23 +2054,23 @@ template <typename Domain> struct ForestDomainOps
 
     template <typename Key>
         requires ForestDomainDescriptorForKey<Domain, Key>
-    static node_pptr find( const Key& key ) noexcept
+    node_pptr find( const Key& key ) const noexcept
     {
         return avl_find<node_pptr>(
-            Domain::root_index(), [&]( node_pptr cur ) -> int { return Domain::compare_key( key, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            domain.root_index(), [&]( node_pptr cur ) -> int { return domain.compare_key( key, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 
-    static void insert( node_pptr new_node ) noexcept
+    void insert( node_pptr new_node ) const noexcept
     {
-        index_type* root = Domain::root_index_ptr();
+        index_type* root = domain.root_index_ptr();
         if ( root == nullptr || new_node.is_null() )
             return;
-        if ( Domain::resolve_node( new_node ) == nullptr || !forest_domain_validate_node<Domain>( new_node ) )
+        if ( domain.resolve_node( new_node ) == nullptr || !forest_domain_validate_node( domain, new_node ) )
             return;
         avl_insert(
-            new_node, *root, [new_node]( node_pptr cur ) -> bool { return Domain::less_node( new_node, cur ); },
-            []( node_pptr p ) -> typename Domain::node_type* { return Domain::resolve_node( p ); } );
+            new_node, *root, [this, new_node]( node_pptr cur ) -> bool { return domain.less_node( new_node, cur ); },
+            [this]( node_pptr p ) -> node_type* { return domain.resolve_node( p ); } );
     }
 };
 
@@ -3771,11 +3782,59 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     using node_type    = pmap_node<_K, _V>;
     using node_pptr    = typename ManagerT::template pptr<node_type>;
 
+    struct forest_domain_descriptor
+    {
+        using index_type = typename ManagerT::index_type;
+        using node_type  = pmap_node<_K, _V>;
+        using node_pptr  = typename ManagerT::template pptr<node_type>;
+
+        index_type* root_index_slot;
+
+        constexpr explicit forest_domain_descriptor( index_type* root = nullptr ) noexcept : root_index_slot( root ) {}
+
+        static constexpr const char* name() noexcept { return "container/pmap"; }
+
+        index_type root_index() const noexcept { return root_index_slot != nullptr ? *root_index_slot : 0; }
+
+        index_type* root_index_ptr() const noexcept { return root_index_slot; }
+
+        static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
+
+        static int compare_key( const _K& key, node_pptr cur ) noexcept
+        {
+            node_type* obj = resolve_node( cur );
+            if ( obj == nullptr )
+                return 0;
+            return ( key == obj->key ) ? 0 : ( ( key < obj->key ) ? -1 : 1 );
+        }
+
+        static bool less_node( node_pptr lhs, node_pptr rhs ) noexcept
+        {
+            node_type* lhs_obj = resolve_node( lhs );
+            node_type* rhs_obj = resolve_node( rhs );
+            return lhs_obj != nullptr && rhs_obj != nullptr && lhs_obj->key < rhs_obj->key;
+        }
+
+        static bool validate_node( node_pptr p ) noexcept { return resolve_node( p ) != nullptr; }
+    };
+
+    using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
     static constexpr index_type no_block = ManagerT::address_traits::no_block;
 
     index_type _root_idx;
 
     pmap() noexcept : _root_idx( static_cast<index_type>( 0 ) ) {}
+
+    forest_domain_policy forest_domain_ops() noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( &_root_idx ) );
+    }
+
+    forest_domain_policy forest_domain_ops() const noexcept
+    {
+        return forest_domain_policy( forest_domain_descriptor( const_cast<index_type*>( &_root_idx ) ) );
+    }
 
     bool empty() const noexcept { return _root_idx == static_cast<index_type>( 0 ); }
 
@@ -3788,8 +3847,9 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
 
     node_pptr insert( const _K& key, const _V& val ) noexcept
     {
+        auto ops = forest_domain_ops();
 
-        node_pptr existing = _avl_find( key );
+        node_pptr existing = ops.find( key );
         if ( !existing.is_null() )
         {
 
@@ -3812,18 +3872,18 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
 
         detail::avl_init_node( new_node );
 
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
 
-    node_pptr find( const _K& key ) const noexcept { return _avl_find( key ); }
+    node_pptr find( const _K& key ) const noexcept { return forest_domain_ops().find( key ); }
 
-    bool contains( const _K& key ) const noexcept { return !_avl_find( key ).is_null(); }
+    bool contains( const _K& key ) const noexcept { return !forest_domain_ops().find( key ).is_null(); }
 
     bool erase( const _K& key ) noexcept
     {
-        node_pptr target = _avl_find( key );
+        node_pptr target = forest_domain_ops().find( key );
         if ( target.is_null() )
             return false;
 
@@ -3840,7 +3900,7 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
         _root_idx = static_cast<index_type>( 0 );
     }
 
-    void reset() noexcept { _root_idx = static_cast<index_type>( 0 ); }
+    void reset() noexcept { forest_domain_ops().reset_root(); }
 
     using iterator = detail::AvlInorderIterator<node_pptr>;
 
@@ -3853,38 +3913,6 @@ template <typename _K, typename _V, typename ManagerT> struct pmap
     }
 
     iterator end() const noexcept { return iterator( static_cast<index_type>( 0 ) ); }
-
-  private:
-
-    node_pptr _avl_find( const _K& key ) const noexcept
-    {
-        return detail::avl_find<node_pptr>(
-            _root_idx,
-            [&]( node_pptr cur ) -> int
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                if ( obj == nullptr )
-                    return 0;
-                if ( key == obj->key )
-                    return 0;
-                return ( key < obj->key ) ? -1 : 1;
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
-    void _avl_insert( node_pptr new_node ) noexcept
-    {
-        node_type* new_obj = ManagerT::template resolve<node_type>( new_node );
-        detail::avl_insert(
-            new_node, _root_idx,
-            [&]( node_pptr cur ) -> bool
-            {
-                node_type* obj = ManagerT::template resolve<node_type>( cur );
-                return ( obj != nullptr ) && ( new_obj->key < obj->key );
-            },
-            []( node_pptr p ) -> node_type* { return ManagerT::template resolve<node_type>( p ); } );
-    }
-
 };
 
 }
@@ -4355,13 +4383,13 @@ template <typename ManagerT> struct pstringview
         static index_type root_index() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? domain->root_offset : static_cast<index_type>( 0 );
+            return ManagerT::forest_domain_root_index_unlocked( domain );
         }
 
         static index_type* root_index_ptr() noexcept
         {
             auto* domain = ManagerT::symbol_domain_record_unlocked();
-            return ( domain != nullptr ) ? &domain->root_offset : nullptr;
+            return ManagerT::forest_domain_root_index_ptr_unlocked( domain );
         }
 
         static node_type* resolve_node( node_pptr p ) noexcept { return ManagerT::template resolve<node_type>( p ); }
@@ -4385,6 +4413,8 @@ template <typename ManagerT> struct pstringview
     };
 
     using forest_domain_policy = detail::ForestDomainOps<forest_domain_descriptor>;
+
+    static forest_domain_policy forest_domain_ops() noexcept { return forest_domain_policy{}; }
 
     std::uint32_t length;
     char          str[1];
@@ -4430,7 +4460,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return;
         typename ManagerT::thread_policy::unique_lock_type lock( ManagerT::_mutex );
-        forest_domain_policy::reset_root();
+        forest_domain_ops().reset_root();
     }
 
     static index_type root_index() noexcept
@@ -4438,7 +4468,7 @@ template <typename ManagerT> struct pstringview
         if ( !ManagerT::is_initialized() )
             return static_cast<index_type>( 0 );
         typename ManagerT::thread_policy::shared_lock_type lock( ManagerT::_mutex );
-        return forest_domain_policy::root_index();
+        return forest_domain_ops().root_index();
     }
 
     ~pstringview() = default;
@@ -4451,7 +4481,9 @@ template <typename ManagerT> struct pstringview
         if ( s == nullptr )
             s = "";
 
-        psview_pptr found = _avl_find( s );
+        auto ops = forest_domain_ops();
+
+        psview_pptr found = ops.find( s );
         if ( !found.is_null() )
             return found;
 
@@ -4500,14 +4532,10 @@ template <typename ManagerT> struct pstringview
 
         ManagerT::lock_block_permanent( obj );
 
-        _avl_insert( new_node );
+        ops.insert( new_node );
 
         return new_node;
     }
-
-    static psview_pptr _avl_find( const char* s ) noexcept { return forest_domain_policy::find( s ); }
-
-    static void _avl_insert( psview_pptr new_node ) noexcept { forest_domain_policy::insert( new_node ); }
 };
 
 }
@@ -5183,7 +5211,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_legacy_root_offset_unlocked( p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+                                               p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
     template <typename T> static pptr<T> get_root() noexcept
@@ -5191,7 +5220,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root = get_legacy_root_offset_unlocked();
+        index_type legacy_root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
         if ( legacy_root == static_cast<index_type>( 0 ) )
             return pptr<T>();
         return pptr<T>( legacy_root );
@@ -5245,7 +5275,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_name_unlocked( name );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( index_type binding_id ) noexcept
@@ -5254,7 +5284,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_binding_unlocked( binding_id );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     static index_type get_domain_root_offset( pptr<pstringview> symbol ) noexcept
@@ -5263,7 +5293,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return 0;
         const forest_domain* rec = find_domain_by_symbol_unlocked( symbol );
-        return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+        return forest_domain_root_index_unlocked( rec );
     }
 
     template <typename T> static pptr<T> get_domain_root( const char* name ) noexcept
@@ -5290,10 +5320,8 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         if ( !_initialized )
             return false;
         forest_domain* rec = find_domain_by_name_unlocked( name );
-        if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
-            return false;
-        rec->root_offset = root.is_null() ? static_cast<index_type>( 0 ) : root.offset();
-        return true;
+        return set_forest_domain_root_index_unlocked( rec,
+                                                      root.is_null() ? static_cast<index_type>( 0 ) : root.offset() );
     }
 
   private:
@@ -5732,9 +5760,10 @@ static forest_domain* find_domain_by_symbol_unlocked( pptr<pstringview> symbol )
     return nullptr;
 }
 
-static index_type domain_root_offset_unlocked( const forest_domain*                         rec,
-                                               const detail::ManagerHeader<address_traits>* hdr ) noexcept
+static index_type forest_domain_root_index_unlocked( const forest_domain* rec ) noexcept
 {
+    const detail::ManagerHeader<address_traits>* hdr =
+        ( _backend.base_ptr() != nullptr ) ? get_header_c( _backend.base_ptr() ) : nullptr;
     if ( rec == nullptr || hdr == nullptr )
         return 0;
     if ( rec->binding_kind == detail::kForestBindingFreeTree )
@@ -5742,28 +5771,25 @@ static index_type domain_root_offset_unlocked( const forest_domain*             
     return rec->root_offset;
 }
 
-static index_type get_legacy_root_offset_unlocked() noexcept
+static index_type* forest_domain_root_index_ptr_unlocked( forest_domain* rec ) noexcept
 {
-    const forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    return domain_root_offset_unlocked( rec, get_header_c( _backend.base_ptr() ) );
+    if ( rec == nullptr || rec->binding_kind != detail::kForestBindingDirectRoot )
+        return nullptr;
+    return &rec->root_offset;
 }
 
-static void set_legacy_root_offset_unlocked( index_type off ) noexcept
+static bool set_forest_domain_root_index_unlocked( forest_domain* rec, index_type root ) noexcept
 {
-    forest_domain* rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( rec != nullptr && rec->binding_kind == detail::kForestBindingDirectRoot )
-        rec->root_offset = off;
+    index_type* root_ptr = forest_domain_root_index_ptr_unlocked( rec );
+    if ( root_ptr == nullptr )
+        return false;
+    *root_ptr = root;
+    return true;
 }
 
 static forest_domain* symbol_domain_record_unlocked() noexcept
 {
     return find_domain_by_name_unlocked( detail::kSystemDomainSymbols );
-}
-
-static index_type symbol_domain_root_offset_unlocked() noexcept
-{
-    forest_domain* rec = symbol_domain_record_unlocked();
-    return ( rec != nullptr ) ? rec->root_offset : static_cast<index_type>( 0 );
 }
 
 static bool register_domain_unlocked( const char* name, std::uint8_t flags, std::uint8_t binding_kind,
@@ -5818,11 +5844,11 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( s == nullptr )
         s = "";
 
-    using symbol_policy = typename pstringview::forest_domain_policy;
-    if ( symbol_policy::root_index_ptr() == nullptr )
+    auto symbol_policy = pstringview::forest_domain_ops();
+    if ( symbol_policy.root_index_ptr() == nullptr )
         return pptr<pstringview>();
 
-    pptr<pstringview> found = symbol_policy::find( s );
+    pptr<pstringview> found = symbol_policy.find( s );
     if ( !found.is_null() )
         return found;
 
@@ -5848,7 +5874,7 @@ static pptr<pstringview> intern_symbol_unlocked( const char* s ) noexcept
     if ( !lock_block_permanent_unlocked( public_raw ) )
         return pptr<pstringview>();
 
-    symbol_policy::insert( new_node );
+    symbol_policy.insert( new_node );
 
     return new_node;
 }
@@ -6007,7 +6033,7 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     if ( free_rec->binding_kind != detail::kForestBindingFreeTree )
         return false;
 
-    if ( symbol_domain_root_offset_unlocked() == 0 )
+    if ( pstringview::forest_domain_ops().root_index() == 0 )
         return false;
 
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
@@ -6034,7 +6060,8 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainSymbols, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, symbol_domain_root_offset_unlocked() ) )
+                                        detail::kForestBindingDirectRoot,
+                                        pstringview::forest_domain_ops().root_index() ) )
             return false;
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )

--- a/tests/test_issue151_pstringview.cpp
+++ b/tests/test_issue151_pstringview.cpp
@@ -310,6 +310,7 @@ TEST_CASE( "    forest-domain descriptor drives symbol dictionary", "[test_issue
 {
     using Domain = TestPsv::forest_domain_descriptor;
     static_assert( pmm::detail::ForestDomainDescriptor<Domain> );
+    static_assert( pmm::detail::ForestDomainViewDescriptor<Domain> );
     static_assert( pmm::detail::ForestDomainDescriptorForKey<Domain, const char*> );
 
     TestMgr::destroy();

--- a/tests/test_issue151_pstringview.cpp
+++ b/tests/test_issue151_pstringview.cpp
@@ -309,6 +309,7 @@ TEST_CASE( "    AVL root tracked by persistent symbol domain", "[test_issue151_p
 TEST_CASE( "    forest-domain descriptor drives symbol dictionary", "[test_issue151_pstringview]" )
 {
     using Domain = TestPsv::forest_domain_descriptor;
+    static_assert( pmm::detail::ForestDomainDescriptor<Domain> );
     static_assert( pmm::detail::ForestDomainDescriptorForKey<Domain, const char*> );
 
     TestMgr::destroy();
@@ -324,9 +325,10 @@ TEST_CASE( "    forest-domain descriptor drives symbol dictionary", "[test_issue
     TestMgr_pptr_psv beta  = TestMgr::pstringview( "descriptor_beta" );
     REQUIRE( ( !alpha.is_null() && !beta.is_null() ) );
 
-    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_alpha" ) == alpha );
-    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_beta" ) == beta );
-    REQUIRE( TestPsv::forest_domain_policy::find( "descriptor_missing" ).is_null() );
+    auto ops = TestPsv::forest_domain_ops();
+    REQUIRE( ops.find( "descriptor_alpha" ) == alpha );
+    REQUIRE( ops.find( "descriptor_beta" ) == beta );
+    REQUIRE( ops.find( "descriptor_missing" ).is_null() );
     REQUIRE( Domain::validate_node( alpha ) );
     REQUIRE( *Domain::root_index_ptr() == TestPsv::root_index() );
 

--- a/tests/test_issue153_pmap.cpp
+++ b/tests/test_issue153_pmap.cpp
@@ -78,6 +78,40 @@ TEST_CASE( "    insert single key-value pair", "[test_issue153_pmap]" )
     TestMgr::destroy();
 }
 
+/// @brief pmap exposes the same minimal forest-domain descriptor/ops contract as other AVL-backed domains.
+TEST_CASE( "    forest-domain descriptor drives pmap dictionary", "[test_issue153_pmap][issue335]" )
+{
+    using Map    = TestMgr::pmap<int, int>;
+    using Domain = Map::forest_domain_descriptor;
+    static_assert( pmm::detail::ForestDomainDescriptor<Domain> );
+    static_assert( pmm::detail::ForestDomainDescriptorForKey<Domain, int> );
+
+    TestMgr::destroy();
+    REQUIRE( TestMgr::create( 64 * 1024 ) );
+
+    Map  map;
+    auto ops = map.forest_domain_ops();
+
+    REQUIRE( std::strcmp( ops.name(), "container/pmap" ) == 0 );
+    REQUIRE( ops.root_index() == static_cast<TestMgr::index_type>( 0 ) );
+    REQUIRE( ops.root_index_ptr() == &map._root_idx );
+
+    auto p10 = map.insert( 10, 100 );
+    auto p20 = map.insert( 20, 200 );
+    REQUIRE( ( !p10.is_null() && !p20.is_null() ) );
+
+    REQUIRE( ops.root_index() != static_cast<TestMgr::index_type>( 0 ) );
+    REQUIRE( ops.find( 10 ) == p10 );
+    REQUIRE( ops.find( 20 ) == p20 );
+    REQUIRE( ops.find( 30 ).is_null() );
+
+    REQUIRE( ops.reset_root() );
+    REQUIRE( map.empty() );
+    REQUIRE( ops.root_index() == static_cast<TestMgr::index_type>( 0 ) );
+
+    TestMgr::destroy();
+}
+
 /// @brief insert() with multiple distinct keys.
 TEST_CASE( "    insert multiple distinct keys", "[test_issue153_pmap]" )
 {

--- a/tests/test_issue153_pmap.cpp
+++ b/tests/test_issue153_pmap.cpp
@@ -52,6 +52,21 @@
 
 using TestMgr = pmm::PersistMemoryManager<pmm::CacheManagerConfig, 153>;
 
+template <typename MapT>
+concept HasConstForestDomainOps = requires( const MapT& const_map ) { const_map.forest_domain_ops(); };
+
+template <typename MapT>
+concept HasConstForestDomainViewOps = requires( const MapT& const_map ) { const_map.forest_domain_view_ops(); };
+
+template <typename OpsT, typename NodePPtr>
+concept HasConstForestDomainInsert = requires( const OpsT& ops, NodePPtr node ) { ops.insert( node ); };
+
+template <typename OpsT>
+concept HasConstForestDomainResetRoot = requires( const OpsT& ops ) { ops.reset_root(); };
+
+template <typename OpsT>
+concept HasConstForestDomainRootIndexPtr = requires( const OpsT& ops ) { ops.root_index_ptr(); };
+
 // =============================================================================
 // I153-A: Basic insert and find with int keys
 // =============================================================================
@@ -84,7 +99,13 @@ TEST_CASE( "    forest-domain descriptor drives pmap dictionary", "[test_issue15
     using Map    = TestMgr::pmap<int, int>;
     using Domain = Map::forest_domain_descriptor;
     static_assert( pmm::detail::ForestDomainDescriptor<Domain> );
+    static_assert( pmm::detail::ForestDomainViewDescriptor<Domain> );
     static_assert( pmm::detail::ForestDomainDescriptorForKey<Domain, int> );
+    static_assert( !HasConstForestDomainOps<Map> );
+    static_assert( HasConstForestDomainViewOps<Map> );
+    static_assert( !HasConstForestDomainInsert<Map::forest_domain_policy, Map::node_pptr> );
+    static_assert( !HasConstForestDomainResetRoot<Map::forest_domain_policy> );
+    static_assert( !HasConstForestDomainRootIndexPtr<Map::forest_domain_policy> );
 
     TestMgr::destroy();
     REQUIRE( TestMgr::create( 64 * 1024 ) );
@@ -104,6 +125,15 @@ TEST_CASE( "    forest-domain descriptor drives pmap dictionary", "[test_issue15
     REQUIRE( ops.find( 10 ) == p10 );
     REQUIRE( ops.find( 20 ) == p20 );
     REQUIRE( ops.find( 30 ).is_null() );
+
+    const Map& const_map = map;
+    auto       view_ops  = const_map.forest_domain_view_ops();
+    REQUIRE( std::strcmp( view_ops.name(), "container/pmap" ) == 0 );
+    REQUIRE( view_ops.root_index() == ops.root_index() );
+    REQUIRE( view_ops.find( 10 ) == p10 );
+    REQUIRE( view_ops.find( 20 ) == p20 );
+    REQUIRE( const_map.find( 10 ) == p10 );
+    REQUIRE( const_map.contains( 20 ) );
 
     REQUIRE( ops.reset_root() );
     REQUIRE( map.empty() );

--- a/tests/test_issue162_deduplication.cpp
+++ b/tests/test_issue162_deduplication.cpp
@@ -4,8 +4,8 @@
  *
  * Проверяет:
  *   - detail::avl_find() — новая обобщённая функция поиска в AVL-дереве
- *   - pstringview::_avl_find() делегирует в detail::avl_find()
- *   - pmap::_avl_find() делегирует в detail::avl_find()
+ *   - pstringview forest-domain ops delegate to detail::avl_find()
+ *   - pmap forest-domain ops delegate to detail::avl_find()
  *   - Корректность поиска в pstringview после рефакторинга
  *   - Корректность поиска в pmap после рефакторинга
  *   - Поиск несуществующих ключей возвращает null pptr
@@ -247,7 +247,7 @@ TEST_CASE( "I162-B5: pmap::contains() consistent with find()", "[test_issue162_d
 TEST_CASE( "I162-C1: detail::avl_find() template available and correct", "[test_issue162_deduplication]" )
 {
     // Verify that detail::avl_find() compiles and can be instantiated.
-    // We use a pmap to test it indirectly since pmap::_avl_find() delegates to it.
+    // We use a pmap to test it indirectly since pmap forest-domain ops delegate to it.
     TestMgr::create( 64 * 1024 );
 
     TestMgr::pmap<int, int> map;
@@ -271,7 +271,7 @@ TEST_CASE( "I162-C1: detail::avl_find() template available and correct", "[test_
     TestMgr::destroy();
 }
 
-/// @brief Both pstringview and pmap use detail::avl_find() from avl_tree_mixin.h.
+/// @brief Both pstringview and pmap use detail::avl_find() through forest-domain ops.
 ///        This test verifies that the shared helper works correctly for both users.
 TEST_CASE( "I162-C2: detail::avl_find() shared correctly by pstringview and pmap", "[test_issue162_deduplication]" )
 {


### PR DESCRIPTION
## Summary
- Make the forest-domain contract explicit with a read-only `ForestDomainViewDescriptor`/`ForestDomainViewOps` surface and a mutable `ForestDomainDescriptor`/`ForestDomainOps` surface.
- Keep `find`, `root_index`, and `name` available from const contexts while restricting `root_index_ptr`, `insert`, and `reset_root` to mutable handles.
- Remove `pmap::forest_domain_ops() const` and the `_root_idx` `const_cast`; `const pmap` now exposes only `forest_domain_view_ops()` plus normal read APIs (`find`, `contains`).
- Move `pmap` onto the same forest-domain protocol as `pstringview`, including keyed lookup through `compare_key(key, node_pptr)`.
- Route `pstringview/system/symbols`, symbol bootstrap interning, public legacy root access, and public domain-root access through the canonical forest-domain root-index helpers.
- Refresh generated single-header outputs and update the changelog fragment.

Fixes netkeep80/PersistMemoryManager#335

## Removed duplicate paths
- Removed `pmap::_avl_find()` and `pmap::_avl_insert()` as local wrappers around raw AVL helpers.
- Removed `pstringview::_avl_find()` and `pstringview::_avl_insert()` as local wrappers around `ForestDomainOps`.
- Removed `get_legacy_root_offset_unlocked()`, `set_legacy_root_offset_unlocked()`, and `symbol_domain_root_offset_unlocked()` in favor of `forest_domain_root_index_unlocked()`, `forest_domain_root_index_ptr_unlocked()`, and `set_forest_domain_root_index_unlocked()`.
- Removed comments that described the old `_avl_find()` helper path as canonical test intent.

## Canonical protocol
Read-only descriptor/view core:
- `name()`
- `root_index()`
- `resolve_node(node_pptr)`
- optional `compare_key(key, node_pptr)` for keyed lookup

Mutable descriptor/ops core:
- `root_index_ptr()`
- `less_node(lhs, rhs)`
- optional `validate_node(node_pptr)`
- `insert(node)`
- `reset_root()`

## Const-correctness
- `ForestDomainOps::insert`, `ForestDomainOps::reset_root`, and `ForestDomainOps::root_index_ptr` are no longer `const` methods.
- `pmap::forest_domain_descriptor` keeps separate read and mutable root slots; descriptors created from `const pmap` have no mutable root slot.
- `tests/test_issue153_pmap.cpp` statically asserts that `const pmap` cannot call `forest_domain_ops()` and that const policy handles cannot call `insert`, `reset_root`, or `root_index_ptr`.

## Line-count impact
Hand-written core include files changed by net +56 lines:
- `include/pmm/avl_tree_mixin.h`: +40
- `include/pmm/forest_domain_mixin.inc`: -3
- `include/pmm/persist_memory_manager.h`: 0
- `include/pmm/pmap.h`: +23
- `include/pmm/pstringview.h`: -4

The additional lines are mostly the explicit read-only/mutable split requested in PR feedback. The duplicate helper paths listed above remain removed.

## Reproduction
Added `forest-domain descriptor drives pmap dictionary` in `tests/test_issue153_pmap.cpp`.

Before the original implementation, `cmake --build build --target test_issue153_pmap` failed to compile because `Map::forest_domain_descriptor` and `map.forest_domain_ops()` did not exist.

Before the const-correctness follow-up, the added static assertions failed because `const pmap` exposed `forest_domain_ops()` and `const ForestDomainOps` still allowed `insert`, `reset_root`, and `root_index_ptr`.

## Verification
- `cmake --build build --target test_issue153_pmap test_issue151_pstringview test_issue162_deduplication test_forest_registry`
- `./build/tests/test_issue153_pmap` (268 assertions, 16 test cases)
- `./build/tests/test_issue151_pstringview` (439 assertions, 26 test cases)
- `./build/tests/test_issue162_deduplication` (117 assertions, 11 test cases)
- `./build/tests/test_forest_registry` (75 assertions, 3 test cases)
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (92/92 passed)
- `clang-format --dry-run --Werror` on touched source/test files
- `bash scripts/check-file-size.sh`
- `GITHUB_BASE_REF=main bash scripts/check-changelog-fragment.sh`
- `bash scripts/check-docs-consistency.sh`
- `bash scripts/check-repo-guard-rollout.sh`
- `git diff --check`
- `bash scripts/generate-single-headers.sh --strip-comments --output-dir /tmp/generated-pmm-issue335-final` plus `diff -q` against committed generated headers

## Local notes
- `cppcheck` was not available in this runner (`cppcheck: command not found`), so local cppcheck was not run.
- Direct local `bash scripts/check-version-consistency.sh` reports the existing release-owned README badge mismatch (`0.55.12` vs `0.57.7`). The GitHub workflow skips that check for this PR because no release-owned paths changed.