### PR TITLE
Roll out repo-guard size rules

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@c8491872866c33e0ecd04f809dcfd0489047d13f
+        uses: netkeep80/repo-guard@7ab5ca2f2d9859b4ffa2c423f05e951d4971be84
         with:
           mode: check-pr
           enforcement: advisory

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T18:37:15.567Z for PR creation at branch issue-341-d8c8f162b5ae for issue https://github.com/netkeep80/PersistMemoryManager/issues/341

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T18:37:15.567Z for PR creation at branch issue-341-d8c8f162b5ae for issue https://github.com/netkeep80/PersistMemoryManager/issues/341

--- a/changelog.d/20260420_190000_repo_guard_size_rules.md
+++ b/changelog.d/20260420_190000_repo_guard_size_rules.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Rolled repo-guard forward to the size-rules baseline and added canonical kernel anti-bloat policy caps.

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -55,6 +55,14 @@
     "max_new_files": 3,
     "max_net_added_lines": 35
   },
+  "size_rules": [
+    {"id": "kernel-persist-memory-manager-max-lines", "scope": "file", "metric": "lines", "glob": "include/pmm/persist_memory_manager.h", "max": 1146, "count": "all_tracked"},
+    {"id": "kernel-block-state-max-lines", "scope": "file", "metric": "lines", "glob": "include/pmm/block_state.h", "max": 873, "count": "all_tracked"},
+    {"id": "kernel-allocator-policy-max-lines", "scope": "file", "metric": "lines", "glob": "include/pmm/allocator_policy.h", "max": 777, "count": "all_tracked"},
+    {"id": "kernel-avl-tree-mixin-max-lines", "scope": "file", "metric": "lines", "glob": "include/pmm/avl_tree_mixin.h", "max": 761, "count": "all_tracked"},
+    {"id": "kernel-types-max-lines", "scope": "file", "metric": "lines", "glob": "include/pmm/types.h", "max": 674, "count": "all_tracked"},
+    {"id": "kernel-subtree-max-lines", "scope": "directory", "metric": "lines", "glob": "include/pmm/**", "max": 10768, "count": "all_tracked"}
+  ],
   "surfaces": {
     "kernel": ["include/**", "CMakeLists.txt"],
     "tests": ["tests/**"],
@@ -128,7 +136,7 @@
   "change_type_rules": {
     "governance": {
       "forbid_surfaces": ["kernel", "generated"],
-      "max_new_docs": 0,
+      "max_new_docs": 1,
       "max_new_files": 1,
       "max_net_added_lines": 80
     },

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -16,7 +16,15 @@ policy_path = pathlib.Path(sys.argv[2])
 workflow = workflow_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-expected_action = "netkeep80/repo-guard@c8491872866c33e0ecd04f809dcfd0489047d13f"
+expected_action = "netkeep80/repo-guard@7ab5ca2f2d9859b4ffa2c423f05e951d4971be84"
+expected_size_rules = [
+    ("kernel-persist-memory-manager-max-lines", "file", "lines", "include/pmm/persist_memory_manager.h", 1146),
+    ("kernel-block-state-max-lines", "file", "lines", "include/pmm/block_state.h", 873),
+    ("kernel-allocator-policy-max-lines", "file", "lines", "include/pmm/allocator_policy.h", 777),
+    ("kernel-avl-tree-mixin-max-lines", "file", "lines", "include/pmm/avl_tree_mixin.h", 761),
+    ("kernel-types-max-lines", "file", "lines", "include/pmm/types.h", 674),
+    ("kernel-subtree-max-lines", "directory", "lines", "include/pmm/**", 10768),
+]
 required_governance_paths = {
     ".github/workflows/repo-guard.yml",
     ".github/workflows/docs-consistency.yml",
@@ -56,6 +64,52 @@ checks = [
 
 policy_mode = policy.get("enforcement", {}).get("mode")
 checks.append((policy_mode == "advisory", "repo-policy.json must default to advisory enforcement"))
+
+size_rules = policy.get("size_rules", [])
+checks.append((isinstance(size_rules, list) and size_rules, "repo-policy.json must define size_rules"))
+
+rules_by_id = {
+    rule.get("id"): rule
+    for rule in size_rules
+    if isinstance(rule, dict) and isinstance(rule.get("id"), str)
+}
+
+for rule_id, scope, metric, glob, max_size in expected_size_rules:
+    rule = rules_by_id.get(rule_id)
+    checks.append((rule is not None, f"size_rules must include {rule_id}"))
+    if not rule:
+        continue
+    for field, expected_value in {
+        "scope": scope,
+        "metric": metric,
+        "glob": glob,
+        "max": max_size,
+    }.items():
+        checks.append(
+            (
+                rule.get(field) == expected_value,
+                f"{rule_id} must set {field}={expected_value!r}",
+            )
+        )
+    checks.append(
+        (
+            rule.get("count", "all_tracked") == "all_tracked",
+            f"{rule_id} must measure all tracked files, not only changed files",
+        )
+    )
+    checks.append(
+        (
+            rule.get("level", "blocking") == "blocking",
+            f"{rule_id} must remain blocking-ready for the later enforcement switch",
+        )
+    )
+
+checks.append(
+    (
+        not any("single_include/" in str(rule.get("glob", "")) for rule in size_rules if isinstance(rule, dict)),
+        "size_rules must target canonical include/pmm/**, not generated single_include/**",
+    )
+)
 
 governance_paths = set(policy.get("paths", {}).get("governance_paths", []))
 missing_governance = sorted(required_governance_paths - governance_paths)


### PR DESCRIPTION
## Summary
- Update the repo-guard workflow pin to `netkeep80/repo-guard@7ab5ca2f2d9859b4ffa2c423f05e951d4971be84`, the upstream commit that adds `size_rules` support.
- Add calibrated `size_rules` for canonical PMM kernel source: five large `include/pmm/*.h` hotspot caps and one aggregate `include/pmm/**` subtree cap.
- Update `scripts/check-repo-guard-rollout.sh` so the rollout cannot silently regress to the old action pin or lose the size-rule layer.
- Keep the rollout advisory at workflow/policy level while leaving the individual size rules blocking-ready for the later enforcement switch.
- Allow the already-permitted governance release fragment through `change_type_rules.governance.max_new_docs` without allowing new canonical docs.

Fixes netkeep80/PersistMemoryManager#341

## Change Contract

```repo-guard-yaml
change_type: governance
change_class: governance
scope:
  - .github/workflows/repo-guard.yml
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
  - changelog.d/20260420_190000_repo_guard_size_rules.md
budgets:
  max_new_files: 1
  max_new_docs: 1
  max_net_added_lines: 80
anchors:
  affects:
    - repo-guard
    - size_rules
    - include/pmm
must_touch:
  - repo-policy.json
  - scripts/check-repo-guard-rollout.sh
must_not_touch:
  - include/**
  - single_include/**
expected_effects:
  - PMM uses a pinned repo-guard revision with size_rules support.
  - Canonical include/pmm kernel line-count growth is guarded while single_include remains generated output, not the anti-bloat source of truth.
```

## Reproduction
- Hardened `scripts/check-repo-guard-rollout.sh` first, then ran it against the old branch state.
- It failed on the old repo-guard pin and missing `size_rules`, which reproduced the rollout gap this issue describes.

## Verification
- `bash scripts/check-repo-guard-rollout.sh`
- `bash scripts/check-docs-consistency.sh`
- `python3 -m json.tool repo-policy.json`
- `GITHUB_BASE_REF=main bash scripts/check-changelog-fragment.sh`
- `node /tmp/repo-guard-pC52oj/src/repo-guard.mjs --repo-root . --enforcement blocking check-diff --base origin/main --head HEAD --contract /tmp/pmm-issue341-contract.json --format summary` (15 passed, 0 failed)
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (92/92 passed)
- tracked source file-size check (`<=1500` lines)
- `git diff --check origin/main...HEAD`

## Local notes
- Local `clang-format` 22 reports pre-existing formatting differences in untouched C++ files; this PR does not change C++ source.
- `cppcheck` is not installed in this runner, so local cppcheck was not run.
