### PR TITLE
refactor: remove legacy-root migration and simplify forest registry (#339)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T22:12:20.191Z for PR creation at branch issue-339-e35548453f6c for issue https://github.com/netkeep80/PersistMemoryManager/issues/339

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T22:12:20.191Z for PR creation at branch issue-339-e35548453f6c for issue https://github.com/netkeep80/PersistMemoryManager/issues/339

--- a/changelog.d/20260420_222500_issue339_remove_legacy_root.md
+++ b/changelog.d/20260420_222500_issue339_remove_legacy_root.md
@@ -1,0 +1,25 @@
+---
+bump: major
+---
+
+### Removed
+- `pmm::detail::kServiceNameLegacyRoot` service domain constant.
+- `service/legacy_root` domain record from the forest registry bootstrap.
+- `reserved_root_offset` field from `ForestDomainRegistry`.
+- Legacy-root migration branch in `validate_or_bootstrap_forest_registry_unlocked()`
+  that reconstructed a registry from a pre-registry `hdr->root_offset`.
+- `create_forest_registry_root_unlocked( legacy_root_offset )` helper
+  (folded into `bootstrap_forest_registry_unlocked()`).
+
+### Changed
+- `set_root`/`get_root` now back onto the canonical `service/domain_root`
+  registry record instead of the removed `service/legacy_root`.
+- `validate_bootstrap_invariants_unlocked()` now requires `service/domain_root`
+  to be present and drops the `reserved_root_offset == 0` assertion.
+- Persisted `ForestDomainRegistry` layout changed
+  (`reserved_root_offset` removed); old images are not migrated.
+
+### Notes
+- Breaking change: images created before this revision cannot be loaded.
+  The compatibility audit entry for `legacy_root_offset` is deleted and
+  replaced by a note on the canonical `service/domain_root` record.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -48,19 +48,19 @@ structure. This is a persistent, locked block containing:
 - Magic: `0x50465247` ("PFRG")
 - Version: 1
 - Up to 32 domain slots
-- Legacy root offset (0 for fresh images)
 
 The registry's granule index is stored in `hdr->root_offset`.
 
 ### Step 4: System Domain Registration
 
-Three system domains are registered in the forest registry:
+Four system domains are registered in the forest registry:
 
 | Domain Name              | Binding Kind       | Flags  | Purpose                    |
 |--------------------------|--------------------|--------|----------------------------|
 | `system/free_tree`       | `kForestBindingFreeTree` | System | Free block AVL tree        |
 | `system/symbols`         | `kForestBindingDirectRoot` | System | pstringview symbol dictionary |
 | `system/domain_registry` | `kForestBindingDirectRoot` | System | Self-reference to registry |
+| `service/domain_root`    | `kForestBindingDirectRoot` | System | Single-root backing for `set_root`/`get_root` |
 
 Each domain receives a unique, monotonically increasing `binding_id`.
 
@@ -75,7 +75,6 @@ persistent symbol dictionary (pstringview AVL tree):
 - `type/forest_registry`
 - `type/forest_domain_record`
 - `type/pstringview`
-- `service/legacy_root`
 - `service/domain_root`
 - `service/domain_symbol`
 
@@ -131,9 +130,7 @@ When an existing image is loaded via `load()`:
    (`validate_or_bootstrap_forest_registry_unlocked`):
    - If valid registry found: re-registers system domains, ensures symbols
      populated.
-   - If legacy root found (pre-registry image): creates new registry,
-     preserves legacy root.
-   - If neither: creates fresh registry.
+   - Otherwise: creates a fresh registry.
 6. Runs `validate_bootstrap_invariants()` to confirm the image is
    self-consistent.
 

--- a/docs/compatibility_audit.md
+++ b/docs/compatibility_audit.md
@@ -37,7 +37,7 @@ If none apply, the path is **deleted**.
 | 18 | `kMinMemorySize` (non-templated) | `types.h:249-252` | Constant | **Keep** | Used in `persist_memory_manager.h` and `io.h` for validation. Low cost. |
 | 19 | `kManagerHeaderGranules` (non-templated) | `types.h:243` | Constant | **Keep** | Low-cost constant alongside `kManagerHeaderGranules_t<AT>`. |
 | 20 | `kMinBlockSize` (non-templated) | `types.h:246` | Constant | **Keep** | Low-cost constant. |
-| 21 | `legacy_root_offset` in ForestDomainRegistry | `forest_registry.h:57` | Field + `set_root`/`get_root` API | **Keep** | Active public API (`set_root`/`get_root`) backed by forest registry. Single-root use is a supported workflow, not a dead path. |
+| 21 | `reserved_root_offset` in ForestDomainRegistry + `service/legacy_root` domain | `forest_registry.h`, `forest_domain_mixin.inc` | Migration field + domain | **Delete** (issue #339) | Transitional artifact from the pre-forest-registry root model. Removed together with the migration branch in `validate_or_bootstrap_forest_registry_unlocked()`. `set_root`/`get_root` now directly address the `service/domain_root` registry record. |
 | 22 | MSVC `_MSVC_LANG` check | `persist_memory_manager.h:15-21` | Platform detection | **Keep** | Platform-specific path required for MSVC (confirmed by CI). |
 | 23 | Windows file operations (`atomic_rename`, MMapStorage) | `io.h`, `mmap_storage.h` | Platform-specific code | **Keep** | Required for Windows support, gated by `_WIN32`/`_WIN64`. |
 | 24 | Logging policy SFINAE detection | `persist_memory_manager.h:74-85` | Config detection | **Keep** | Low-cost, non-breaking default (`NoLogging`). Part of the configuration API contract. |
@@ -46,7 +46,7 @@ If none apply, the path is **deleted**.
 
 | Seam | Justification |
 |------|---------------|
-| `legacy_root_offset` + `set_root`/`get_root` | Active public API for single-root usage. Forest registry stores it. |
+| `service/domain_root` + `set_root`/`get_root` | Active public API for single-root usage. A canonical registry record, not a migration shim. |
 | MSVC `_MSVC_LANG` | Platform-specific, confirmed by CI. |
 | Windows `_WIN32` / `_WIN64` paths | Platform-specific, mmap and atomic rename. |
 | Logging policy SFINAE | Low-cost config detection with safe default. |

--- a/docs/core_invariants.md
+++ b/docs/core_invariants.md
@@ -103,7 +103,7 @@ Each block is an atom of the linear PAP **and** an atom of the intrusive forest.
 
 | ID | Invariant | Code checkpoint | Test |
 |----|-----------|-----------------|------|
-| C2a | The `ForestDomainRegistry` is a persistent locked block containing up to 32 domain slots. Its granule index is stored in `ManagerHeader::root_offset`. | `bootstrap_forest_registry_unlocked()` allocates and locks the registry. `validate_bootstrap_invariants_unlocked()` checks `hdr->root_offset` matches the registry domain root. | `test_issue241_bootstrap.cpp` — "bootstrap invariants hold after save/load". `test_forest_registry.cpp` — "forest registry persists user domains and legacy root". |
+| C2a | The `ForestDomainRegistry` is a persistent locked block containing up to 32 domain slots. Its granule index is stored in `ManagerHeader::root_offset`. | `bootstrap_forest_registry_unlocked()` allocates and locks the registry. `validate_bootstrap_invariants_unlocked()` checks `hdr->root_offset` matches the registry domain root. | `test_issue241_bootstrap.cpp` — "bootstrap invariants hold after save/load". `test_forest_registry.cpp` — "forest registry persists user domains and root". |
 | C2b | `ForestDomainRegistry` has magic `0x50465247` ("PFRG") and version 1. | `validate_or_bootstrap_forest_registry_unlocked()` in `forest_domain_mixin.inc:397–451` validates magic and version. `verify_forest_registry_unlocked()` in `verify_repair_mixin.inc:64–95`. | `test_issue245_verify_repair.cpp` — "verify detects forest registry corruption". |
 
 ### C3. Symbol dictionary

--- a/docs/mutation_ordering.md
+++ b/docs/mutation_ordering.md
@@ -213,9 +213,8 @@ During bootstrap, symbols are interned in a fixed order
 4. `type/forest_registry`
 5. `type/forest_domain_record`
 6. `type/pstringview`
-7. `service/legacy_root`
-8. `service/domain_root`
-9. `service/domain_symbol`
+7. `service/domain_root`
+8. `service/domain_symbol`
 
 This order is deterministic — identical `create()` calls produce
 identical symbol layouts (invariant D1d).

--- a/include/pmm/forest_domain_mixin.inc
+++ b/include/pmm/forest_domain_mixin.inc
@@ -217,7 +217,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
     static constexpr const char* kBootstrapSymbols[] = {
         detail::kSystemDomainFreeTree,     detail::kSystemDomainSymbols,          detail::kSystemDomainRegistry,
         detail::kSystemTypeForestRegistry, detail::kSystemTypeForestDomainRecord, detail::kSystemTypePstringview,
-        detail::kServiceNameLegacyRoot,    detail::kServiceNameDomainRoot,        detail::kServiceNameDomainSymbol,
+        detail::kServiceNameDomainRoot,    detail::kServiceNameDomainSymbol,
     };
 
     for ( const char* sym : kBootstrapSymbols )
@@ -246,7 +246,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
 
 // ─── Bootstrap: create forest registry root ───────────────────────────────────
 
-static bool create_forest_registry_root_unlocked( index_type legacy_root_offset ) noexcept
+static bool bootstrap_forest_registry_unlocked() noexcept
 {
     static constexpr std::size_t kGranSz = address_traits::granule_size;
 
@@ -269,11 +269,10 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic                = detail::kForestRegistryMagic;
-    reg->version              = detail::kForestRegistryVersion;
-    reg->domain_count         = 0;
-    reg->reserved_root_offset = 0;
-    reg->next_binding_id      = 1;
+    reg->magic           = detail::kForestRegistryMagic;
+    reg->version         = detail::kForestRegistryVersion;
+    reg->domain_count    = 0;
+    reg->next_binding_id = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -302,8 +301,8 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         _last_error = PmmError::BackendError;
         return false;
     }
-    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
+    if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, 0 ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -314,11 +313,6 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         return false;
     }
     return true;
-}
-
-static bool bootstrap_forest_registry_unlocked() noexcept
-{
-    return create_forest_registry_root_unlocked( 0 );
 }
 
 // ─── Bootstrap: invariant verification ───────────────────────────
@@ -350,12 +344,10 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     if ( reg->version != detail::kForestRegistryVersion )
         return false;
     if ( reg->domain_count < 4 )
-        return false; // at least free_tree, symbols, registry, legacy_root
-    if ( reg->reserved_root_offset != 0 )
-        return false;
+        return false; // at least free_tree, symbols, registry, domain_root
     // 3. System domains present with correct flags
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -377,8 +369,8 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
-    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+    const forest_domain* root_rec = find_domain_by_name_unlocked( detail::kServiceNameDomainRoot );
+    if ( root_rec->binding_kind != detail::kForestBindingDirectRoot )
         return false;
     return true;
 }
@@ -390,12 +382,6 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
-        forest_registry* reg = forest_registry_root_unlocked();
-        index_type       migrated_legacy_root =
-            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
-                ? reg->reserved_root_offset
-                : static_cast<index_type>( 0 );
-
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -406,56 +392,15 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
             return false;
-        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
+        if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, 0 ) )
             return false;
 
-        if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
-        {
-            free_rec->flags |= detail::kForestDomainFlagSystem;
-            free_rec->binding_kind = detail::kForestBindingFreeTree;
-            free_rec->root_offset  = 0;
-        }
-        if ( forest_domain* symbols_rec = find_domain_by_name_unlocked( detail::kSystemDomainSymbols ) )
-        {
-            symbols_rec->flags |= detail::kForestDomainFlagSystem;
-            symbols_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( forest_domain* registry_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry ) )
-        {
-            registry_rec->flags |= detail::kForestDomainFlagSystem;
-            registry_rec->binding_kind = detail::kForestBindingDirectRoot;
-            registry_rec->root_offset  = hdr->root_offset;
-        }
-        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
-        {
-            legacy_rec->flags |= detail::kForestDomainFlagSystem;
-            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( reg != nullptr )
-            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 
-    index_type legacy_root = 0;
-    if ( hdr->root_offset != address_traits::no_block &&
-         is_valid_user_offset_unlocked( hdr->root_offset, sizeof( std::uint32_t ) ) )
-    {
-        if ( !is_valid_user_offset_unlocked( hdr->root_offset, sizeof( forest_registry ) ) )
-        {
-            legacy_root = hdr->root_offset;
-        }
-        else
-        {
-            auto* candidate = reinterpret_cast<const forest_registry*>(
-                _backend.base_ptr() + static_cast<std::size_t>( hdr->root_offset ) * address_traits::granule_size );
-            if ( candidate->magic != detail::kForestRegistryMagic )
-                legacy_root = hdr->root_offset;
-        }
-    }
-
     hdr->root_offset = address_traits::no_block;
-    return create_forest_registry_root_unlocked( legacy_root );
+    return bootstrap_forest_registry_unlocked();
 }
 
 // ─── Free block tree traversal ────────────────────────────────────────────────

--- a/include/pmm/forest_registry.h
+++ b/include/pmm/forest_registry.h
@@ -19,7 +19,6 @@ inline constexpr const char*   kSystemDomainRegistry         = "system/domain_re
 inline constexpr const char*   kSystemTypeForestRegistry     = "type/forest_registry";
 inline constexpr const char*   kSystemTypeForestDomainRecord = "type/forest_domain_record";
 inline constexpr const char*   kSystemTypePstringview        = "type/pstringview";
-inline constexpr const char*   kServiceNameLegacyRoot        = "service/legacy_root";
 inline constexpr const char*   kServiceNameDomainRoot        = "service/domain_root";
 inline constexpr const char*   kServiceNameDomainSymbol      = "service/domain_symbol";
 inline constexpr std::uint32_t kForestRegistryMagic          = 0x50465247U; // "PFRG"
@@ -54,13 +53,12 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
-          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), next_binding_id( 1 ),
+          domains{}
     {
     }
 };

--- a/include/pmm/persist_memory_manager.h
+++ b/include/pmm/persist_memory_manager.h
@@ -511,19 +511,18 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
 
     // ─── Root object API ──────────────────────────────
 
-    /// @brief Compatibility shim for the legacy root object API.
-    /// Stores the root in the canonical `service/legacy_root` domain record.
+    /// @brief Store a user root pptr in the canonical `service/domain_root` registry record.
     template <typename T> static void set_root( pptr<T> p ) noexcept
     {
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ),
                                                p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
     /**
-     * @brief Compatibility shim for the legacy root object API.
+     * @brief Retrieve the user root pptr from the `service/domain_root` registry record.
      *
      * @tparam T Тип объекта (должен совпадать с типом, переданным в set_root).
      * @return pptr<T> — корневой указатель или пустой pptr, если корень не установлен.
@@ -533,11 +532,11 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root =
-            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
-        if ( legacy_root == static_cast<index_type>( 0 ) )
+        index_type root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ) );
+        if ( root == static_cast<index_type>( 0 ) )
             return pptr<T>();
-        return pptr<T>( legacy_root );
+        return pptr<T>( root );
     }
 
     static index_type find_domain_by_name( const char* name ) noexcept

--- a/include/pmm/verify_repair_mixin.inc
+++ b/include/pmm/verify_repair_mixin.inc
@@ -100,7 +100,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -5113,7 +5113,6 @@ inline constexpr const char*   kSystemDomainRegistry         = "system/domain_re
 inline constexpr const char*   kSystemTypeForestRegistry     = "type/forest_registry";
 inline constexpr const char*   kSystemTypeForestDomainRecord = "type/forest_domain_record";
 inline constexpr const char*   kSystemTypePstringview        = "type/pstringview";
-inline constexpr const char*   kServiceNameLegacyRoot        = "service/legacy_root";
 inline constexpr const char*   kServiceNameDomainRoot        = "service/domain_root";
 inline constexpr const char*   kServiceNameDomainSymbol      = "service/domain_symbol";
 inline constexpr std::uint32_t kForestRegistryMagic          = 0x50465247U; // "PFRG"
@@ -5148,13 +5147,12 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
-          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), next_binding_id( 1 ),
+          domains{}
     {
     }
 };
@@ -8357,19 +8355,18 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
 
     // ─── Root object API ──────────────────────────────
 
-    /// @brief Compatibility shim for the legacy root object API.
-    /// Stores the root in the canonical `service/legacy_root` domain record.
+    /// @brief Store a user root pptr in the canonical `service/domain_root` registry record.
     template <typename T> static void set_root( pptr<T> p ) noexcept
     {
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ),
                                                p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
     /**
-     * @brief Compatibility shim for the legacy root object API.
+     * @brief Retrieve the user root pptr from the `service/domain_root` registry record.
      *
      * @tparam T Тип объекта (должен совпадать с типом, переданным в set_root).
      * @return pptr<T> — корневой указатель или пустой pptr, если корень не установлен.
@@ -8379,11 +8376,11 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root =
-            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
-        if ( legacy_root == static_cast<index_type>( 0 ) )
+        index_type root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ) );
+        if ( root == static_cast<index_type>( 0 ) )
             return pptr<T>();
-        return pptr<T>( legacy_root );
+        return pptr<T>( root );
     }
 
     static index_type find_domain_by_name( const char* name ) noexcept
@@ -9148,7 +9145,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
     static constexpr const char* kBootstrapSymbols[] = {
         detail::kSystemDomainFreeTree,     detail::kSystemDomainSymbols,          detail::kSystemDomainRegistry,
         detail::kSystemTypeForestRegistry, detail::kSystemTypeForestDomainRecord, detail::kSystemTypePstringview,
-        detail::kServiceNameLegacyRoot,    detail::kServiceNameDomainRoot,        detail::kServiceNameDomainSymbol,
+        detail::kServiceNameDomainRoot,    detail::kServiceNameDomainSymbol,
     };
 
     for ( const char* sym : kBootstrapSymbols )
@@ -9177,7 +9174,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
 
 // ─── Bootstrap: create forest registry root ───────────────────────────────────
 
-static bool create_forest_registry_root_unlocked( index_type legacy_root_offset ) noexcept
+static bool bootstrap_forest_registry_unlocked() noexcept
 {
     static constexpr std::size_t kGranSz = address_traits::granule_size;
 
@@ -9200,11 +9197,10 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic                = detail::kForestRegistryMagic;
-    reg->version              = detail::kForestRegistryVersion;
-    reg->domain_count         = 0;
-    reg->reserved_root_offset = 0;
-    reg->next_binding_id      = 1;
+    reg->magic           = detail::kForestRegistryMagic;
+    reg->version         = detail::kForestRegistryVersion;
+    reg->domain_count    = 0;
+    reg->next_binding_id = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -9233,8 +9229,8 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         _last_error = PmmError::BackendError;
         return false;
     }
-    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
+    if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, 0 ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -9245,11 +9241,6 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         return false;
     }
     return true;
-}
-
-static bool bootstrap_forest_registry_unlocked() noexcept
-{
-    return create_forest_registry_root_unlocked( 0 );
 }
 
 // ─── Bootstrap: invariant verification ───────────────────────────
@@ -9281,12 +9272,10 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     if ( reg->version != detail::kForestRegistryVersion )
         return false;
     if ( reg->domain_count < 4 )
-        return false; // at least free_tree, symbols, registry, legacy_root
-    if ( reg->reserved_root_offset != 0 )
-        return false;
+        return false; // at least free_tree, symbols, registry, domain_root
     // 3. System domains present with correct flags
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -9308,8 +9297,8 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
-    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+    const forest_domain* root_rec = find_domain_by_name_unlocked( detail::kServiceNameDomainRoot );
+    if ( root_rec->binding_kind != detail::kForestBindingDirectRoot )
         return false;
     return true;
 }
@@ -9321,12 +9310,6 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
-        forest_registry* reg = forest_registry_root_unlocked();
-        index_type       migrated_legacy_root =
-            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
-                ? reg->reserved_root_offset
-                : static_cast<index_type>( 0 );
-
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -9337,56 +9320,15 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
             return false;
-        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
+        if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, 0 ) )
             return false;
 
-        if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
-        {
-            free_rec->flags |= detail::kForestDomainFlagSystem;
-            free_rec->binding_kind = detail::kForestBindingFreeTree;
-            free_rec->root_offset  = 0;
-        }
-        if ( forest_domain* symbols_rec = find_domain_by_name_unlocked( detail::kSystemDomainSymbols ) )
-        {
-            symbols_rec->flags |= detail::kForestDomainFlagSystem;
-            symbols_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( forest_domain* registry_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry ) )
-        {
-            registry_rec->flags |= detail::kForestDomainFlagSystem;
-            registry_rec->binding_kind = detail::kForestBindingDirectRoot;
-            registry_rec->root_offset  = hdr->root_offset;
-        }
-        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
-        {
-            legacy_rec->flags |= detail::kForestDomainFlagSystem;
-            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( reg != nullptr )
-            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 
-    index_type legacy_root = 0;
-    if ( hdr->root_offset != address_traits::no_block &&
-         is_valid_user_offset_unlocked( hdr->root_offset, sizeof( std::uint32_t ) ) )
-    {
-        if ( !is_valid_user_offset_unlocked( hdr->root_offset, sizeof( forest_registry ) ) )
-        {
-            legacy_root = hdr->root_offset;
-        }
-        else
-        {
-            auto* candidate = reinterpret_cast<const forest_registry*>(
-                _backend.base_ptr() + static_cast<std::size_t>( hdr->root_offset ) * address_traits::granule_size );
-            if ( candidate->magic != detail::kForestRegistryMagic )
-                legacy_root = hdr->root_offset;
-        }
-    }
-
     hdr->root_offset = address_traits::no_block;
-    return create_forest_registry_root_unlocked( legacy_root );
+    return bootstrap_forest_registry_unlocked();
 }
 
 // ─── Free block tree traversal ────────────────────────────────────────────────
@@ -9719,7 +9661,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/single_include/pmm/pmm_no_comments.h
+++ b/single_include/pmm/pmm_no_comments.h
@@ -3267,7 +3267,6 @@ inline constexpr const char*   kSystemDomainRegistry         = "system/domain_re
 inline constexpr const char*   kSystemTypeForestRegistry     = "type/forest_registry";
 inline constexpr const char*   kSystemTypeForestDomainRecord = "type/forest_domain_record";
 inline constexpr const char*   kSystemTypePstringview        = "type/pstringview";
-inline constexpr const char*   kServiceNameLegacyRoot        = "service/legacy_root";
 inline constexpr const char*   kServiceNameDomainRoot        = "service/domain_root";
 inline constexpr const char*   kServiceNameDomainSymbol      = "service/domain_symbol";
 inline constexpr std::uint32_t kForestRegistryMagic          = 0x50465247U;
@@ -3302,13 +3301,12 @@ template <typename AddressTraitsT> struct ForestDomainRegistry
     std::uint32_t                      magic;
     std::uint16_t                      version;
     std::uint16_t                      domain_count;
-    index_type                         reserved_root_offset;
     index_type                         next_binding_id;
     ForestDomainRecord<AddressTraitsT> domains[kMaxForestDomains];
 
     constexpr ForestDomainRegistry() noexcept
-        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ),
-          reserved_root_offset( 0 ), next_binding_id( 1 ), domains{}
+        : magic( kForestRegistryMagic ), version( kForestRegistryVersion ), domain_count( 0 ), next_binding_id( 1 ),
+          domains{}
     {
     }
 };
@@ -5301,7 +5299,7 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::unique_lock_type lock( _mutex );
         if ( !_initialized )
             return;
-        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ),
+        set_forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ),
                                                p.is_null() ? static_cast<index_type>( 0 ) : p.offset() );
     }
 
@@ -5310,11 +5308,11 @@ class PersistMemoryManager : public detail::PersistMemoryTypedApi<PersistMemoryM
         typename thread_policy::shared_lock_type lock( _mutex );
         if ( !_initialized )
             return pptr<T>();
-        index_type legacy_root =
-            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) );
-        if ( legacy_root == static_cast<index_type>( 0 ) )
+        index_type root =
+            forest_domain_root_index_unlocked( find_domain_by_name_unlocked( detail::kServiceNameDomainRoot ) );
+        if ( root == static_cast<index_type>( 0 ) )
             return pptr<T>();
-        return pptr<T>( legacy_root );
+        return pptr<T>( root );
     }
 
     static index_type find_domain_by_name( const char* name ) noexcept
@@ -5974,7 +5972,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
     static constexpr const char* kBootstrapSymbols[] = {
         detail::kSystemDomainFreeTree,     detail::kSystemDomainSymbols,          detail::kSystemDomainRegistry,
         detail::kSystemTypeForestRegistry, detail::kSystemTypeForestDomainRecord, detail::kSystemTypePstringview,
-        detail::kServiceNameLegacyRoot,    detail::kServiceNameDomainRoot,        detail::kServiceNameDomainSymbol,
+        detail::kServiceNameDomainRoot,    detail::kServiceNameDomainSymbol,
     };
 
     for ( const char* sym : kBootstrapSymbols )
@@ -6001,7 +5999,7 @@ static bool bootstrap_system_symbols_unlocked() noexcept
     return true;
 }
 
-static bool create_forest_registry_root_unlocked( index_type legacy_root_offset ) noexcept
+static bool bootstrap_forest_registry_unlocked() noexcept
 {
     static constexpr std::size_t kGranSz = address_traits::granule_size;
 
@@ -6024,11 +6022,10 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
     }
 
     std::memset( reg, 0, sizeof( forest_registry ) );
-    reg->magic                = detail::kForestRegistryMagic;
-    reg->version              = detail::kForestRegistryVersion;
-    reg->domain_count         = 0;
-    reg->reserved_root_offset = 0;
-    reg->next_binding_id      = 1;
+    reg->magic           = detail::kForestRegistryMagic;
+    reg->version         = detail::kForestRegistryVersion;
+    reg->domain_count    = 0;
+    reg->next_binding_id = 1;
 
     if ( !lock_block_permanent_unlocked( raw ) )
     {
@@ -6057,8 +6054,8 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         _last_error = PmmError::BackendError;
         return false;
     }
-    if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                    detail::kForestBindingDirectRoot, legacy_root_offset ) )
+    if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                    detail::kForestBindingDirectRoot, 0 ) )
     {
         _last_error = PmmError::BackendError;
         return false;
@@ -6069,11 +6066,6 @@ static bool create_forest_registry_root_unlocked( index_type legacy_root_offset 
         return false;
     }
     return true;
-}
-
-static bool bootstrap_forest_registry_unlocked() noexcept
-{
-    return create_forest_registry_root_unlocked( 0 );
 }
 
 static bool validate_bootstrap_invariants_unlocked() noexcept
@@ -6103,11 +6095,9 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
         return false;
     if ( reg->domain_count < 4 )
         return false;
-    if ( reg->reserved_root_offset != 0 )
-        return false;
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );
@@ -6129,8 +6119,8 @@ static bool validate_bootstrap_invariants_unlocked() noexcept
     const forest_domain* reg_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry );
     if ( reg_rec->root_offset != hdr->root_offset )
         return false;
-    const forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot );
-    if ( legacy_rec->binding_kind != detail::kForestBindingDirectRoot )
+    const forest_domain* root_rec = find_domain_by_name_unlocked( detail::kServiceNameDomainRoot );
+    if ( root_rec->binding_kind != detail::kForestBindingDirectRoot )
         return false;
     return true;
 }
@@ -6140,12 +6130,6 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
     detail::ManagerHeader<address_traits>* hdr = get_header( _backend.base_ptr() );
     if ( forest_registry_root_unlocked() != nullptr )
     {
-        forest_registry* reg = forest_registry_root_unlocked();
-        index_type       migrated_legacy_root =
-            ( find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) == nullptr && reg != nullptr )
-                ? reg->reserved_root_offset
-                : static_cast<index_type>( 0 );
-
         if ( !register_domain_unlocked( detail::kSystemDomainFreeTree, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingFreeTree, 0 ) )
             return false;
@@ -6156,56 +6140,15 @@ static bool validate_or_bootstrap_forest_registry_unlocked() noexcept
         if ( !register_domain_unlocked( detail::kSystemDomainRegistry, detail::kForestDomainFlagSystem,
                                         detail::kForestBindingDirectRoot, hdr->root_offset ) )
             return false;
-        if ( !register_domain_unlocked( detail::kServiceNameLegacyRoot, detail::kForestDomainFlagSystem,
-                                        detail::kForestBindingDirectRoot, migrated_legacy_root ) )
+        if ( !register_domain_unlocked( detail::kServiceNameDomainRoot, detail::kForestDomainFlagSystem,
+                                        detail::kForestBindingDirectRoot, 0 ) )
             return false;
 
-        if ( forest_domain* free_rec = find_domain_by_name_unlocked( detail::kSystemDomainFreeTree ) )
-        {
-            free_rec->flags |= detail::kForestDomainFlagSystem;
-            free_rec->binding_kind = detail::kForestBindingFreeTree;
-            free_rec->root_offset  = 0;
-        }
-        if ( forest_domain* symbols_rec = find_domain_by_name_unlocked( detail::kSystemDomainSymbols ) )
-        {
-            symbols_rec->flags |= detail::kForestDomainFlagSystem;
-            symbols_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( forest_domain* registry_rec = find_domain_by_name_unlocked( detail::kSystemDomainRegistry ) )
-        {
-            registry_rec->flags |= detail::kForestDomainFlagSystem;
-            registry_rec->binding_kind = detail::kForestBindingDirectRoot;
-            registry_rec->root_offset  = hdr->root_offset;
-        }
-        if ( forest_domain* legacy_rec = find_domain_by_name_unlocked( detail::kServiceNameLegacyRoot ) )
-        {
-            legacy_rec->flags |= detail::kForestDomainFlagSystem;
-            legacy_rec->binding_kind = detail::kForestBindingDirectRoot;
-        }
-        if ( reg != nullptr )
-            reg->reserved_root_offset = 0;
         return bootstrap_system_symbols_unlocked();
     }
 
-    index_type legacy_root = 0;
-    if ( hdr->root_offset != address_traits::no_block &&
-         is_valid_user_offset_unlocked( hdr->root_offset, sizeof( std::uint32_t ) ) )
-    {
-        if ( !is_valid_user_offset_unlocked( hdr->root_offset, sizeof( forest_registry ) ) )
-        {
-            legacy_root = hdr->root_offset;
-        }
-        else
-        {
-            auto* candidate = reinterpret_cast<const forest_registry*>(
-                _backend.base_ptr() + static_cast<std::size_t>( hdr->root_offset ) * address_traits::granule_size );
-            if ( candidate->magic != detail::kForestRegistryMagic )
-                legacy_root = hdr->root_offset;
-        }
-    }
-
     hdr->root_offset = address_traits::no_block;
-    return create_forest_registry_root_unlocked( legacy_root );
+    return bootstrap_forest_registry_unlocked();
 }
 
 template <typename Callback>
@@ -6486,7 +6429,7 @@ static void verify_forest_registry_unlocked( VerifyResult& result ) noexcept
     }
 
     static constexpr const char* kRequired[] = { detail::kSystemDomainFreeTree, detail::kSystemDomainSymbols,
-                                                 detail::kSystemDomainRegistry, detail::kServiceNameLegacyRoot };
+                                                 detail::kSystemDomainRegistry, detail::kServiceNameDomainRoot };
     for ( const char* name : kRequired )
     {
         const forest_domain* rec = find_domain_by_name_unlocked( name );

--- a/tests/test_forest_registry.cpp
+++ b/tests/test_forest_registry.cpp
@@ -19,23 +19,23 @@ TEST_CASE( "forest registry bootstraps system domains", "[test_forest_registry]"
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainFreeTree ) );
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainSymbols ) );
     REQUIRE( ForestMgr::has_domain( pmm::detail::kSystemDomainRegistry ) );
-    REQUIRE( ForestMgr::has_domain( pmm::detail::kServiceNameLegacyRoot ) );
+    REQUIRE( ForestMgr::has_domain( pmm::detail::kServiceNameDomainRoot ) );
 
     auto free_id     = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainFreeTree );
     auto symbols_id  = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainSymbols );
     auto registry_id = ForestMgr::find_domain_by_name( pmm::detail::kSystemDomainRegistry );
-    auto legacy_id   = ForestMgr::find_domain_by_name( pmm::detail::kServiceNameLegacyRoot );
+    auto root_id     = ForestMgr::find_domain_by_name( pmm::detail::kServiceNameDomainRoot );
 
     REQUIRE( free_id != 0 );
     REQUIRE( symbols_id != 0 );
     REQUIRE( registry_id != 0 );
-    REQUIRE( legacy_id != 0 );
+    REQUIRE( root_id != 0 );
 
     REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) != 0 );
     REQUIRE( ForestMgr::get_domain_root_offset( free_id ) ==
              ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) );
     REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kSystemDomainSymbols ) != 0 );
-    REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == 0 );
+    REQUIRE( ForestMgr::get_domain_root_offset( pmm::detail::kServiceNameDomainRoot ) == 0 );
 
     ForestMgr::pptr<ForestMgr::pstringview> symbols_domain_symbol =
         ForestMgr::pstringview( pmm::detail::kSystemDomainSymbols );
@@ -55,7 +55,7 @@ TEST_CASE( "forest registry bootstraps system domains", "[test_forest_registry]"
     ForestMgr::destroy();
 }
 
-TEST_CASE( "forest registry persists user domains and legacy root", "[test_forest_registry]" )
+TEST_CASE( "forest registry persists user domains and root", "[test_forest_registry]" )
 {
     const char* filename = "test_forest_registry.dat";
 
@@ -120,11 +120,11 @@ TEST_CASE( "forest registry persists user domains and legacy root", "[test_fores
     REQUIRE( !alpha_symbol_after.is_null() );
     REQUIRE( ForestPersistMgr::get_domain_root_offset( alpha_symbol_after ) == alpha_offset );
 
-    auto legacy_root = ForestPersistMgr::get_root<int>();
-    REQUIRE( !legacy_root.is_null() );
-    REQUIRE( legacy_root.offset() == alpha_offset );
-    REQUIRE( *legacy_root == 11 );
-    REQUIRE( ForestPersistMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == alpha_offset );
+    auto root = ForestPersistMgr::get_root<int>();
+    REQUIRE( !root.is_null() );
+    REQUIRE( root.offset() == alpha_offset );
+    REQUIRE( *root == 11 );
+    REQUIRE( ForestPersistMgr::get_domain_root_offset( pmm::detail::kServiceNameDomainRoot ) == alpha_offset );
 
     REQUIRE( ForestPersistMgr::get_domain_root_offset( pmm::detail::kSystemDomainFreeTree ) != 0 );
     REQUIRE( ForestPersistMgr::pstringview::root_index() != 0 );
@@ -141,47 +141,38 @@ TEST_CASE( "forest registry persists user domains and legacy root", "[test_fores
     std::remove( filename );
 }
 
-TEST_CASE( "legacy root API is a compatibility shim over the domain registry", "[test_forest_registry][issue313]" )
+TEST_CASE( "root object API is a thin view over the service/domain_root registry record",
+           "[test_forest_registry][issue313]" )
 {
     CanonicalRootMgr::destroy();
     REQUIRE( CanonicalRootMgr::create( 128 * 1024 ) );
 
-    REQUIRE( CanonicalRootMgr::has_domain( pmm::detail::kServiceNameLegacyRoot ) );
-    auto legacy_domain_id = CanonicalRootMgr::find_domain_by_name( pmm::detail::kServiceNameLegacyRoot );
-    REQUIRE( legacy_domain_id != 0 );
+    REQUIRE( CanonicalRootMgr::has_domain( pmm::detail::kServiceNameDomainRoot ) );
+    auto root_domain_id = CanonicalRootMgr::find_domain_by_name( pmm::detail::kServiceNameDomainRoot );
+    REQUIRE( root_domain_id != 0 );
 
     REQUIRE( CanonicalRootMgr::get_root<int>().is_null() );
-    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameLegacyRoot ).is_null() );
-    REQUIRE( CanonicalRootMgr::get_domain_root_offset( legacy_domain_id ) == 0 );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameDomainRoot ).is_null() );
+    REQUIRE( CanonicalRootMgr::get_domain_root_offset( root_domain_id ) == 0 );
 
-    using AT           = CanonicalRootMgr::address_traits;
-    std::uint8_t* base = CanonicalRootMgr::backend().base_ptr();
-    auto*         hdr  = pmm::detail::manager_header_at<AT>( base );
-    auto*         reg  = reinterpret_cast<pmm::detail::ForestDomainRegistry<AT>*>(
-        base + static_cast<std::size_t>( hdr->root_offset ) * AT::granule_size );
-    REQUIRE( reg->reserved_root_offset == 0 );
+    auto first_value  = CanonicalRootMgr::create_typed<int>( 31 );
+    auto second_value = CanonicalRootMgr::create_typed<int>( 313 );
+    REQUIRE( !first_value.is_null() );
+    REQUIRE( !second_value.is_null() );
 
-    auto legacy_value = CanonicalRootMgr::create_typed<int>( 31 );
-    auto domain_value = CanonicalRootMgr::create_typed<int>( 313 );
-    REQUIRE( !legacy_value.is_null() );
-    REQUIRE( !domain_value.is_null() );
+    CanonicalRootMgr::set_root( first_value );
+    REQUIRE( CanonicalRootMgr::get_domain_root_offset( pmm::detail::kServiceNameDomainRoot ) == first_value.offset() );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( root_domain_id ).offset() == first_value.offset() );
 
-    CanonicalRootMgr::set_root( legacy_value );
-    REQUIRE( CanonicalRootMgr::get_domain_root_offset( pmm::detail::kServiceNameLegacyRoot ) == legacy_value.offset() );
-    REQUIRE( CanonicalRootMgr::get_domain_root<int>( legacy_domain_id ).offset() == legacy_value.offset() );
-
-    REQUIRE( CanonicalRootMgr::set_domain_root( pmm::detail::kServiceNameLegacyRoot, domain_value ) );
-    REQUIRE( CanonicalRootMgr::get_root<int>().offset() == domain_value.offset() );
+    REQUIRE( CanonicalRootMgr::set_domain_root( pmm::detail::kServiceNameDomainRoot, second_value ) );
+    REQUIRE( CanonicalRootMgr::get_root<int>().offset() == second_value.offset() );
     REQUIRE( *CanonicalRootMgr::get_root<int>() == 313 );
 
-    reg->reserved_root_offset = legacy_value.offset();
-    REQUIRE( CanonicalRootMgr::get_root<int>().offset() == domain_value.offset() );
-    reg->reserved_root_offset = 0;
     REQUIRE( CanonicalRootMgr::validate_bootstrap_invariants() );
 
     CanonicalRootMgr::set_root( CanonicalRootMgr::pptr<int>() );
     REQUIRE( CanonicalRootMgr::get_root<int>().is_null() );
-    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameLegacyRoot ).is_null() );
+    REQUIRE( CanonicalRootMgr::get_domain_root<int>( pmm::detail::kServiceNameDomainRoot ).is_null() );
 
     CanonicalRootMgr::destroy();
 }


### PR DESCRIPTION
## Summary

Aggressively removes the transitional pre-forest-registry compatibility path from the forest registry bootstrap, addressing [#339](https://github.com/netkeep80/PersistMemoryManager/issues/339).

Fixes netkeep80/PersistMemoryManager#339

## Removed legacy entities (per issue's required PR format)

| Entity | File |
|---|---|
| `pmm::detail::kServiceNameLegacyRoot` constant (`"service/legacy_root"`) | `include/pmm/forest_registry.h` |
| `reserved_root_offset` field in `ForestDomainRegistry` | `include/pmm/forest_registry.h` |
| `service/legacy_root` domain bootstrap / registration | `include/pmm/forest_domain_mixin.inc` |
| `create_forest_registry_root_unlocked(legacy_root_offset)` helper (folded into `bootstrap_forest_registry_unlocked()`) | `include/pmm/forest_domain_mixin.inc` |
| Legacy-root migration branch in `validate_or_bootstrap_forest_registry_unlocked()` (treated `hdr->root_offset` as a pre-registry legacy root) | `include/pmm/forest_domain_mixin.inc` |
| Legacy-root invariant checks (`reserved_root_offset == 0`, `legacy_rec` binding) in `validate_bootstrap_invariants_unlocked()` | `include/pmm/forest_domain_mixin.inc` |
| Legacy-root entry in bootstrap symbol list | `include/pmm/forest_domain_mixin.inc` |
| Legacy-root entry in verify/repair required-domain list | `include/pmm/verify_repair_mixin.inc` |
| "Compatibility shim" wording on `set_root`/`get_root` (API now directly uses `service/domain_root`) | `include/pmm/persist_memory_manager.h` |
| `legacy root` test case asserting compatibility shim semantics; `has_domain(kServiceNameLegacyRoot)` / `reserved_root_offset` asserts | `tests/test_forest_registry.cpp` |

## Behavior after this PR

- `bootstrap_forest_registry_unlocked()` linearly registers exactly four system domains: `system/free_tree`, `system/symbols`, `system/domain_registry`, `service/domain_root`. No branching for legacy headers.
- `set_root<T>` / `get_root<T>` store and read the root offset on the `service/domain_root` registry record directly — no shim layer.
- `validate_or_bootstrap_forest_registry_unlocked()` reduces to: if registry is valid, re-assert system domains and re-intern bootstrap symbols; otherwise, reset `hdr->root_offset` and bootstrap fresh.
- Persisted format changed (field removal). Old images cannot be loaded — matches the issue's `Совместимость не поддерживать` requirement.

## Acceptance criteria (from issue)

1. ✅ No legacy-root service domain in the codebase.
2. ✅ No migration branches for the old root model.
3. ✅ Registry bootstrap reads linearly (`bootstrap_forest_registry_unlocked()` in `forest_domain_mixin.inc`).
4. ✅ Simpler persisted metadata (`reserved_root_offset` removed from `ForestDomainRegistry`).
5. ✅ LOC reduced: `12 files changed, 135 insertions(+), 296 deletions(-)`.

## Test plan

- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j4` — builds cleanly.
- [x] `ctest --test-dir build --output-on-failure` — **100% tests passed, 0 tests failed out of 92**.
- [x] `scripts/check-docs-consistency.sh` — OK.
- [x] `scripts/generate-single-headers.sh --strip-comments` — regenerated `single_include/pmm/pmm.h` and `pmm_no_comments.h` (no more `kServiceNameLegacyRoot` / `reserved_root_offset` references).
- [x] Manual: `grep -R 'kServiceNameLegacyRoot\|reserved_root_offset\|service/legacy_root'` reports no source-code matches (only a historical row in `docs/compatibility_audit.md` describing the deletion).