### PR TITLE
refactor: narrow block_state FSM scope to allocator domain

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T22:38:29.129Z for PR creation at branch issue-340-e834a5b26a7a for issue https://github.com/netkeep80/PersistMemoryManager/issues/340

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T22:38:29.129Z for PR creation at branch issue-340-e834a5b26a7a for issue https://github.com/netkeep80/PersistMemoryManager/issues/340

--- a/changelog.d/20260420_224148_narrow_block_state_scope.md
+++ b/changelog.d/20260420_224148_narrow_block_state_scope.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+### Changed
+- Narrow `block_state.h` docstring and surrounding docs (`atomic_writes.md`,
+  `architecture.md`) to describe the block FSM strictly as the allocator /
+  free-tree physical mutation protocol. Clarify explicitly that `pmap` and
+  `pstringview` operate on already-allocated blocks and do not traverse the
+  `FreeBlock ↔ AllocatedBlock` transitions defined here — this is not a
+  general forest-node lifecycle.

--- a/changelog.d/20260420_224148_narrow_block_state_scope.md
+++ b/changelog.d/20260420_224148_narrow_block_state_scope.md
@@ -3,9 +3,8 @@ bump: patch
 ---
 
 ### Changed
-- Narrow `block_state.h` docstring and surrounding docs (`atomic_writes.md`,
-  `architecture.md`) to describe the block FSM strictly as the allocator /
-  free-tree physical mutation protocol. Clarify explicitly that `pmap` and
-  `pstringview` operate on already-allocated blocks and do not traverse the
-  `FreeBlock ↔ AllocatedBlock` transitions defined here — this is not a
-  general forest-node lifecycle.
+- Compress `block_state.h` docstring to a short Russian scope-note: FSM =
+  allocator/free-tree domain; `pmap`/`pstringview` do not traverse
+  `FreeBlock ↔ AllocatedBlock`; `BlockStateBase<AT>::*` is a low-level helper
+  layer for allocator/repair. Canonical explanation stays in
+  `docs/atomic_writes.md`; `docs/architecture.md` keeps a one-line reference.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,8 @@ This document focuses on the low-level layout, invariants, and algorithms.
 │   recompute_counters)                                                 │
 ├───────────────────────────────────────────────────────────────────────┤
 │  BlockState machine (block_state.h)                                   │
-│  (type-safe state transitions: Free → Allocated → Free)               │
+│  Allocator / free-tree FSM: Free → Allocated → Free                   │
+│  (not a general forest-node lifecycle; pmap/pstringview do not use it)│
 ├───────────────────────────────────────────────────────────────────────┤
 │  Block<AddressTraitsT> raw memory layout                              │
 │  (LinkedListNode<A> + TreeNode<A>, granule indices)                   │
@@ -410,6 +411,11 @@ buffer_start (= Block<A>_0)
 ---
 
 ## Block state machine
+
+The block state machine is a **narrow allocator / free-tree FSM**: it describes the
+physical mutation of a single `Block<A>` during allocate / deallocate / split / coalesce.
+It is not a general forest-node lifecycle — `pmap` and `pstringview` operate on
+already-allocated blocks and do not traverse `FreeBlock ↔ AllocatedBlock` transitions.
 
 Blocks transition between two correct states and several transient states. See
 [`docs/atomic_writes.md`](atomic_writes.md) for the full state diagram and crash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -412,11 +412,6 @@ buffer_start (= Block<A>_0)
 
 ## Block state machine
 
-The block state machine is a **narrow allocator / free-tree FSM**: it describes the
-physical mutation of a single `Block<A>` during allocate / deallocate / split / coalesce.
-It is not a general forest-node lifecycle — `pmap` and `pstringview` operate on
-already-allocated blocks and do not traverse `FreeBlock ↔ AllocatedBlock` transitions.
-
 Blocks transition between two correct states and several transient states. See
 [`docs/atomic_writes.md`](atomic_writes.md) for the full state diagram and crash
 recovery analysis.

--- a/docs/atomic_writes.md
+++ b/docs/atomic_writes.md
@@ -10,9 +10,13 @@ and the algorithms for verifying and recovering the image after an interrupted o
 at any stage of a write, the image can be verified, the interruption point identified, and
 the operation completed (or rolled back).
 
-**Scope:** covers the core block allocator operations. Persistent data structures
-(`pstringview`, `pmap`) build their own AVL trees using the same block headers — their
-AVL rotations follow the same "non-critical" guarantee: on `load()`, only the free-block
+**Scope:** covers the core block allocator operations — the allocator / free-tree
+domain. The block state machine described here is the physical mutation protocol for
+allocate / deallocate / split / coalesce; it is not a general forest-node lifecycle.
+Persistent data structures (`pstringview`, `pmap`) build their own AVL trees using the
+same block headers but do **not** participate in this FSM: their blocks stay in the
+`AllocatedBlock` state from the allocator's point of view, and their tree rotations are
+orthogonal to `FreeBlock ↔ AllocatedBlock` transitions. On `load()`, only the free-block
 AVL tree is rebuilt; user-data AVL trees (pstringview interning, pmap) are not affected
 by `rebuild_free_tree()` and must be managed by the user across process restarts.
 

--- a/docs/atomic_writes.md
+++ b/docs/atomic_writes.md
@@ -10,15 +10,13 @@ and the algorithms for verifying and recovering the image after an interrupted o
 at any stage of a write, the image can be verified, the interruption point identified, and
 the operation completed (or rolled back).
 
-**Scope:** covers the core block allocator operations — the allocator / free-tree
-domain. The block state machine described here is the physical mutation protocol for
-allocate / deallocate / split / coalesce; it is not a general forest-node lifecycle.
-Persistent data structures (`pstringview`, `pmap`) build their own AVL trees using the
-same block headers but do **not** participate in this FSM: their blocks stay in the
-`AllocatedBlock` state from the allocator's point of view, and their tree rotations are
-orthogonal to `FreeBlock ↔ AllocatedBlock` transitions. On `load()`, only the free-block
-AVL tree is rebuilt; user-data AVL trees (pstringview interning, pmap) are not affected
-by `rebuild_free_tree()` and must be managed by the user across process restarts.
+**Scope:** the block FSM described here is the allocator / free-tree physical mutation
+protocol (allocate / deallocate / split / coalesce), not a general forest-node lifecycle.
+Persistent data structures (`pstringview`, `pmap`) build their own AVL trees over the
+same block headers but do **not** traverse `FreeBlock ↔ AllocatedBlock`: their blocks
+remain `AllocatedBlock` from the allocator's point of view. On `load()`, only the
+free-block AVL tree is rebuilt; user-data AVL trees must be managed by the user across
+process restarts.
 
 ---
 

--- a/include/pmm/block_state.h
+++ b/include/pmm/block_state.h
@@ -1,38 +1,38 @@
 /**
  * @file pmm/block_state.h
- * @brief BlockState machine — автомат состояний блока для атомарных операций.
+ * @brief Allocator/free-tree block FSM — physical mutation protocol for the allocator domain.
  *
- * Реализует state machine через наследование состояний, где каждое состояние — это
- * наследник Block<A> с доступными методами работы. Каждый метод
- * выполняет один атомарный шаг критической операции и возвращает следующего
- * наследника, соответствующего новому состоянию блока.
+ * Scope is deliberately narrow: this header describes the states and transitions of a
+ * single `Block<A>` inside the allocator / free-tree domain. It is the protocol of
+ * material block mutation (allocate / deallocate / split / coalesce), not a general
+ * forest-node lifecycle. Forest-domain containers such as `pmap` and `pstringview`
+ * do NOT traverse these states — they operate on already-allocated blocks and manage
+ * their own tree links without participating in the FSM defined here.
  *
- * Корректные состояния:
- *   - FreeBlock        — свободный блок (weight=0, root_offset=0, в AVL-дереве)
- *   - AllocatedBlock   — занятый блок (weight>0, root_offset=idx, не в AVL)
+ * Correct states (visible in a saved image):
+ *   - FreeBlock        — free block (weight=0, root_offset=0, in the free-tree AVL)
+ *   - AllocatedBlock   — allocated block (weight>0, root_offset=own_idx, not in AVL)
  *
- * Переходные состояния (только во время операций):
- *   - FreeBlockRemovedAVL    — свободный, удалённый из AVL (перед allocate)
- *   - FreeBlockNotInAVL      — свободный, не в AVL (после deallocate, перед coalesce)
- *   - SplittingBlock         — блок в процессе разбиения
- *   - CoalescingBlock        — блок в процессе слияния
+ * Transient states (only during an in-flight allocator operation):
+ *   - FreeBlockRemovedAVL    — free, removed from AVL (before allocate completes)
+ *   - FreeBlockNotInAVL      — free, not yet in AVL (after deallocate, before coalesce)
+ *   - SplittingBlock         — block being split during allocate
+ *   - CoalescingBlock        — block being merged with a neighbour during deallocate
  *
- * Гарантии:
- *   1. Типобезопасность: компилятор запрещает вызов недоступных методов
- *   2. Восстановимость: переходные состояния детектируются при load()
- *   3. Атомарность: каждый метод выполняет один атомарный шаг
- *   4. Завершаемость: цепочка вызовов приводит к корректному состоянию
+ * Guarantees within this scope:
+ *   1. Type safety: the compiler forbids calling methods invalid for the current state.
+ *   2. Recoverability: transient states are detected during `load()`.
+ *   3. Atomicity: each method performs exactly one physical write step.
+ *   4. Termination: the chain of calls always ends in a correct state.
  *
- *   - reset_avl_fields_of()     — сброс AVL-полей перед rebuild_free_tree
- *   - repair_prev_offset()      — восстановление prev_offset при repair_linked_list
- *   - get_next_offset()         — чтение next_offset в repair-методах (load)
- *   - get_weight()              — чтение weight в repair-методах (load)
+ * `BlockStateBase<AT>` also exposes raw field accessors (`get_weight`, `get_next_offset`,
+ * `reset_avl_fields_of`, ...) that are used by allocator repair paths during `load()`
+ * and by read-only validators. They are low-level helpers for allocator/free-tree code —
+ * not a public protocol for other forest domains.
  *
- *   repair_block_prev_offset(), read_block_next_offset(), read_block_weight()
- *   AllocatorPolicy вызывает BlockStateBase<AT>::* напрямую.
- *
- * @see docs/atomic_writes.md «Граф состояний блока»
- * @version 0.4
+ * @see docs/atomic_writes.md — state graph and crash-recovery analysis
+ * @see include/pmm/free_block_tree.h — forest-policy that consumes this FSM
+ * @version 0.5
  */
 
 #pragma once

--- a/include/pmm/block_state.h
+++ b/include/pmm/block_state.h
@@ -1,37 +1,13 @@
 /**
  * @file pmm/block_state.h
- * @brief Allocator/free-tree block FSM — physical mutation protocol for the allocator domain.
+ * @brief FSM allocator/free-tree domain: FreeBlock ↔ AllocatedBlock.
  *
- * Scope is deliberately narrow: this header describes the states and transitions of a
- * single `Block<A>` inside the allocator / free-tree domain. It is the protocol of
- * material block mutation (allocate / deallocate / split / coalesce), not a general
- * forest-node lifecycle. Forest-domain containers such as `pmap` and `pstringview`
- * do NOT traverse these states — they operate on already-allocated blocks and manage
- * their own tree links without participating in the FSM defined here.
+ * Scope: автомат физической мутации блока (allocate/deallocate/split/coalesce).
+ * `pmap`/`pstringview` работают с уже выделенными блоками и через FSM не проходят.
+ * `BlockStateBase<AT>::*` — low-level helper layer для allocator/repair, не public API.
  *
- * Correct states (visible in a saved image):
- *   - FreeBlock        — free block (weight=0, root_offset=0, in the free-tree AVL)
- *   - AllocatedBlock   — allocated block (weight>0, root_offset=own_idx, not in AVL)
+ * Полный граф состояний и анализ восстановления — docs/atomic_writes.md.
  *
- * Transient states (only during an in-flight allocator operation):
- *   - FreeBlockRemovedAVL    — free, removed from AVL (before allocate completes)
- *   - FreeBlockNotInAVL      — free, not yet in AVL (after deallocate, before coalesce)
- *   - SplittingBlock         — block being split during allocate
- *   - CoalescingBlock        — block being merged with a neighbour during deallocate
- *
- * Guarantees within this scope:
- *   1. Type safety: the compiler forbids calling methods invalid for the current state.
- *   2. Recoverability: transient states are detected during `load()`.
- *   3. Atomicity: each method performs exactly one physical write step.
- *   4. Termination: the chain of calls always ends in a correct state.
- *
- * `BlockStateBase<AT>` also exposes raw field accessors (`get_weight`, `get_next_offset`,
- * `reset_avl_fields_of`, ...) that are used by allocator repair paths during `load()`
- * and by read-only validators. They are low-level helpers for allocator/free-tree code —
- * not a public protocol for other forest domains.
- *
- * @see docs/atomic_writes.md — state graph and crash-recovery analysis
- * @see include/pmm/free_block_tree.h — forest-policy that consumes this FSM
  * @version 0.5
  */
 

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -872,38 +872,14 @@ static_assert( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) == 32, "Block<Def
 
 /**
  * @file pmm/block_state.h
- * @brief Allocator/free-tree block FSM — physical mutation protocol for the allocator domain.
+ * @brief FSM allocator/free-tree domain: FreeBlock ↔ AllocatedBlock.
  *
- * Scope is deliberately narrow: this header describes the states and transitions of a
- * single `Block<A>` inside the allocator / free-tree domain. It is the protocol of
- * material block mutation (allocate / deallocate / split / coalesce), not a general
- * forest-node lifecycle. Forest-domain containers such as `pmap` and `pstringview`
- * do NOT traverse these states — they operate on already-allocated blocks and manage
- * their own tree links without participating in the FSM defined here.
+ * Scope: автомат физической мутации блока (allocate/deallocate/split/coalesce).
+ * `pmap`/`pstringview` работают с уже выделенными блоками и через FSM не проходят.
+ * `BlockStateBase<AT>::*` — low-level helper layer для allocator/repair, не public API.
  *
- * Correct states (visible in a saved image):
- *   - FreeBlock        — free block (weight=0, root_offset=0, in the free-tree AVL)
- *   - AllocatedBlock   — allocated block (weight>0, root_offset=own_idx, not in AVL)
+ * Полный граф состояний и анализ восстановления — docs/atomic_writes.md.
  *
- * Transient states (only during an in-flight allocator operation):
- *   - FreeBlockRemovedAVL    — free, removed from AVL (before allocate completes)
- *   - FreeBlockNotInAVL      — free, not yet in AVL (after deallocate, before coalesce)
- *   - SplittingBlock         — block being split during allocate
- *   - CoalescingBlock        — block being merged with a neighbour during deallocate
- *
- * Guarantees within this scope:
- *   1. Type safety: the compiler forbids calling methods invalid for the current state.
- *   2. Recoverability: transient states are detected during `load()`.
- *   3. Atomicity: each method performs exactly one physical write step.
- *   4. Termination: the chain of calls always ends in a correct state.
- *
- * `BlockStateBase<AT>` also exposes raw field accessors (`get_weight`, `get_next_offset`,
- * `reset_avl_fields_of`, ...) that are used by allocator repair paths during `load()`
- * and by read-only validators. They are low-level helpers for allocator/free-tree code —
- * not a public protocol for other forest domains.
- *
- * @see docs/atomic_writes.md — state graph and crash-recovery analysis
- * @see include/pmm/free_block_tree.h — forest-policy that consumes this FSM
  * @version 0.5
  */
 

--- a/single_include/pmm/pmm.h
+++ b/single_include/pmm/pmm.h
@@ -872,39 +872,39 @@ static_assert( sizeof( pmm::Block<pmm::DefaultAddressTraits> ) == 32, "Block<Def
 
 /**
  * @file pmm/block_state.h
- * @brief BlockState machine — автомат состояний блока для атомарных операций.
+ * @brief Allocator/free-tree block FSM — physical mutation protocol for the allocator domain.
  *
- * Реализует state machine через наследование состояний, где каждое состояние — это
- * наследник Block<A> с доступными методами работы. Каждый метод
- * выполняет один атомарный шаг критической операции и возвращает следующего
- * наследника, соответствующего новому состоянию блока.
+ * Scope is deliberately narrow: this header describes the states and transitions of a
+ * single `Block<A>` inside the allocator / free-tree domain. It is the protocol of
+ * material block mutation (allocate / deallocate / split / coalesce), not a general
+ * forest-node lifecycle. Forest-domain containers such as `pmap` and `pstringview`
+ * do NOT traverse these states — they operate on already-allocated blocks and manage
+ * their own tree links without participating in the FSM defined here.
  *
- * Корректные состояния:
- *   - FreeBlock        — свободный блок (weight=0, root_offset=0, в AVL-дереве)
- *   - AllocatedBlock   — занятый блок (weight>0, root_offset=idx, не в AVL)
+ * Correct states (visible in a saved image):
+ *   - FreeBlock        — free block (weight=0, root_offset=0, in the free-tree AVL)
+ *   - AllocatedBlock   — allocated block (weight>0, root_offset=own_idx, not in AVL)
  *
- * Переходные состояния (только во время операций):
- *   - FreeBlockRemovedAVL    — свободный, удалённый из AVL (перед allocate)
- *   - FreeBlockNotInAVL      — свободный, не в AVL (после deallocate, перед coalesce)
- *   - SplittingBlock         — блок в процессе разбиения
- *   - CoalescingBlock        — блок в процессе слияния
+ * Transient states (only during an in-flight allocator operation):
+ *   - FreeBlockRemovedAVL    — free, removed from AVL (before allocate completes)
+ *   - FreeBlockNotInAVL      — free, not yet in AVL (after deallocate, before coalesce)
+ *   - SplittingBlock         — block being split during allocate
+ *   - CoalescingBlock        — block being merged with a neighbour during deallocate
  *
- * Гарантии:
- *   1. Типобезопасность: компилятор запрещает вызов недоступных методов
- *   2. Восстановимость: переходные состояния детектируются при load()
- *   3. Атомарность: каждый метод выполняет один атомарный шаг
- *   4. Завершаемость: цепочка вызовов приводит к корректному состоянию
+ * Guarantees within this scope:
+ *   1. Type safety: the compiler forbids calling methods invalid for the current state.
+ *   2. Recoverability: transient states are detected during `load()`.
+ *   3. Atomicity: each method performs exactly one physical write step.
+ *   4. Termination: the chain of calls always ends in a correct state.
  *
- *   - reset_avl_fields_of()     — сброс AVL-полей перед rebuild_free_tree
- *   - repair_prev_offset()      — восстановление prev_offset при repair_linked_list
- *   - get_next_offset()         — чтение next_offset в repair-методах (load)
- *   - get_weight()              — чтение weight в repair-методах (load)
+ * `BlockStateBase<AT>` also exposes raw field accessors (`get_weight`, `get_next_offset`,
+ * `reset_avl_fields_of`, ...) that are used by allocator repair paths during `load()`
+ * and by read-only validators. They are low-level helpers for allocator/free-tree code —
+ * not a public protocol for other forest domains.
  *
- *   repair_block_prev_offset(), read_block_next_offset(), read_block_weight()
- *   AllocatorPolicy вызывает BlockStateBase<AT>::* напрямую.
- *
- * @see docs/atomic_writes.md «Граф состояний блока»
- * @version 0.4
+ * @see docs/atomic_writes.md — state graph and crash-recovery analysis
+ * @see include/pmm/free_block_tree.h — forest-policy that consumes this FSM
+ * @version 0.5
  */
 
 /**


### PR DESCRIPTION
## Summary

Narrows `block_state.h` to its honest role: the allocator / free-tree physical-mutation
FSM. Aggressive text-surface compression. Canonical explanation lives in
`docs/atomic_writes.md`; `block_state.h` keeps a short Russian scope-note; other
places carry only a brief one-line reference.

Closes #340

## Ответственность block state machine (после PR)

- Протокол физической мутации одного `Block<A>` в allocator/free-tree domain.
- Корректные состояния: `FreeBlock`, `AllocatedBlock`.
- Переходные состояния в ходе allocate/deallocate/split/coalesce:
  `FreeBlockRemovedAVL`, `FreeBlockNotInAVL`, `SplittingBlock`, `CoalescingBlock`.
- Типобезопасные переходы (`FreeBlock::remove_from_avl`,
  `FreeBlockRemovedAVL::mark_as_allocated`, …).
- `BlockStateBase<AT>::*` — low-level helper layer для allocator/repair paths
  (не public API).

## Ответственность forest domain protocol (вне block_state.h)

- Free-tree ordering и best-fit (`free_block_tree.h`, `AvlFreeTree`).
- User forest domains (`pmap`, `pstringview`) — собственные lifecycle'ы;
  их блоки остаются в состоянии `AllocatedBlock` с точки зрения аллокатора,
  FSM они не проходят.
- Forest registry, domain bindings, canonical symbol paths.

## Что удалено как ложная обобщённость

- Длинный narrative preamble в `block_state.h`, который пересказывал и так
  документированный граф состояний.
- Stale bullet-list, упоминавший `repair_block_prev_offset()`,
  `read_block_next_offset()`, `read_block_weight()` как будто это generic
  low-level forest API (этих имён не существует; реальные вызовы идут через
  `BlockStateBase<AT>::*`).
- Дублирование scope-note между `block_state.h`, `docs/atomic_writes.md` и
  `docs/architecture.md`: canonical место теперь одно — `atomic_writes.md`;
  `architecture.md` оставляет только одну строку-ссылку; `block_state.h`
  — короткий русский preamble.

## Files touched

| File | Change |
|---|---|
| `include/pmm/block_state.h` | Docstring: компактный русский scope-note (3 пункта) вместо длинного preamble. `0.4 → 0.5`. Net −22 строк. |
| `docs/atomic_writes.md` | Scope-paragraph уточняет, что FSM — это allocator mutation protocol и что `pmap`/`pstringview` через него не проходят. Канонический источник. |
| `docs/architecture.md` | Layers diagram: строка BlockState теперь явно говорит «Allocator / free-tree FSM … not a general forest-node lifecycle». Дублирующий абзац в секции «Block state machine» удалён. |
| `changelog.d/20260420_224148_narrow_block_state_scope.md` | `bump: patch`, Changed entry. |
| `single_include/pmm/pmm.h` | Regenerated bundle. |

## Критерии приёмки

1. ✅ После чтения `block_state.h` видно, что это allocator/material FSM, а не общий forest protocol.
2. ✅ В коде state machine не используется как универсальная domain abstraction.
3. ✅ Free-tree ↔ block-state boundary описана коротко и однозначно.
4. ✅ Комментариев стало меньше, смысл стал точнее (stale bullets удалены; preamble короче).
5. ✅ LOC уменьшился: +34 / −69 (net −35) по всему PR; `block_state.h` — net −22.

## Review feedback addressed

- Русский язык в `include/pmm/block_state.h` восстановлен; без самовольного
  перевода kernel-комментариев.
- Реальное схлопывание поверхности (net negative), не «тот же объём другими словами».
- Удалены дублирующие объяснения в `docs/architecture.md`; canonical место —
  `docs/atomic_writes.md`.

## Test plan

- [x] `cmake --build build -j4` — сборка проходит.
- [x] `ctest --test-dir build --output-on-failure` — 92/92 проходят (в т.ч. `test_block_state`, `test_issue106_block_state_integration`).
- [x] `bash scripts/check-docs-consistency.sh` — OK.
- [x] `bash scripts/check-changelog-fragment.sh` — OK.