### PR TITLE
[governance/repo-guard] Update PMM repo-guard action pin

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@99bf716da62c5d01070aa0d7e4d4f8031b43a351
+        uses: netkeep80/repo-guard@6c81bb1050c7dca93de1a13108e0a024fe095298
         with:
           mode: check-pr
           enforcement: advisory

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-21T05:28:16.878Z for PR creation at branch issue-347-f0b9eb433bd1 for issue https://github.com/netkeep80/PersistMemoryManager/issues/347

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-21T05:28:16.878Z for PR creation at branch issue-347-f0b9eb433bd1 for issue https://github.com/netkeep80/PersistMemoryManager/issues/347

--- a/docs/pmm_transformation_rules.md
+++ b/docs/pmm_transformation_rules.md
@@ -115,6 +115,8 @@ A PR is first assessed on **contract conformance**, not on local code quality:
 A technically correct PR that violates its issue contract is rejected.
 A minimal PR that respects its contract is preferred over a broader one that
 "also fixes a few other things".
+Governance-path edits require `authorized_governance_paths` in the linked issue
+body; PR-body governance authorization is not trusted.
 For generated closure, reviewers check that the generated diff is mechanically
 explained by the allowed source diff and is not a disguised mixed change.
 

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -22,9 +22,12 @@ workflow = workflow_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 issue_template = issue_template_path.read_text(encoding="utf-8")
 pr_template = pr_template_path.read_text(encoding="utf-8")
-expected_action_ref = "99bf716da62c5d01070aa0d7e4d4f8031b43a351"
+expected_action_ref = "6c81bb1050c7dca93de1a13108e0a024fe095298"
 expected_action = f"netkeep80/repo-guard@{expected_action_ref}"
-old_action_ref = "7ab5ca2f2d9859b4ffa2c423f05e951d4971be84"
+old_action_refs = {
+    "7ab5ca2f2d9859b4ffa2c423f05e951d4971be84",
+    "99bf716da62c5d01070aa0d7e4d4f8031b43a351",
+}
 expected_profiles = {
     "governance",
     "docs-comments-cleanup",
@@ -77,7 +80,8 @@ if action_refs:
         re.fullmatch(r"[0-9a-f]{40}", action_ref) or re.fullmatch(r"v\d+\.\d+\.\d+", action_ref),
         "repo-guard workflow must use a pinned commit SHA or pinned release tag",
     )
-require(old_action_ref not in workflow, "repo-guard workflow must not use the old Action pin")
+for old_action_ref in old_action_refs:
+    require(old_action_ref not in workflow, f"repo-guard workflow must not use old Action pin {old_action_ref}")
 require("mode: check-pr" in workflow, "repo-guard workflow must run check-pr mode")
 require("enforcement: advisory" in workflow, "repo-guard workflow must remain advisory in this stage")
 require("fetch-depth: 0" in workflow, "repo-guard workflow must use full checkout history")


### PR DESCRIPTION
## Summary

Updates PMM's advisory repo-guard workflow to the newer pinned repo-guard commit that reads the full runtime policy from the trusted PR base policy, and updates the rollout checker so the previous pin is treated as stale. Adds one canonical governance sentence to the transformation rules doc.

Fixes netkeep80/PersistMemoryManager#347

## Change Contract

The PR body carries normal change intent. Governance authorization comes from the linked issue body via `authorized_governance_paths`; PR-body authorization is intentionally not used.

```repo-guard-yaml
change_type: governance
scope:
  - .github/workflows/repo-guard.yml
  - scripts/check-repo-guard-rollout.sh
  - docs/pmm_transformation_rules.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 20
must_touch:
  - .github/workflows/repo-guard.yml
  - scripts/check-repo-guard-rollout.sh
  - docs/pmm_transformation_rules.md
must_not_touch:
  - include/**
  - single_include/**
  - tests/**
  - benchmarks/**
  - demo/**
  - examples/**
  - CMakeLists.txt
  - CHANGELOG.md
  - changelog.d/**
expected_effects:
  - PMM uses repo-guard commit 6c81bb1050c7dca93de1a13108e0a024fe095298 for advisory PR checks.
  - Rollout verification fails if PMM drifts back to either older repo-guard pin.
  - Governance-path authorization remains documented as linked-issue-body only.
```

## Verification

- `bash scripts/check-repo-guard-rollout.sh`
- `bash scripts/check-docs-consistency.sh`
- `GITHUB_BASE_REF=main bash scripts/check-changelog-fragment.sh`
- `git diff --check origin/main...HEAD`

Note: `scripts/check-version-consistency.sh` is release-owned and fails on current `main` because the existing README version badge is `2.0.1` while `CMakeLists.txt` and `CHANGELOG.md` are `3.0.0`. This PR no longer touches README, so that workflow gate will skip release-owned validation for this diff.
