### PR TITLE
Fix release single-header generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Regenerate single-header presets
         if: steps.check.outputs.should_release == 'true'
-        run: bash scripts/generate-single-headers.sh --strip-comments
+        run: bash scripts/generate-single-headers.sh
 
       - name: Commit version bump, changelog and single-header presets
         if: steps.check.outputs.should_release == 'true'
@@ -137,7 +137,7 @@ jobs:
         run: pip install quom
 
       - name: Regenerate single-header presets
-        run: bash scripts/generate-single-headers.sh --strip-comments
+        run: bash scripts/generate-single-headers.sh
 
       - name: Commit version bump, changelog and single-header presets
         run: |

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T11:52:39.615Z for PR creation at branch issue-358-e8e509632ac8 for issue https://github.com/netkeep80/PersistMemoryManager/issues/358

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T11:52:39.615Z for PR creation at branch issue-358-e8e509632ac8 for issue https://github.com/netkeep80/PersistMemoryManager/issues/358

--- a/changelog.d/20260426_120135_issue358_release_generator.md
+++ b/changelog.d/20260426_120135_issue358_release_generator.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Align the release workflow with the current single-header generator command so auto and manual releases no longer pass the removed `--strip-comments` option.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -316,6 +316,10 @@ target_compile_definitions(test_issue352_kernel_subtree_size PRIVATE PMM_SOURCE_
 pmm_add_test(test_issue354_include_anchors test_issue354_include_anchors.cpp)
 target_compile_definitions(test_issue354_include_anchors PRIVATE PMM_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
+# ─── Issue 358: release workflow single-header generation contract ──
+pmm_add_test(test_issue358_release_workflow test_issue358_release_workflow.cpp)
+target_compile_definitions(test_issue358_release_workflow PRIVATE PMM_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
 # ─── Issue 314: build graph compaction contract ─────────────────
 add_test(
     NAME test_issue314_build_graph_contract

--- a/tests/test_issue358_release_workflow.cpp
+++ b/tests/test_issue358_release_workflow.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+std::string read_file( const std::filesystem::path& path )
+{
+    std::ifstream input( path );
+    REQUIRE( input.good() );
+    return std::string( std::istreambuf_iterator<char>( input ), std::istreambuf_iterator<char>() );
+}
+
+std::vector<std::string> release_single_header_commands( const std::string& workflow )
+{
+    std::vector<std::string> commands;
+    std::istringstream       lines( workflow );
+    std::string              line;
+
+    while ( std::getline( lines, line ) )
+    {
+        if ( line.find( "run: bash scripts/generate-single-headers.sh" ) != std::string::npos )
+            commands.push_back( line );
+    }
+
+    return commands;
+}
+
+} // namespace
+
+TEST_CASE( "issue358: release workflow uses the supported single-header generator command", "[issue358][release]" )
+{
+    const auto workflow =
+        read_file( std::filesystem::path( PMM_SOURCE_DIR ) / ".github" / "workflows" / "release.yml" );
+    const auto commands = release_single_header_commands( workflow );
+
+    REQUIRE( commands.size() == 2 );
+    for ( const auto& command : commands )
+    {
+        REQUIRE( command == "        run: bash scripts/generate-single-headers.sh" );
+        REQUIRE( command.find( "--strip-comments" ) == std::string::npos );
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the obsolete `--strip-comments` argument from auto and manual release single-header regeneration.
- Add `test_issue358_release_workflow` to guard the release workflow command against the removed option.
- Add a patch changelog fragment for the release workflow fix.

## Reproduction
- The reported Auto Release run `24955769979` failed at `bash scripts/generate-single-headers.sh --strip-comments` with `Unknown option: --strip-comments`.
- Local reproduction before the fix: `bash scripts/generate-single-headers.sh --strip-comments` exited with status 1.

## Tests
- `bash scripts/generate-single-headers.sh`
- `bash scripts/generate-single-headers.sh --output-dir /tmp/pmm-generated-issue358` plus diffs against committed single headers
- `ctest --test-dir build -R '^(test_issue354_include_anchors|test_issue358_release_workflow)$' --output-on-failure`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (94 tests passed)
- `clang-format --dry-run --Werror tests/test_issue358_release_workflow.cpp`
- `GITHUB_BASE_REF=main ./scripts/check-changelog-fragment.sh`
- `git diff --check upstream/main...HEAD`

Fixes netkeep80/PersistMemoryManager#358