### PR TITLE
issue-371: cap local build/test parallelism at 3 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ on:
     paths-ignore:
       - "**/*.md"
       - ".gitkeep"
+  # Issue #371: in pull requests, only re-run on actual commits (and the
+  # initial open) so that adding a comment, reopening, or marking ready for
+  # review does not retrigger CI/CD.
   pull_request:
+    types: [opened, synchronize]
     branches: ["**"]
     paths-ignore:
       - "**/*.md"

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -23,7 +23,11 @@ on:
       - ".github/workflows/repo-guard.yml"
       - ".github/PULL_REQUEST_TEMPLATE.md"
       - ".github/ISSUE_TEMPLATE/**"
+  # Issue #371: in pull requests, only re-run on actual commits (and the
+  # initial open) so that adding a comment, reopening, or marking ready for
+  # review does not retrigger CI/CD.
   pull_request:
+    types: [opened, synchronize]
     branches: ["**"]
     paths:
       - "**/*.md"

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,8 +1,11 @@
 name: repo-guard policy check
 
 on:
+  # Issue #371: in pull requests, only re-run on actual commits (and the
+  # initial open) so that adding a comment, reopening, or marking ready for
+  # review does not retrigger CI/CD.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize]
     branches: ["**"]
 
 permissions:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-28T14:29:02.326Z for PR creation at branch issue-371-c056149c6097 for issue https://github.com/netkeep80/PersistMemoryManager/issues/371

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-28T14:29:02.326Z for PR creation at branch issue-371-c056149c6097 for issue https://github.com/netkeep80/PersistMemoryManager/issues/371

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # съедал все ядра общей машины. В GitHub Actions переменная CI выставляется
 # автоматически — там используем неограниченный /MP.
 set(PMM_LOCAL_BUILD_JOBS "3" CACHE STRING
-    "Default parallel job count for local builds (MSVC /MP and CMake/CTest -j hints). 0 = unbounded.")
+    "Default parallel job count for local builds (MSVC /MP and Ninja job pools). 0 = unbounded.")
+
+if(NOT PMM_LOCAL_BUILD_JOBS MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+        "PMM_LOCAL_BUILD_JOBS must be a non-negative integer; "
+        "got '${PMM_LOCAL_BUILD_JOBS}'. Use 0 for unbounded.")
+endif()
 
 if(DEFINED ENV{CI})
     set(_pmm_in_ci TRUE)
@@ -23,8 +29,20 @@ if(_pmm_in_ci OR PMM_LOCAL_BUILD_JOBS STREQUAL "0")
     set(_pmm_msvc_mp_flag "/MP")
 else()
     set(_pmm_msvc_mp_flag "/MP${PMM_LOCAL_BUILD_JOBS}")
+    # CMAKE_JOB_POOLS is honoured by the Ninja generator; it caps compile and
+    # link parallelism inside the generated build graph so an unparameterized
+    # `cmake --build build` (no -j flag) does not saturate every core. Make
+    # generators do not honour job pools — for Make/Ninja-Makefiles the cap
+    # has to come from `cmake --build -j ${PMM_LOCAL_BUILD_JOBS}` (see the
+    # CONTRIBUTING.md "Build parallelism" section and the helper scripts in
+    # scripts/).
+    set(CMAKE_JOB_POOLS
+        "pmm_compile=${PMM_LOCAL_BUILD_JOBS};pmm_link=${PMM_LOCAL_BUILD_JOBS}"
+        CACHE STRING "PMM local build parallelism job pools (Ninja generator)" FORCE)
+    set(CMAKE_JOB_POOL_COMPILE "pmm_compile" CACHE STRING "" FORCE)
+    set(CMAKE_JOB_POOL_LINK    "pmm_link"    CACHE STRING "" FORCE)
     message(STATUS "PMM: local build parallelism capped at ${PMM_LOCAL_BUILD_JOBS} jobs "
-                   "(set PMM_LOCAL_BUILD_JOBS=0 or CI=1 in env to remove the cap)")
+                   "(re-run cmake with -DPMM_LOCAL_BUILD_JOBS=0 or set CI=1 in env to remove the cap)")
 endif()
 
 # ─── Основная библиотека (header-only) ────────────────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,28 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# ─── Локальный лимит параллелизма сборки (issue #371) ────────────────────────
+# Локально (без переменной окружения CI) ограничиваем многопоточность сборки
+# и компиляции MSVC значением PMM_LOCAL_BUILD_JOBS, чтобы один разработчик не
+# съедал все ядра общей машины. В GitHub Actions переменная CI выставляется
+# автоматически — там используем неограниченный /MP.
+set(PMM_LOCAL_BUILD_JOBS "3" CACHE STRING
+    "Default parallel job count for local builds (MSVC /MP and CMake/CTest -j hints). 0 = unbounded.")
+
+if(DEFINED ENV{CI})
+    set(_pmm_in_ci TRUE)
+else()
+    set(_pmm_in_ci FALSE)
+endif()
+
+if(_pmm_in_ci OR PMM_LOCAL_BUILD_JOBS STREQUAL "0")
+    set(_pmm_msvc_mp_flag "/MP")
+else()
+    set(_pmm_msvc_mp_flag "/MP${PMM_LOCAL_BUILD_JOBS}")
+    message(STATUS "PMM: local build parallelism capped at ${PMM_LOCAL_BUILD_JOBS} jobs "
+                   "(set PMM_LOCAL_BUILD_JOBS=0 or CI=1 in env to remove the cap)")
+endif()
+
 # ─── Основная библиотека (header-only) ────────────────────────────────────────
 add_library(pmm INTERFACE)
 target_include_directories(pmm INTERFACE
@@ -15,7 +37,7 @@ target_include_directories(pmm INTERFACE
 
 # Параметры компилятора
 if(MSVC)
-    target_compile_options(pmm INTERFACE /W4 /utf-8 /MP)
+    target_compile_options(pmm INTERFACE /W4 /utf-8 ${_pmm_msvc_mp_flag})
 else()
     target_compile_options(pmm INTERFACE -Wall -Wextra -Wpedantic)
 endif()
@@ -38,7 +60,7 @@ if(BUILD_TESTING)
     if(MSVC)
         foreach(pmm_catch2_target Catch2 Catch2WithMain)
             if(TARGET ${pmm_catch2_target})
-                target_compile_options(${pmm_catch2_target} PRIVATE /MP)
+                target_compile_options(${pmm_catch2_target} PRIVATE ${_pmm_msvc_mp_flag})
             endif()
         endforeach()
     endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,21 @@ Pre-commit hooks enforce:
 
 ### Building and Testing
 
+The simplest path is the helper script, which already applies the local
+3-job cap from issue #371:
+
 ```bash
-# Configure and build (defaults to 3 parallel jobs locally — see "Build
-# parallelism" below)
+# Linux / macOS
+./scripts/test.sh
+
+# Windows
+scripts\test.bat
+```
+
+Or invoke CMake directly (defaults to 3 parallel jobs locally — see "Build
+parallelism" below):
+
+```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j 3
 
@@ -46,29 +58,45 @@ ctest --test-dir build --output-on-failure -j 3
 
 Local builds default to **3 parallel jobs** so that a single contributor does
 not saturate every core on a shared workstation. The defaults are applied in
-two places:
+three places, each covering a different layer of the build:
 
-- `CMakeLists.txt` caps the MSVC `/MP` flag to `/MP${PMM_LOCAL_BUILD_JOBS}`
-  (default `3`) when the `CI` environment variable is **not** set.
-- The Windows convenience scripts (`scripts/test.bat`, `scripts/demo.bat`)
-  pass `-j 3` to `cmake --build` and `ctest` unless `PMM_JOBS` is overridden.
+| Layer                        | Mechanism                                          | Generator scope |
+|------------------------------|----------------------------------------------------|-----------------|
+| MSVC compile-time `/MP`      | `target_compile_options(... /MP${PMM_LOCAL_BUILD_JOBS})` | MSVC            |
+| Generated build graph        | `CMAKE_JOB_POOLS` + `JOB_POOL_COMPILE`/`JOB_POOL_LINK` | Ninja           |
+| `cmake --build` / `ctest -j` | helper scripts in `scripts/`                       | All             |
+
+The CMake-side mechanisms (rows 1 and 2) only kick in when the `CI`
+environment variable is **not** set. The helper scripts (`scripts/test.sh`,
+`scripts/test.bat`, `scripts/demo.sh`, `scripts/demo.bat`) always pass `-j 3`
+to `cmake --build` and `ctest`, overridable via `PMM_JOBS`.
+
+> **Note for Make/Ninja-Makefiles users:** the Makefile generator does not
+> honour `CMAKE_JOB_POOLS`. If you bypass the helper scripts and run
+> `cmake --build build` directly without `-j`, GNU Make may still spawn one
+> job per core. Either pass `-j 3` explicitly, set
+> `CMAKE_BUILD_PARALLEL_LEVEL=3` in your shell, or use the helper scripts.
 
 **Override locally** when you really do want full parallelism:
 
 ```bash
-# CMake-side cap (raises MSVC /MP and is recorded in the CMake cache)
-cmake -B build -DPMM_LOCAL_BUILD_JOBS=0   # 0 = unbounded /MP
+# CMake-side cap (raises MSVC /MP and the Ninja job pools, recorded in cache)
+cmake -B build -DPMM_LOCAL_BUILD_JOBS=0   # 0 = unbounded
 
 # Per-invocation override at the cmake/ctest layer
 cmake --build build -j 8
 ctest --test-dir build -j 8
+
+# Helper scripts (Linux/macOS / Windows)
+PMM_JOBS=8 ./scripts/test.sh
+set PMM_JOBS=8 && scripts\test.bat
 ```
 
 **GitHub Actions** sets `CI=true` automatically, so MSVC falls back to
-unbounded `/MP`. The workflow already pins
-`CMAKE_BUILD_PARALLEL_LEVEL` and `CTEST_PARALLEL_LEVEL` for cmake/ctest; CI
-runners therefore continue to use full parallelism without any further
-changes.
+unbounded `/MP` and the Ninja job pools are not configured. The workflow
+already pins `CMAKE_BUILD_PARALLEL_LEVEL` and `CTEST_PARALLEL_LEVEL` for
+cmake/ctest; CI runners therefore continue to use full parallelism without
+any further changes.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,42 @@ Pre-commit hooks enforce:
 ### Building and Testing
 
 ```bash
-# Configure and build
+# Configure and build (defaults to 3 parallel jobs locally — see "Build
+# parallelism" below)
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build
+cmake --build build -j 3
 
-# Run all tests
-ctest --test-dir build --output-on-failure
+# Run all tests with the same 3-job cap
+ctest --test-dir build --output-on-failure -j 3
 ```
+
+### Build parallelism (issue #371)
+
+Local builds default to **3 parallel jobs** so that a single contributor does
+not saturate every core on a shared workstation. The defaults are applied in
+two places:
+
+- `CMakeLists.txt` caps the MSVC `/MP` flag to `/MP${PMM_LOCAL_BUILD_JOBS}`
+  (default `3`) when the `CI` environment variable is **not** set.
+- The Windows convenience scripts (`scripts/test.bat`, `scripts/demo.bat`)
+  pass `-j 3` to `cmake --build` and `ctest` unless `PMM_JOBS` is overridden.
+
+**Override locally** when you really do want full parallelism:
+
+```bash
+# CMake-side cap (raises MSVC /MP and is recorded in the CMake cache)
+cmake -B build -DPMM_LOCAL_BUILD_JOBS=0   # 0 = unbounded /MP
+
+# Per-invocation override at the cmake/ctest layer
+cmake --build build -j 8
+ctest --test-dir build -j 8
+```
+
+**GitHub Actions** sets `CI=true` automatically, so MSVC falls back to
+unbounded `/MP`. The workflow already pins
+`CMAKE_BUILD_PARALLEL_LEVEL` and `CTEST_PARALLEL_LEVEL` for cmake/ctest; CI
+runners therefore continue to use full parallelism without any further
+changes.
 
 ## Code Style
 
@@ -171,9 +200,9 @@ touches release-owned paths, so docs-only work never inherits a forced bump.
    find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' \
      -print0 | xargs -0 wc -l | awk '$1 > 1500 {print "FAIL:", $0; exit 1}'
 
-   # Build and test
-   cmake -B build && cmake --build build
-   ctest --test-dir build --output-on-failure
+   # Build and test (3-job cap matches the local default; see "Build parallelism")
+   cmake -B build && cmake --build build -j 3
+   ctest --test-dir build --output-on-failure -j 3
    ```
 5. Open a pull request targeting `main`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AVL-based allocator, проверкой структуры и восстанов
 [![CI](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml/badge.svg)](https://github.com/netkeep80/PersistMemoryManager/actions/workflows/ci.yml)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://isocpp.org/std/the-standard)
-[![Version](https://img.shields.io/badge/version-3.0.6-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.0-green.svg)](CHANGELOG.md)
 
 ## Что это
 

--- a/changelog.d/20260428_143225_limit_local_build_parallelism.md
+++ b/changelog.d/20260428_143225_limit_local_build_parallelism.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+### Changed
+- Local builds now cap parallelism at 3 jobs by default (issue #371) so a
+  single contributor cannot saturate every core on a shared workstation.
+  `CMakeLists.txt` exposes `PMM_LOCAL_BUILD_JOBS` (default `3`, `0` =
+  unbounded) and routes it into the MSVC `/MP` flag when the `CI`
+  environment variable is unset. `scripts/test.bat` and `scripts/demo.bat`
+  pass `-j 3` to `cmake --build` and `ctest`, overridable via `PMM_JOBS`.
+  GitHub Actions sets `CI=true` automatically, so CI keeps using full
+  parallelism via `CMAKE_BUILD_PARALLEL_LEVEL` / `CTEST_PARALLEL_LEVEL`.

--- a/changelog.d/20260428_143225_limit_local_build_parallelism.md
+++ b/changelog.d/20260428_143225_limit_local_build_parallelism.md
@@ -6,8 +6,16 @@ bump: patch
 - Local builds now cap parallelism at 3 jobs by default (issue #371) so a
   single contributor cannot saturate every core on a shared workstation.
   `CMakeLists.txt` exposes `PMM_LOCAL_BUILD_JOBS` (default `3`, `0` =
-  unbounded) and routes it into the MSVC `/MP` flag when the `CI`
-  environment variable is unset. `scripts/test.bat` and `scripts/demo.bat`
-  pass `-j 3` to `cmake --build` and `ctest`, overridable via `PMM_JOBS`.
-  GitHub Actions sets `CI=true` automatically, so CI keeps using full
-  parallelism via `CMAKE_BUILD_PARALLEL_LEVEL` / `CTEST_PARALLEL_LEVEL`.
+  unbounded), routes it into the MSVC `/MP` flag, and configures
+  `CMAKE_JOB_POOLS` so the Ninja generator caps compile/link jobs in the
+  generated build graph. The cap is suppressed when the `CI` environment
+  variable is set or `PMM_LOCAL_BUILD_JOBS=0`. Helper scripts
+  (`scripts/test.sh`, `scripts/test.bat`, `scripts/demo.sh`,
+  `scripts/demo.bat`) pass `-j 3` to `cmake --build` and `ctest`,
+  overridable via `PMM_JOBS`. GitHub Actions sets `CI=true` automatically,
+  so CI keeps using full parallelism via `CMAKE_BUILD_PARALLEL_LEVEL` /
+  `CTEST_PARALLEL_LEVEL`.
+- PR-triggered workflows (`ci.yml`, `docs-consistency.yml`,
+  `repo-guard.yml`) now use `pull_request.types: [opened, synchronize]` so
+  CI/CD only re-runs on actual commits, not on `reopened` /
+  `ready_for_review` lifecycle events (issue #371 follow-up comment).

--- a/scripts/demo.bat
+++ b/scripts/demo.bat
@@ -1,6 +1,11 @@
+@echo off
+rem Local demo build entry point. Limits parallelism to 3 jobs by default
+rem (issue #371). Override via the PMM_JOBS env var, e.g. `set PMM_JOBS=8`.
+if "%PMM_JOBS%"=="" set PMM_JOBS=3
+
 mkdir build
 cd build
 cmake .. -DPMM_BUILD_DEMO=ON
-cmake --build . --config=Release --target pmm_demo
+cmake --build . --config=Release --target pmm_demo -j %PMM_JOBS%
 cd ..
 build\demo\Release\pmm_demo.exe

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Local demo build entry point. Limits parallelism to 3 jobs by default
+# (issue #371). Override via the PMM_JOBS env var, e.g. `PMM_JOBS=8 ./scripts/demo.sh`.
+set -euo pipefail
+
+: "${PMM_JOBS:=3}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="$repo_root/build"
+
+mkdir -p "$build_dir"
+cmake -S "$repo_root" -B "$build_dir" -DPMM_BUILD_DEMO=ON
+cmake --build "$build_dir" --target pmm_demo -j "$PMM_JOBS"
+"$build_dir/demo/pmm_demo"

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -1,7 +1,11 @@
+@echo off
+rem Local build/test entry point. Limits parallelism to 3 jobs by default
+rem (issue #371). Override via the PMM_JOBS env var, e.g. `set PMM_JOBS=8`.
+if "%PMM_JOBS%"=="" set PMM_JOBS=3
+
 mkdir build
 cd build
 cmake ..
-cmake --build . --config=Release
-ctest -C Release
-@echo off
+cmake --build . --config=Release -j %PMM_JOBS%
+ctest -C Release -j %PMM_JOBS%
 rem ctest -C Release --verbose

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Local build/test entry point. Limits parallelism to 3 jobs by default
+# (issue #371). Override via the PMM_JOBS env var, e.g. `PMM_JOBS=8 ./scripts/test.sh`.
+set -euo pipefail
+
+: "${PMM_JOBS:=3}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="$repo_root/build"
+
+mkdir -p "$build_dir"
+cmake -S "$repo_root" -B "$build_dir"
+cmake --build "$build_dir" -j "$PMM_JOBS"
+ctest --test-dir "$build_dir" --output-on-failure -j "$PMM_JOBS"

--- a/tests/issue314_build_graph_contract.cmake
+++ b/tests/issue314_build_graph_contract.cmake
@@ -80,8 +80,11 @@ issue314_configure(compact_tests ON -DPMM_BUILD_EXAMPLES=OFF)
 issue314_assert_target("${compact_tests_build_dir}" test_allocate TRUE)
 issue314_assert_target("${compact_tests_build_dir}" basic_usage FALSE)
 if(MSVC)
-    issue314_assert_target_property("${compact_tests_build_dir}" Catch2 compileCommandFragments "/MP")
-    issue314_assert_target_property("${compact_tests_build_dir}" Catch2WithMain compileCommandFragments "/MP")
+    # Issue #371: the local default caps MSVC parallelism at /MP3, while CI
+    # uses unbounded /MP. Accept either form to keep the contract stable
+    # across both environments.
+    issue314_assert_target_property("${compact_tests_build_dir}" Catch2 compileCommandFragments "/MP[0-9]*")
+    issue314_assert_target_property("${compact_tests_build_dir}" Catch2WithMain compileCommandFragments "/MP[0-9]*")
 endif()
 
 issue314_configure(default_graph ON -DPMM_BUILD_EXAMPLES=ON)


### PR DESCRIPTION
## Summary

Closes netkeep80/PersistMemoryManager#371.

A local `cmake --build` / `ctest` run currently saturates every core, which
blocks other contributors on shared workstations. This PR caps **local**
build/test parallelism at **3 jobs** at three layers (MSVC `/MP`, Ninja job
pools, helper scripts) while leaving GitHub Actions at full parallelism (CI
exports `CMAKE_BUILD_PARALLEL_LEVEL=4` / `CTEST_PARALLEL_LEVEL=4` and sets
`CI=true`, which short-circuits the local cap).

It also addresses the follow-up comment on issue #371 about CI/CD being
re-triggered by non-commit PR events.

### Where the cap is enforced

| Layer                        | Mechanism                                                | Generator scope |
|------------------------------|----------------------------------------------------------|-----------------|
| MSVC compile-time `/MP`      | `target_compile_options(... /MP${PMM_LOCAL_BUILD_JOBS})` | MSVC            |
| Generated build graph        | `CMAKE_JOB_POOLS` + `JOB_POOL_COMPILE`/`JOB_POOL_LINK`   | Ninja           |
| `cmake --build` / `ctest -j` | Helper scripts in `scripts/`                             | All             |

> Make-based generators (Unix Makefiles, Ninja-Makefiles) do **not** honour
> `CMAKE_JOB_POOLS`. CONTRIBUTING.md calls this out explicitly so users
> bypassing the helper scripts pass `-j 3` or set
> `CMAKE_BUILD_PARALLEL_LEVEL=3` themselves.

### Changes

- **`CMakeLists.txt`** — new cache variable `PMM_LOCAL_BUILD_JOBS` (default
  `3`, `0` = unbounded). When `CI` is unset and the cap is non-zero:
  - the MSVC `/MP` flag becomes `/MP${PMM_LOCAL_BUILD_JOBS}` (applied to
    `pmm` and the FetchContent Catch2/Catch2WithMain targets);
  - `CMAKE_JOB_POOLS=pmm_compile=N;pmm_link=N` is set as cache values, with
    `CMAKE_JOB_POOL_COMPILE` and `CMAKE_JOB_POOL_LINK` pointed at them, so
    Ninja-generated builds cap compile/link concurrency in the build graph;
  - `PMM_LOCAL_BUILD_JOBS` is validated as a non-negative integer
    (`FATAL_ERROR` on `abc`, etc.);
  - the configure-time `STATUS` line announces the cap and now correctly
    instructs users to re-run cmake with `-DPMM_LOCAL_BUILD_JOBS=0` (cache
    var) instead of the previous misleading "set PMM_LOCAL_BUILD_JOBS=0"
    (which read like an env var).
- **`scripts/test.sh`, `scripts/demo.sh`** *(new)* — portable Linux/macOS
  counterparts of the existing `.bat` helpers, default `PMM_JOBS=3`,
  override via env (`PMM_JOBS=8 ./scripts/test.sh`).
- **`scripts/test.bat`, `scripts/demo.bat`** — pass `-j %PMM_JOBS%` to
  `cmake --build` / `ctest`.
- **`CONTRIBUTING.md`** — new "Build parallelism (issue #371)" section
  documenting the three layers, the Make caveat, the override knobs, and
  pointing both Linux/macOS and Windows users at the new helper scripts.
- **`tests/issue314_build_graph_contract.cmake`** — relax the MSVC Catch2
  fragment assertion from literal `/MP` to `/MP[0-9]*` so the contract
  holds under both the local default (`/MP3`) and CI's unbounded `/MP`.
- **`.github/workflows/ci.yml`, `docs-consistency.yml`, `repo-guard.yml`**
  — `pull_request.types` pinned to `[opened, synchronize]`, so re-opening a
  PR or marking it ready-for-review no longer re-triggers CI/CD. This
  addresses the follow-up comment in issue #371 ("лучше чтобы CI/CD
  запускался в Pull Requests только на коммитах").
- **`changelog.d/`** — patch-bump fragment describing the change.
- **`README.md`** — sync the version badge to `5.0.0` to match
  `CMakeLists.txt` / `CHANGELOG.md`. The `chore: release v5.0.0` release
  commit (1045421) bumped `CMakeLists.txt` and `CHANGELOG.md` but missed
  the badge, so any subsequent PR touching `CMakeLists.txt` fails the
  release-owned version-consistency check until the badge is resynced.
  This is a one-line bookkeeping fix; the underlying release workflow gap
  is a separate concern that the maintainer may want to follow up on.

### How CI keeps full parallelism

GitHub Actions exports `CI=true` automatically, which short-circuits the
local cap in `CMakeLists.txt`, so MSVC keeps unbounded `/MP` and the Ninja
job pools are not configured. The CI workflow already pins
`CMAKE_BUILD_PARALLEL_LEVEL=4` / `CTEST_PARALLEL_LEVEL=4` for cmake/ctest
— no workflow changes needed for parallelism.

### How a contributor opts out locally

```bash
# CMake-side cap (raises MSVC /MP and the Ninja pools, recorded in cache)
cmake -B build -DPMM_LOCAL_BUILD_JOBS=0   # 0 = unbounded

# Per-invocation override at the cmake/ctest layer
cmake --build build -j 8
ctest --test-dir build -j 8

# Helper scripts (Linux/macOS / Windows)
PMM_JOBS=8 ./scripts/test.sh
set PMM_JOBS=8 && scripts\test.bat
```

## Test plan

- [x] `cmake -B build` locally — see `-- PMM: local build parallelism capped at 3 jobs ...` status line.
- [x] `cmake -B build -G Ninja` — `build/CMakeFiles/rules.ninja` contains `pool pmm_compile depth = 3` and `pool pmm_link depth = 3`; build edges declare `pool = pmm_compile`.
- [x] `CI=1 cmake -B build` — status line is suppressed; no `pmm_compile` / `pmm_link` pools written.
- [x] `cmake -B build -DPMM_LOCAL_BUILD_JOBS=0` — status line is suppressed; no pools written.
- [x] `cmake -B build -DPMM_LOCAL_BUILD_JOBS=abc` — fails with FATAL_ERROR ("must be a non-negative integer").
- [x] `cmake --build build -j 3` — full build succeeds.
- [x] `ctest --test-dir build --output-on-failure -j 3` — all 92 tests pass, including `test_issue314_build_graph_contract`.
- [x] `PMM_JOBS=2 ./scripts/test.sh` — runs 92 tests to completion (exit 0).
- [x] `bash scripts/check-version-consistency.sh` — passes after the README badge sync.
- [x] `bash scripts/check-docs-consistency.sh` — passes.
- [x] `bash scripts/check-repo-guard-rollout.sh` — passes (workflow trigger narrowing not pinned by the rollout check).
- [x] `bash scripts/check-changelog-fragment.sh` — passes.