### PR TITLE
[governance/repo-guard] Adopt hardened policy-delta gate; flip enforcement to blocking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Governance ownership for the library-size and policy-delta gate.
+# Edits to these paths require maintainer review and are tracked by
+# repo-guard's trusted policy boundary.
+/repo-policy.json @netkeep80
+/.github/workflows/repo-guard.yml @netkeep80
+/.github/CODEOWNERS @netkeep80

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   policy-check:
-    name: repo-guard advisory check
+    name: repo-guard blocking check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     steps:
@@ -25,10 +25,10 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@6c81bb1050c7dca93de1a13108e0a024fe095298
+        uses: netkeep80/repo-guard@b1b6756639092bbd4ff6a473aeaa637a63475a86
         with:
           mode: check-pr
-          enforcement: advisory
+          enforcement: blocking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T08:30:35.453Z for PR creation at branch issue-384-7ee996adfbc4 for issue https://github.com/netkeep80/PersistMemoryManager/issues/384

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T08:30:35.453Z for PR creation at branch issue-384-7ee996adfbc4 for issue https://github.com/netkeep80/PersistMemoryManager/issues/384

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Single entry point for PMM documentation. The canonical set below must match
 | [PMM Target Model](pmm_target_model.md) | Normative top-level model: PMM as compact persistent storage kernel; boundary vs `pjson` / `pjson_db` / execution / product layers |
 | [PMM Transformation Rules](pmm_transformation_rules.md) | Normative operational rulebook: allowed issue types, atomic-issue / no-mixed-PR / extraction-first / surface-compression rules, PR review semantics |
 | [Comment Policy](comment_policy.md) | Canonical text discipline for comments, docs placement, and text-surface review |
-| [BlockHeader Semantics](block_and_treenode_semantics.md) | Field-level specification of the single physical [BlockHeader](../include/pmm/block_header.h#pmm-blockheader) layout (`Block<AT>` is a type alias for `BlockHeader<AT>`) |
+| [BlockHeader Semantics](block_and_treenode_semantics.md) | Field-level specification of the single physical `BlockHeader` layout (`Block<AT>` is a type alias for `BlockHeader<AT>`) |
 | [Architecture](architecture.md) | Layer stack, memory layout, algorithms, storage backends, configuration |
 | [API Reference](api_reference.md) | Complete public API: lifecycle, allocation, containers, I/O, error codes |
 | [Validation Model](validation_model.md) | Low-level pointer and block validation: cheap vs full modes, conversion paths, error categories |

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -2,7 +2,7 @@
   "policy_format_version": "0.3.0",
   "repository_kind": "library",
   "enforcement": {
-    "mode": "advisory"
+    "mode": "blocking"
   },
   "paths": {
     "forbidden": [
@@ -33,6 +33,7 @@
     "governance_paths": [
       "repo-policy.json",
       "CONTRIBUTING.md",
+      ".github/CODEOWNERS",
       ".github/workflows/repo-guard.yml",
       ".github/workflows/docs-consistency.yml",
       ".github/PULL_REQUEST_TEMPLATE.md",

--- a/scripts/check-repo-guard-rollout.sh
+++ b/scripts/check-repo-guard-rollout.sh
@@ -22,11 +22,12 @@ workflow = workflow_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 issue_template = issue_template_path.read_text(encoding="utf-8")
 pr_template = pr_template_path.read_text(encoding="utf-8")
-expected_action_ref = "6c81bb1050c7dca93de1a13108e0a024fe095298"
+expected_action_ref = "b1b6756639092bbd4ff6a473aeaa637a63475a86"
 expected_action = f"netkeep80/repo-guard@{expected_action_ref}"
 old_action_refs = {
     "7ab5ca2f2d9859b4ffa2c423f05e951d4971be84",
     "99bf716da62c5d01070aa0d7e4d4f8031b43a351",
+    "6c81bb1050c7dca93de1a13108e0a024fe095298",
 }
 expected_profiles = {
     "governance",
@@ -78,7 +79,8 @@ if action_refs:
 for old_action_ref in old_action_refs:
     require(old_action_ref not in workflow, f"repo-guard workflow must not use old Action pin {old_action_ref}")
 require("mode: check-pr" in workflow, "repo-guard workflow must run check-pr mode")
-require("enforcement: advisory" in workflow, "repo-guard workflow must remain advisory in this stage")
+require("enforcement: blocking" in workflow, "repo-guard workflow must enforce policy in blocking mode")
+require("enforcement: advisory" not in workflow, "repo-guard workflow must not run in advisory mode")
 require("fetch-depth: 0" in workflow, "repo-guard workflow must use full checkout history")
 require("contents: read" in workflow, "repo-guard workflow must keep contents read-only permission")
 require("issues: read" in workflow, "repo-guard workflow must keep issues read-only permission")
@@ -94,7 +96,7 @@ for forbidden in (
     require(forbidden not in workflow, f"repo-guard workflow must not use legacy manual integration pattern: {forbidden}")
 
 policy_mode = policy.get("enforcement", {}).get("mode")
-require(policy_mode == "advisory", "repo-policy.json must default to advisory enforcement")
+require(policy_mode == "blocking", "repo-policy.json must enforce policy in blocking mode")
 
 for removed in ("change_classes", "new_file_rules", "change_type_rules"):
     require(removed not in policy, f"repo-policy.json must not use legacy {removed}")


### PR DESCRIPTION
## Summary

Upgrades PMM's repo-guard PR check to consume the policy-delta hardening released in [netkeep80/repo-guard#99](https://github.com/netkeep80/repo-guard/pull/99) and flips both the workflow and `repo-policy.json` from advisory to blocking. The existing `kernel-subtree-max-bytes` budget (`include/**`, `270000` bytes, `all_tracked`, `blocking`) is preserved unchanged, so this change enforces the existing library-size budget rather than raising it.

Fixes netkeep80/PersistMemoryManager#384

## Changes

- `.github/workflows/repo-guard.yml`
  - Pin reusable Action from `6c81bb1…` to `b1b6756639092bbd4ff6a473aeaa637a63475a86` (the merge commit of `netkeep80/repo-guard#99`).
  - Rename job from `repo-guard advisory check` to `repo-guard blocking check`.
  - Set `enforcement: blocking`.
- `repo-policy.json`
  - Top-level `enforcement.mode`: `advisory` → `blocking`.
  - Add `.github/CODEOWNERS` to `paths.governance_paths` so future edits to it are gated like other governance files.
- `scripts/check-repo-guard-rollout.sh`
  - Bump `expected_action_ref` to the new pin; retire `6c81bb1…` into `old_action_refs`.
  - Require `enforcement: blocking` in the workflow (and forbid `enforcement: advisory`).
  - Require `repo-policy.json` `enforcement.mode == "blocking"`.
- `.github/CODEOWNERS` (new file)
  - Scope `repo-policy.json`, `.github/workflows/repo-guard.yml`, and `.github/CODEOWNERS` itself to `@netkeep80`.
- `docs/index.md`
  - Fix pre-existing `canonical-docs-sync` registry-rule failure by replacing the inline `[BlockHeader](../include/pmm/block_header.h#pmm-blockheader)` link with inline code, so that the new `repo-guard`'s `markdown_section_links` parser no longer picks up `include/pmm/block_header.h` as a canonical doc entry. Canonical document set is unchanged.

The `size_rules[0]` entry for `kernel-subtree-max-bytes` is deliberately untouched. The 270000-byte `include/**` budget now sits behind a blocking gate.

## Change Contract

Governance authorization is carried on the linked issue body; PR-body authorization is intentionally not used.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
  - .github/workflows/repo-guard.yml
  - .github/CODEOWNERS
  - scripts/check-repo-guard-rollout.sh
  - docs/index.md
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 80
authorized_governance_paths:
  - repo-policy.json
  - .github/workflows/repo-guard.yml
  - .github/CODEOWNERS
  - scripts/check-repo-guard-rollout.sh
must_touch:
  - repo-policy.json
  - .github/workflows/repo-guard.yml
must_not_touch:
  - include/**
  - single_include/**
expected_effects:
  - PMM uses repo-guard commit b1b6756639092bbd4ff6a473aeaa637a63475a86 (policy-delta hardening).
  - repo-guard PR check becomes blocking rather than advisory.
  - repo-policy.json enforcement.mode becomes blocking.
  - Existing include subtree byte budget becomes a merge-blocking invariant.
  - AI-authored PRs cannot self-raise the library size limit in the same change that grows the library.
  - pre-existing canonical-docs-sync incompatibility in docs/index.md is fixed without changing the canonical document set.
```

## Verification

- `bash scripts/check-repo-guard-rollout.sh` → `Repo-guard rollout wiring is current.`
- `bash scripts/check-docs-consistency.sh` → `OK: all docs-consistency checks passed`
- Diff stat is within the governance profile budget (`max_new_files: 1`, `max_new_docs: 0`, `max_net_added_lines: 80`): 1 new file (`.github/CODEOWNERS`), 0 new docs.
- `include/**` and `single_include/**` are not touched; `size_rules[0]` (`kernel-subtree-max-bytes`, `max: 270000`, `count: all_tracked`, `level: blocking`) is unchanged.

## Manual verification (post-merge)

A test branch that does both of the following in one PR should now fail the repo-guard blocking gate:

1. Grows the tracked size under `include/**`.
2. Raises `size_rules[*].max` for `kernel-subtree-max-bytes`.

Expected result:

```text
FAIL: policy-relaxation
PR attempts to relax trusted repository policy
```

A normal kernel PR that exceeds the trusted base size limit should also fail via the size rule rather than only producing a warning.

## Required maintainer follow-up (outside code)

Per acceptance criteria #5 of the issue, after this PR lands branch protection / repository ruleset for `main` should be configured to:

- require PR before merge;
- require the `repo-guard blocking check` status check;
- require approval for governance files via the new CODEOWNERS;
- not allow AI/bot users to bypass this gate.

If a separate governance follow-up is preferred for the ruleset, the CODEOWNERS file added here is ready to be enforced once branch protection requires it.
